### PR TITLE
Fix: type agent response

### DIFF
--- a/backend/custom_llm.py
+++ b/backend/custom_llm.py
@@ -67,7 +67,7 @@ async def models_lifespan(app: FastAPI):
     
     start = time.time()
     response = client.get("/api/gen_revisions",
-        params={"doc": test_doc, "prompt": test_prompt, "n": 1})
+        params={"doc": test_doc, "prompt": test_prompt, "n": 1, "max_length": 16})
     print(f"Gen revisions endpoint: {time.time() - start:.2f}s")
 
     yield
@@ -138,7 +138,9 @@ def get_next_token_predictions(original_doc: str,
 def gen_revisions(
         prompt: str,
         doc: str,
-        n: Optional[int] = 5):
+        n: Optional[int] = 5,
+        max_length: Optional[int] = 1024,
+        ):
 
 
     model = ml_models['llm']['model']
@@ -154,7 +156,7 @@ def gen_revisions(
 
     generations = model.generate(
         tokenized_chat, num_return_sequences=n,
-        max_length=1024, do_sample=True, top_k=50, top_p=0.95, temperature=0.5,
+        max_length=max_length, do_sample=True, top_k=50, top_p=0.95, temperature=0.5,
         return_dict_in_generate=True, output_scores=True)
     generated_docs = tokenizer.batch_decode(generations.sequences, skip_special_tokens=True)
     #print(generations.scores)

--- a/backend/custom_llm.py
+++ b/backend/custom_llm.py
@@ -37,7 +37,12 @@ async def models_lifespan(app: FastAPI):
 
     ml_models["llm"] = llm = {
         'tokenizer': AutoTokenizer.from_pretrained(model_name),
-        'model': AutoModelForCausalLM.from_pretrained(model_name, device_map="auto" if USE_GPU else "cpu", torch_dtype=dtype)
+        'model': AutoModelForCausalLM.from_pretrained(
+            model_name,
+            device_map="auto" if USE_GPU else "cpu",
+            torch_dtype=dtype,
+            attn_implementation='eager'
+        )
     }
     print("Loaded llm with device map:")
     print(llm['model'].hf_device_map)

--- a/backend/custom_llm.py
+++ b/backend/custom_llm.py
@@ -156,7 +156,7 @@ def gen_revisions(
 
     generations = model.generate(
         tokenized_chat, num_return_sequences=n,
-        max_length=max_length, do_sample=True, top_k=50, top_p=0.95, temperature=0.5,
+        max_new_tokens=max_length, do_sample=True, top_k=50, top_p=0.95, temperature=0.5,
         return_dict_in_generate=True, output_scores=True)
     generated_docs = tokenizer.batch_decode(generations.sequences, skip_special_tokens=True)
     #print(generations.scores)

--- a/backend/custom_llm_inference.py
+++ b/backend/custom_llm_inference.py
@@ -203,7 +203,7 @@ def continue_messages_inner(model, tokenizer, messages, n_branch_tokens, n_futur
     #     tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=True, continue_final_message=True, return_tensors="pt").to(model.device)
     # else:
     #     tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=True, return_tensors="pt").to(model.device)
-    tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=True, return_tensors="pt").to(model.device)
+    tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=True, return_tensors="pt", continue_final_message=True).to(model.device)
 
     print(tokenizer.batch_decode(tokenized_chat, skip_special_tokens=False))
 

--- a/backend/custom_llm_inference.py
+++ b/backend/custom_llm_inference.py
@@ -37,7 +37,8 @@ def get_highlights_inner(model, tokenizer, doc, prompt, updated_doc, k):
     updated_doc_ids = tokenize_doc_in_progress(tokenizer, updated_doc)
 
     joined_ids = torch.cat([tokenized_chat, updated_doc_ids])
-    # Call the model
+
+    # Compute the next-token logits for the entire document
     with torch.no_grad():
         logits = model(joined_ids[None].to(model.device)).logits[0].cpu()
     
@@ -194,7 +195,7 @@ def get_next_token_predictions_slow(
 
 
 
-def continue_messages_inner(model, tokenizer, messages, n_branch_tokens, n_future_tokens)
+def continue_messages_inner(model, tokenizer, messages, n_branch_tokens, n_future_tokens):
     device = model.device
 
     final_message_is_assistant = messages[-1]['role'] == "assistant"

--- a/backend/custom_llm_inference.py
+++ b/backend/custom_llm_inference.py
@@ -191,3 +191,71 @@ def get_next_token_predictions_slow(
 
     decoded_next_tokens = tokenizer.batch_decode(lookahead_sequences, skip_special_tokens=True)
     return decoded_next_tokens, next_token_logits
+
+
+
+def continue_messages_inner(model, tokenizer, messages, n_branch_tokens, n_future_tokens)
+    device = model.device
+
+    final_message_is_assistant = messages[-1]['role'] == "assistant"
+    print(f"final_message_is_assistant: {final_message_is_assistant}")
+    # if final_message_is_assistant:
+    #     tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=True, continue_final_message=True, return_tensors="pt").to(model.device)
+    # else:
+    #     tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=True, return_tensors="pt").to(model.device)
+    tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=True, return_tensors="pt").to(model.device)
+
+    print(tokenizer.batch_decode(tokenized_chat, skip_special_tokens=False))
+
+    # This fails with
+    # RuntimeError: Index put requires the source and destination dtypes match, got BFloat16 for the destination and Float for the source.
+    # generations = model.generate(
+    #     tokenized_chat,
+    #     num_return_sequences=n_branch_tokens,
+    #     num_beam_groups=n_branch_tokens, num_beams=n_branch_tokens,
+    #     do_sample=False, max_new_tokens=n_future_tokens, diversity_penalty=1e5, top_k=None,
+    #     return_dict_in_generate=True, output_scores=True)
+
+    # Instead, we'll do this in two steps:
+    # 1. Get the next token predictions for the k most likely continuations
+    from transformers.cache_utils import DynamicCache
+    past_key_values = DynamicCache()
+    with torch.no_grad():
+        model_outs = model(
+            tokenized_chat,
+            past_key_values=past_key_values,
+            output_hidden_states=True,
+            use_cache=True,
+        )
+        branch_tokens = model_outs.logits[0, -1].topk(n_branch_tokens).indices
+    
+    hypotheses = branch_tokens.unsqueeze(1)
+    # Branch off the k most likely continuations
+    past_key_values.reorder_cache(torch.zeros((n_branch_tokens,), dtype=torch.long, device=device))
+
+    # 2. Generate the next n_future_tokens for each branch
+    for i in range(n_future_tokens):
+        position_id_for_final_token = tokenized_chat.shape[0] + i
+        cache_position = torch.full((1,), position_id_for_final_token, dtype=int, device=device)
+        final_token_ids = hypotheses[:, -1:]
+        with torch.no_grad():
+            model_outs = model(
+                final_token_ids,
+                past_key_values=past_key_values,
+                output_hidden_states=True,
+                use_cache=True,
+                cache_position=cache_position
+            )
+
+        # Grab the single most likely token from each of the k sequences
+        next_token_logits = model_outs.logits[:, -1]
+        vocab_size = model.config.vocab_size
+        assert next_token_logits.shape == (n_branch_tokens, vocab_size), f"{next_token_logits.shape=}, {n_branch_tokens=}, {vocab_size=}"
+        most_likely_token_ids = next_token_logits.argmax(dim=-1)
+        hypotheses = torch.cat([
+            hypotheses,
+            most_likely_token_ids.unsqueeze(1)
+        ], dim=1)
+
+    generated_docs = tokenizer.batch_decode(hypotheses, skip_special_tokens=True)
+    return generated_docs

--- a/backend/test_llm_inference.py
+++ b/backend/test_llm_inference.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import custom_llm_inference
+from transformers.cache_utils import DynamicCache
+
+@pytest.fixture
+def model_and_tokenizer():
+    model_name = 'google/gemma-2-2b-it'
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    if tokenizer.bos_token_id is None:
+        tokenizer.bos_token_id = tokenizer.pad_token_id
+    model = AutoModelForCausalLM.from_pretrained(
+        model_name, 
+        device_map="cpu", 
+        #torch_dtype=torch.float16
+    )
+    return model, tokenizer
+
+@pytest.fixture
+def sample_inputs():
+    doc = "The quick brown fox loves to jump over lazy dogs."
+    prompt = "Rewrite this document to make more sense."
+    doc_in_progress = "Sure, here's the document rewritten as requested:\n\nA fox,"
+    return doc, prompt, doc_in_progress
+
+def test_get_next_token_predictions(model_and_tokenizer, sample_inputs):
+    model, tokenizer = model_and_tokenizer
+    doc, prompt, doc_in_progress = sample_inputs
+    
+    predictions = custom_llm_inference.get_next_token_predictions_slow(
+        model, tokenizer, doc, prompt, doc_in_progress=doc_in_progress, k=5
+    )
+    
+    assert len(predictions) == 2  # Should return (token_texts, logits)
+    assert len(predictions[0]) == 5  # Should return k=5 predictions
+    assert predictions[1].shape[1] == model.config.vocab_size
+
+def test_get_tokenized_chat(model_and_tokenizer, sample_inputs):
+    model, tokenizer = model_and_tokenizer
+    doc, prompt, _ = sample_inputs
+    
+    tokenized_chat = custom_llm_inference.get_tokenized_chat(tokenizer, prompt, doc)
+    
+    assert isinstance(tokenized_chat, torch.Tensor)
+    assert tokenized_chat.dim() == 1
+    assert tokenized_chat.dtype == torch.int64
+
+def test_highlights(model_and_tokenizer, sample_inputs):
+    model, tokenizer = model_and_tokenizer
+    doc, prompt, updated_doc = sample_inputs
+    
+    highlights = custom_llm_inference.get_highlights_inner(
+        model, tokenizer, doc, prompt, updated_doc=updated_doc, k=5
+    )
+    
+    assert isinstance(highlights, list)
+    assert len(highlights) > 0
+    for h in highlights:
+        assert h['start'] >= 0
+        assert h['end'] >= h['start']
+        assert isinstance(h['token'], str)
+        assert isinstance(h['token_loss'], float)
+        assert isinstance(h['most_likely_token'], str)
+        assert isinstance(h['topk_tokens'], list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,4 +29,9 @@ gpu = [
     "accelerate>=1.1.1",
     "torch>=2.5.1",
     "transformers>=4.46.2",
+    "tokenizers>=0.21.0",
+]
+dev = [
+    "ipython>=8.32.0",
+    "marimo>=0.10.6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "sse-starlette>=2.1.3",
     "tenacity>=9.0.0",
     "uvicorn>=0.30.6",
+    "pytest>=8.3.4",
 ]
 
 [tool.uv.sources]

--- a/sandbox/LLM inference demo.py
+++ b/sandbox/LLM inference demo.py
@@ -1,19 +1,31 @@
 import marimo
 
-__generated_with = "0.9.27"
+__generated_with = "0.10.6"
 app = marimo.App(width="medium")
 
 
 @app.cell
-def __():
+def _():
     import marimo as mo
     from transformers import AutoModelForCausalLM, AutoTokenizer
     import torch
-    return AutoModelForCausalLM, AutoTokenizer, mo, torch
+    import sys
+    import pathlib
+    backend_path = pathlib.Path("backend").resolve().absolute()
+    sys.path.insert(0, str(backend_path))
+    return (
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        backend_path,
+        mo,
+        pathlib,
+        sys,
+        torch,
+    )
 
 
 @app.cell
-def __(AutoModelForCausalLM, AutoTokenizer, torch):
+def _(AutoModelForCausalLM, AutoTokenizer, torch):
     model_name = 'google/gemma-2-2b-it'
     #model_name = "HuggingFaceTB/SmolLM2-1.7B-Instruct"
     #model_name = 'Qwen/Qwen2.5-0.5B-Instruct'
@@ -26,7 +38,13 @@ def __(AutoModelForCausalLM, AutoTokenizer, torch):
 
 
 @app.cell
-def __(tokenizer, torch):
+def _(sys):
+    sys.path
+    return
+
+
+@app.cell
+def _(tokenizer, torch):
     import custom_llm_inference
     get_tokenized_chat = custom_llm_inference.get_tokenized_chat
     def tokenize_doc_in_progress(tokenizer, doc_in_progress):
@@ -50,7 +68,7 @@ def __(tokenizer, torch):
 
 
 @app.cell
-def __():
+def _():
     doc = "The quick brown fox loves to jump over some really lazy dogs because it's just distracted from doing what foxes ought to do."
     prompt = "Rewrite this document to make more sense."
     updated_doc = doc
@@ -59,14 +77,14 @@ def __():
 
 
 @app.cell
-def __():
+def _():
     #ref_output = custom_llm_inference.get_next_token_predictions_inner(model, tokenizer, doc, prompt, doc_in_progress="", k=5)
     #ref_output
     return
 
 
 @app.cell
-def __(
+def _(
     custom_llm_inference,
     doc,
     doc_in_progress,
@@ -80,19 +98,13 @@ def __(
 
 
 @app.cell
-def __():
+def _():
     from transformers.cache_utils import DynamicCache
     return (DynamicCache,)
 
 
 @app.cell
-def __(tokenizer):
-    tokenizer.__len__()
-    return
-
-
-@app.cell
-def __(
+def _(
     DynamicCache,
     doc,
     get_tokenized_chat,
@@ -174,41 +186,65 @@ def __(
 
 
 @app.cell
-def __(past_key_values):
+def _(torch):
+    torch.nn.modules.module
+    return
+
+
+@app.cell
+def _(past_key_values):
     past_key_values.key_cache[1].shape
     return
 
 
 @app.cell
-def __(lookahead_sequences, tokenizer):
+def _(lookahead_sequences, tokenizer):
     tokenizer.batch_decode(lookahead_sequences)
     return
 
 
 @app.cell
-def __(next_token_logits, ref_output):
+def _(next_token_logits, ref_output):
     print(next_token_logits)
     print(ref_output[1])
     return
 
 
 @app.cell
-def __(next_token_logits, ref_output, torch):
+def _(next_token_logits, ref_output, torch):
     #torch.allclose(next_token_logits, ref_output[1])
     torch.linalg.vector_norm((next_token_logits - ref_output[1]), dim=1)
     return
 
 
 @app.cell
-def __(hypotheses, model, tokenizer):
-    seqs = model.generate(hypotheses, num_beams=5, num_beam_groups=5, max_new_tokens=10, do_sample=False, diversity_penalty=1e5, top_k=None, num_return_sequences=5)#, token_healing=True, tokenizer=tokenizer)
+def _(hypotheses, model, seqs, tokenizer):
+    beam_group_output = model.generate(hypotheses, num_beams=5, num_beam_groups=5, max_new_tokens=3, do_sample=False, diversity_penalty=1e5, top_k=None, num_return_sequences=5, return_dict_in_generate=True)
     tokenizer.batch_decode(seqs)
-    return (seqs,)
+    return (beam_group_output,)
 
 
 @app.cell
-def __(tokenizer):
+def _(tokenizer):
     tokenizer.convert_tokens_to_ids([" "])
+    return
+
+
+@app.cell
+def _():
+    from transformers.generation.beam_search import BeamSearchScorer
+    return (BeamSearchScorer,)
+
+
+@app.cell
+def _(hypotheses):
+    hypotheses.shape
+    return
+
+
+@app.cell
+def _(hypotheses, model):
+    model.generate(hypotheses, do_sample=True, num_return_sequences=5, temperature=.9)
     return
 
 


### PR DESCRIPTION
It turns out the completions method had a very simple fix: `continue_messages=True`.

But as part of finding, fixing, and testing that, I:

- Refactored the API method to extract the code to a separate module
- Added some tests of other functionality (they don't do much yet)
- Bumped dependencies (but then I reverted)
- Worked around a bug that just emerged with Torch

The Torch bug is specifically weird because it persists even when I revert to the uv.lock from before this branch. 