### PR TITLE
Remove positional sensitivity

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -101,7 +101,7 @@ export async function getReflection(
 
 		return relfectionResponses;
 	}
- catch (error) {
+	catch (error) {
 		// TODO: Log errors better
 		// console.error(error);
 		// debugger;

--- a/frontend/src/api/wordEditorAPI.ts
+++ b/frontend/src/api/wordEditorAPI.ts
@@ -125,6 +125,7 @@ export const wordEditorAPI: EditorAPI = {
 						afterCursor: ''
 					};
 
+					// Get the selected word
 					const wordSelection = context.document
 						.getSelection()
 						.getTextRanges([' '], false);
@@ -135,23 +136,20 @@ export const wordEditorAPI: EditorAPI = {
 					// Get the text of the selected word
 					docContext.selectedText = wordSelection.items.map(item => item.text).join(' ');
 
-
 					// Get the text before the selected word
 					const beforeCursor = wordSelection.items[0].expandTo(body.getRange('Start'));
 					context.load(beforeCursor, 'text');
-
 
 					// Get the text after the selected word
 					const afterCursor = wordSelection.items[wordSelection.items.length-1].expandTo(body.getRange('End'));
 					context.load(afterCursor, 'text');
 
-
 					await context.sync();
 
+					// Set the beforeCursor and afterCursor properties of the docContext object
 					docContext.beforeCursor = beforeCursor.text;
 					docContext.afterCursor = afterCursor.text;
 					resolve(docContext);
-
 				});
 			}
 			catch (error) {

--- a/frontend/src/api/wordEditorAPI.ts
+++ b/frontend/src/api/wordEditorAPI.ts
@@ -97,7 +97,7 @@ export const wordEditorAPI: EditorAPI = {
 			}
 		});
 	},
-	
+
 	addSelectionChangeHandler: (handler: () => void) => {
 		Office.context.document.addHandlerAsync(
 			Office.EventType.DocumentSelectionChanged,
@@ -119,7 +119,7 @@ export const wordEditorAPI: EditorAPI = {
 			try {
 				await Word.run(async (context: Word.RequestContext) => {
 					const body: Word.Body = context.document.body;
-					let docContext: DocContext = {
+					const docContext: DocContext = {
 						beforeCursor: '',
 						selectedText: '',
 						afterCursor: ''
@@ -135,12 +135,12 @@ export const wordEditorAPI: EditorAPI = {
 					// Get the text of the selected word
 					docContext.selectedText = wordSelection.items.map(item => item.text).join(' ');
 
-					
+
 					// Get the text before the selected word
 					const beforeCursor = wordSelection.items[0].expandTo(body.getRange('Start'));
 					context.load(beforeCursor, 'text');
 
-					
+
 					// Get the text after the selected word
 					const afterCursor = wordSelection.items[wordSelection.items.length-1].expandTo(body.getRange('End'));
 					context.load(afterCursor, 'text');
@@ -151,33 +151,12 @@ export const wordEditorAPI: EditorAPI = {
 					docContext.beforeCursor = beforeCursor.text;
 					docContext.afterCursor = afterCursor.text;
 					resolve(docContext);
-					
+
 				});
 			}
-            catch (error) {
+			catch (error) {
 				reject(error);
 			}
-		});
-	},
-
-	getCursorPosInfo() {
-		return new Promise<{charsToCursor: number, docLength: number}>(async (resolve, _reject) => {
-			await Word.run(async (context: Word.RequestContext) => {
-				const body: Word.Body = context.document.body;
-
-				const cursorSelection = context.document.getSelection();
-				const rangeToCursor = cursorSelection.expandTo(body.getRange('Start'));
-
-				context.load(rangeToCursor, 'text');
-				context.load(body, 'text');
-
-				await context.sync();
-
-				const charsToCursor = rangeToCursor.text.toString().length;
-
-				const docLength = body.text.toString().length;
-				resolve({ charsToCursor, docLength });
-			});
 		});
 	}
 };

--- a/frontend/src/api/wordEditorAPI.ts
+++ b/frontend/src/api/wordEditorAPI.ts
@@ -127,29 +127,29 @@ export const wordEditorAPI: EditorAPI = {
 
 					// Get the selected word
 					const wordSelection = context.document
-						.getSelection()
-						.getTextRanges([' '], false);
+						.getSelection();
+						//.getTextRanges([''], false);
 
 					context.load(wordSelection, 'items');
 					await context.sync();
 
 					// Get the text of the selected word
 					// Note that we need to join by ' ' to make sure to grab the entire word (which would end with a space)
-					docContext.selectedText = wordSelection.items.map(item => item.text).join(' ');
+					docContext.selectedText = wordSelection.text;//items.map(item => item.text).join(' ');
 
 					// Get the text before the selected word
-					const beforeCursor = wordSelection.items[0].expandTo(body.getRange('Start'));
+					const beforeCursor = wordSelection.expandTo(body.getRange('Start'));
 					context.load(beforeCursor, 'text');
 
 					// Get the text after the selected word
-					const afterCursor = wordSelection.items[wordSelection.items.length-1].expandTo(body.getRange('End'));
+					const afterCursor = wordSelection.expandTo(body.getRange('End'));
 					context.load(afterCursor, 'text');
 
 					await context.sync();
 
 					// Set the beforeCursor and afterCursor properties of the docContext object
-					docContext.beforeCursor = beforeCursor.text;
-					docContext.afterCursor = afterCursor.text;
+					docContext.beforeCursor = beforeCursor.text.slice(0, -docContext.selectedText.length);
+					docContext.afterCursor = afterCursor.text.slice(docContext.selectedText.length);
 					resolve(docContext);
 				});
 			}

--- a/frontend/src/api/wordEditorAPI.ts
+++ b/frontend/src/api/wordEditorAPI.ts
@@ -134,6 +134,7 @@ export const wordEditorAPI: EditorAPI = {
 					await context.sync();
 
 					// Get the text of the selected word
+					// Note that we need to join by ' ' to make sure to grab the entire word (which would end with a space)
 					docContext.selectedText = wordSelection.items.map(item => item.text).join(' ');
 
 					// Get the text before the selected word

--- a/frontend/src/api/wordEditorAPI.ts
+++ b/frontend/src/api/wordEditorAPI.ts
@@ -127,29 +127,29 @@ export const wordEditorAPI: EditorAPI = {
 
 					// Get the selected word
 					const wordSelection = context.document
-						.getSelection();
-						//.getTextRanges([''], false);
+						.getSelection()
+						.getTextRanges([' '], false);
 
 					context.load(wordSelection, 'items');
 					await context.sync();
 
 					// Get the text of the selected word
 					// Note that we need to join by ' ' to make sure to grab the entire word (which would end with a space)
-					docContext.selectedText = wordSelection.text;//items.map(item => item.text).join(' ');
+					docContext.selectedText = wordSelection.items.map(item => item.text).join(' ');
 
 					// Get the text before the selected word
-					const beforeCursor = wordSelection.expandTo(body.getRange('Start'));
+					const beforeCursor = wordSelection.items[0].expandTo(body.getRange('Start'));
 					context.load(beforeCursor, 'text');
 
 					// Get the text after the selected word
-					const afterCursor = wordSelection.expandTo(body.getRange('End'));
+					const afterCursor = wordSelection.items[wordSelection.items.length-1].expandTo(body.getRange('End'));
 					context.load(afterCursor, 'text');
 
 					await context.sync();
 
 					// Set the beforeCursor and afterCursor properties of the docContext object
-					docContext.beforeCursor = beforeCursor.text.slice(0, -docContext.selectedText.length);
-					docContext.afterCursor = afterCursor.text.slice(docContext.selectedText.length);
+					docContext.beforeCursor = beforeCursor.text;
+					docContext.afterCursor = afterCursor.text;
 					resolve(docContext);
 				});
 			}

--- a/frontend/src/components/navbar/index.tsx
+++ b/frontend/src/components/navbar/index.tsx
@@ -6,7 +6,7 @@ import classes from './styles.module.css';
 /**
  * An array of objects representing the names and titles of pages.
  * Each object contains the following properties:
- * 
+ *
  * @property {PageName} name - The name identifier of the page.
  * @property {string} title - The display title of the page.
  */
@@ -18,7 +18,7 @@ type Page = {
 
 const pageNames: Page[] = [
 	{ name: PageName.Draft, title: 'Draft' },
-	// { name: 'revise', title: 'Revise' },
+	// { name: PageName.Revise, title: 'Revise' },
 	// { name: 'searchbar', title: 'SearchBar' },
 	// { name: 'chat', title: 'Chat' },
 ];

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -35,15 +35,10 @@ function App() {
 		},
 		getDocContext: async (): Promise<DocContext> => {
 			return {
-				beforeCursor: docRef.current,  
-				selectedText: '',              
-				afterCursor: ''                
+				beforeCursor: docRef.current,
+				selectedText: '',
+				afterCursor: ''
 			};
-		},
-		getCursorPosInfo: async () => {
-			const doc = docRef.current;
-
-			return { charsToCursor: doc.length, docLength: doc.length };
 		},
 		addSelectionChangeHandler: (handler: () => void) => {
 			selectionChangeHandlers.current.push(handler);

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -33,8 +33,12 @@ function App() {
 		doLogout: async (auth0Client: Auth0ContextInterface) => {
 			await auth0Client.logout();
 		},
-		getDocContext: async (_positionalSensitivity: boolean) => {
-			return docRef.current;
+		getDocContext: async (): Promise<DocContext> => {
+			return {
+				beforeCursor: docRef.current,  
+				selectedText: '',              
+				afterCursor: ''                
+			};
 		},
 		getCursorPosInfo: async () => {
 			const doc = docRef.current;

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -13,12 +13,8 @@ import {
 	AiOutlineStar,
 	AiOutlineSave
 } from 'react-icons/ai';
-
 import { iconFunc } from './iconFunc';
-
-
 import { SERVER_URL, log } from '@/api';
-
 import classes from './styles.module.css';
 import SavedGenerations from './savedGenerations';
 
@@ -45,7 +41,6 @@ const visibleIconForMode = {
 
 
 function GenerationResult({ generation }: { generation: GenerationResult }) {
-
 	return <Remark>{ generation.result }</Remark>;
 }
 
@@ -90,6 +85,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 
 	const IS_OBSCURED = false;
 
+	// Save the generation
 	function save(generation: GenerationResult, document: string) {
 		const newSaved = [...savedItems];
 
@@ -118,6 +114,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 		updateSavedItems(newSaved);
 	}
 
+	// Delete a saved item
 	function deleteSavedItem(dateSaved: Date) {
 		const newSaved = [...savedItems].filter(
 			savedItem => savedItem.dateSaved !== dateSaved
@@ -137,12 +134,13 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 		updateSavedItems(newSaved);
 	}
 
+	// Update the cursor position
 	async function handleSelectionChanged() {
+		// Get the document context (before cursor, selected text, after cursor)
 		const docInfo = await getDocContext();
 		updateDocContext(docInfo);
 
-		// const { charsToCursor, docLength } = await getCursorPosInfo();
-
+		// Update the cursor position
 		const charsToCursor = docInfo.beforeCursor.length;
     const docLength = docInfo.beforeCursor.length + docInfo.selectedText.length + docInfo.afterCursor.length;
 
@@ -150,6 +148,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 		updateCursorAtEnd(charsToCursor >= docLength);
 	}
 
+	// Get a generation from the backend
 	async function getGeneration(
 		username: string,
 		type: string,
@@ -186,7 +185,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 			updateGeneration((await response.json()) as GenerationResult);
 			updateGenCtxText(contextText);
 		}
- catch (err: any) {
+		catch (err: any) {
 			setIsLoading(false);
 			let errMsg = '';
 			if (err.name === 'AbortError')
@@ -252,9 +251,6 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 			);
 	else
 		results = (
-			// <div className={ classes.resultTextWrapper }>
-			// 	<div className={ classes.resultText }>{ generation }</div>
-			// </div>
 			<div className={ classes.resultTextWrapper }>
 				<div>
 					<div
@@ -290,7 +286,6 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 						}
 					>
 						{ iconFunc(generationMode) }
-
 					</div>
 				</div>
 			</div>

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -58,7 +58,11 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 		getCursorPosInfo
 	} = editorAPI;
 
-	const [docContext, updateDocContext] = useState('');
+	const [docContext, updateDocContext] = useState<DocContext>({
+		beforeCursor: '',
+		selectedText: '',
+		afterCursor: ''
+	});
 	const [_cursorPos, updateCursorPos] = useState(0);
 	const [_cursorAtEnd, updateCursorAtEnd] = useState(true);
 	const [genCtxText, updateGenCtxText] = useState('');
@@ -135,7 +139,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 	}
 
 	async function handleSelectionChanged() {
-		const docText = await getDocContext(true);
+		const docText = await getDocContext();
 		updateDocContext(docText);
 		const { charsToCursor, docLength } = await getCursorPosInfo();
 		updateCursorPos(charsToCursor);
@@ -226,7 +230,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 			</div>
 		);
 	else if (generationMode === 'None' || generation === null)
-		if (!docContext.trim())
+		if (docContext.beforeCursor === '')
 			results = (
 				<div className={ classes.initTextWrapper }>
 					<div className={ classes.initText }>
@@ -302,8 +306,8 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 			<div className={ classes.contextText }>
 				<h4>Suggestions will be generated using:</h4>
 				<p>
-					{ docContext.length > 100 ? '...' : '' }
-					{ docContext.substring(docContext.length - 100) }
+					{ docContext.beforeCursor.length > 100 ? '...' : '' }
+					{ docContext.beforeCursor.substring(docContext.beforeCursor.length - 100) }
 				</p>
 			</div>
 
@@ -319,20 +323,20 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 							<Fragment key={ mode }>
 							<button
 								className={ classes.optionsButton }
-								disabled={ docContext.trim() === '' || isLoading }
+								disabled={ docContext.beforeCursor === '' || isLoading }
 								onClick={ () => {
 									log({
 										username: username,
 										interaction: `${mode}_Frontend`,
-										prompt: docContext
+										prompt: docContext.beforeCursor
 									});
-									if (docContext === '') return;
+									if (docContext.beforeCursor === '') return;
 
 									updateGenerationMode(mode);
 									getGeneration(
 										username,
 										`${mode}_Backend`,
-										docContext
+										docContext.beforeCursor
 									);
 								} }
 								onMouseEnter={ () =>
@@ -427,7 +431,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 									className={ classes.utilIconWrapper }
 									onClick={ () => {
 										// Save the generation
-										save(generation, docContext);
+										save(generation, docContext.beforeCursor);
 
 										setSaved(true);
 										setTimeout(() => setSaved(false), 2000);

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -208,7 +208,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 	}
 
 	// Temporarily select the text from the start to the cursor
-	async function selectToCursor(duration: number = 1000): Promise<void> {
+	async function _selectToCursor(duration: number = 1000): Promise<void> {
     try {
 			await Word.run(async (context: Word.RequestContext) => {
 				// TODO: Instead, use the "wordSelection" from the wordEditorAPI.ts
@@ -362,9 +362,10 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 								className={ classes.optionsButton }
 								disabled={ docContext.beforeCursor === '' || isLoading }
 								onClick={ async () => {
-									if (docContext.beforeCursor !== '') {
-										await selectToCursor();
-									}
+									// if (docContext.beforeCursor !== '') {
+									// 	await selectToCursor();
+									// }
+
 									log({
 										username: username,
 										interaction: `${mode}_Frontend`,

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -54,8 +54,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 	const {
 		addSelectionChangeHandler,
 		removeSelectionChangeHandler,
-		getDocContext,
-		getCursorPosInfo
+		getDocContext
 	} = editorAPI;
 
 	const [docContext, updateDocContext] = useState<DocContext>({
@@ -139,9 +138,14 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 	}
 
 	async function handleSelectionChanged() {
-		const docText = await getDocContext();
-		updateDocContext(docText);
-		const { charsToCursor, docLength } = await getCursorPosInfo();
+		const docInfo = await getDocContext();
+		updateDocContext(docInfo);
+
+		// const { charsToCursor, docLength } = await getCursorPosInfo();
+
+		const charsToCursor = docInfo.beforeCursor.length;
+    const docLength = docInfo.beforeCursor.length + docInfo.selectedText.length + docInfo.afterCursor.length;
+
 		updateCursorPos(charsToCursor);
 		updateCursorAtEnd(charsToCursor >= docLength);
 	}

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -146,6 +146,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 
 		updateCursorPos(charsToCursor);
 		updateCursorAtEnd(charsToCursor >= docLength);
+		// updateCursorAtEnd((docInfo.selectedText + docInfo.afterCursor).trim().length > 0);
 	}
 
 	// Get a generation from the backend

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -271,7 +271,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 			</div>
 		);
 	else if (generationMode === 'None' || generation === null)
-		if (docContext.beforeCursor === '')
+		if (!docContext.beforeCursor.trim())
 			results = (
 				<div className={ classes.initTextWrapper }>
 					<div className={ classes.initText }>

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -225,7 +225,6 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 
 				// Select the range
 				rangeToCursor.select();
-				// rangeToCursor.font.highlightColor = '#FFFF00';
 				await context.sync();
 
 				// Unselect after specified duration
@@ -233,7 +232,6 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 					await Word.run(async (context: Word.RequestContext) => {
 						const rangeToCursor = wordSelection.items[wordSelection.items.length-1].expandTo(body.getRange('Start'));
 						rangeToCursor.select();
-						// rangeToCursor.font.highlightColor = '#ffffff';
 						await context.sync();
 					});
 				}, duration);
@@ -346,6 +344,7 @@ export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
 				<p>
 					{ docContext.beforeCursor.length > 100 ? '...' : '' }
 					{ docContext.beforeCursor.substring(docContext.beforeCursor.length - 100) }
+					{ /* { JSON.stringify(docContext) } */ }
 				</p>
 			</div>
 

--- a/frontend/src/pages/draft/savedGenerations.tsx
+++ b/frontend/src/pages/draft/savedGenerations.tsx
@@ -18,7 +18,7 @@ export default function SavedGenerations({
     savedItems, 
     deleteSavedItem,
 }: { 
-    docContext: string, 
+    docContext: DocContext, 
     saved: boolean, 
     isLoading: boolean 
     savedItems: SavedItem[],
@@ -36,7 +36,7 @@ function GenerationResult({ generation }: { generation: GenerationResult }) {
             <div className={ classes.historyButtonWrapper }>
                 <button
                     className={ classes.historyButton }
-                    disabled={ docContext.trim() === '' || isLoading }
+                    disabled={ docContext.beforeCursor === '' || isLoading }
                     onClick={ () => {
                         // Toggle between the current page and the saved page
                         setSavedOpen(!isSavedOpen);

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -48,4 +48,3 @@ interface DocContext {
 	selectedText: string;
 	afterCursor: string;
 }
-

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -26,7 +26,6 @@ interface EditorAPI {
 	doLogin(auth0Client: Auth0ContextInterface): Promise<void>;
 	doLogout(auth0Client: Auth0ContextInterface): Promise<void>;
 	getDocContext(): Promise<DocContext>;
-	getCursorPosInfo(): Promise<{charsToCursor: number, docLength: number}>;
 	addSelectionChangeHandler: (handler: () => void) => void;
 	removeSelectionChangeHandler: (handler: () => void) => void;
 }

--- a/frontend/src/types.d.ts
+++ b/frontend/src/types.d.ts
@@ -25,7 +25,7 @@ interface SavedItem {
 interface EditorAPI {
 	doLogin(auth0Client: Auth0ContextInterface): Promise<void>;
 	doLogout(auth0Client: Auth0ContextInterface): Promise<void>;
-	getDocContext(positionalSensitivity: boolean): Promise<string>;
+	getDocContext(): Promise<DocContext>;
 	getCursorPosInfo(): Promise<{charsToCursor: number, docLength: number}>;
 	addSelectionChangeHandler: (handler: () => void) => void;
 	removeSelectionChangeHandler: (handler: () => void) => void;
@@ -43,3 +43,10 @@ interface CardData {
 	paragraphIndex: number;
 	body: string;
 }
+
+interface DocContext {
+	beforeCursor: string;
+	selectedText: string;
+	afterCursor: string;
+}
+


### PR DESCRIPTION
## goal
removing positional sensitivity flag from `getDocContext()` function and made it return `DocContext` object.

interface DocContext {
	beforeCursor: string;
	selectedText: string;
	afterCursor: string;
}



## Implementation Details

- Removed positional sensitivity flag in `getDocContext()`
- Update `types.d.ts` for new `DocContext` object
- Update web editor (but `selectedText` and `afterCursor` are empty string)
- Update Draft page to use DocContext (currently only using `beforeCursor`)