### PR TITLE
Fix:custom editor function

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -6,4 +6,3 @@ module.exports = {
     moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
     testMatch: ['**/__tests__/**/*.test.ts', '**/?(*.)+(spec|test).ts']
 };
-  

--- a/frontend/src/api/wordEditorAPI.ts
+++ b/frontend/src/api/wordEditorAPI.ts
@@ -10,6 +10,7 @@ export const wordEditorAPI: EditorAPI = {
 				| { message: string; origin: string | undefined }
 				| { error: number }
 		) => {
+			
 			if ('error' in args) {
 				// eslint-disable-next-line no-console
 				console.error('Error:', args.error);
@@ -20,7 +21,13 @@ export const wordEditorAPI: EditorAPI = {
 
 			if (messageFromDialog.status === 'success') {
 				// The dialog reported a successful login.
-				auth0Client.handleRedirectCallback(messageFromDialog.urlWithAuthInfo);
+				try {
+					auth0Client.handleRedirectCallback(messageFromDialog.urlWithAuthInfo);
+				}
+				catch (error) {
+					// eslint-disable-next-line no-console
+					console.error('auth0Client.handleRedirectCallback Error:', error);
+				}
 			}
 			else {
 				// eslint-disable-next-line no-console

--- a/frontend/src/editor/editor.module.css
+++ b/frontend/src/editor/editor.module.css
@@ -1,6 +1,6 @@
 .editorContainer {
     margin: 20px;
-    height: 80vh;
+    height: 90vh;
     background: #fff;
     color: #000;
     position: relative;
@@ -8,7 +8,7 @@
     font-weight: 400;
     text-align: left;
     border: 1px solid rgb(218, 218, 218);
-    box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.3);
+    box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
     padding: 50px 0px 50px 50px;
 }
 

--- a/frontend/src/editor/editor.tsx
+++ b/frontend/src/editor/editor.tsx
@@ -146,63 +146,6 @@ function getCursorText(aNode: any, aOffset: any, mode: string): string {
 }
 
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function $getTextBeforeCursor() {
-	const selection = $getSelection();
-
-	if (!$isRangeSelection(selection)) return '';
-
-	const anchor = selection.anchor;
-	const anchorNode = anchor.getNode();
-	let anchorOffset = anchor.offset;
-
-	const currentNodeText = anchorNode.getTextContent();
-
-	// If anchorOffset is mid-word, extend it to the end of the word.
-	// Use a regular expression to find an end-of-word boundary.
-	if (anchorOffset < currentNodeText.length) {
-		const wordEnd = /(\W|$)/.exec(currentNodeText.slice(anchorOffset));
-
-		if (wordEnd) anchorOffset += wordEnd.index;
-	}
-
-	let textBeforeCursor = currentNodeText.slice(0, anchorOffset);
-
-	// Get text from previous siblings and their descendants
-	let currentNode: LexicalNode = anchorNode;
-	let prevNode: LexicalNode | null;
-
-	while ((prevNode = currentNode.getPreviousSibling())) {
-		currentNode = prevNode;
-		if (currentNode.getType() === 'paragraph')
-			textBeforeCursor = '\n\n' + textBeforeCursor;
-		else if (currentNode.getType() === 'linebreak')
-			textBeforeCursor = '\n' + textBeforeCursor;
-
-		textBeforeCursor = currentNode.getTextContent() + textBeforeCursor;
-	}
-
-	// Traverse up the tree and get text from previous siblings
-	let parent = anchorNode.getParent();
-
-	while (parent) {
-		let sibling: LexicalNode = parent;
-		let nextSibling: LexicalNode | null;
-
-		while ((nextSibling = sibling.getPreviousSibling())) {
-			if (sibling.getType() === 'paragraph')
-				textBeforeCursor = '\n\n' + textBeforeCursor;
-
-			sibling = nextSibling;
-			textBeforeCursor = sibling.getTextContent() + textBeforeCursor;
-		}
-
-		parent = parent.getParent();
-	}
-
-	return textBeforeCursor;
-}
-
 function LexicalEditor({
 	updateDocContext,
 	initialState
@@ -234,23 +177,7 @@ function LexicalEditor({
 					<OnChangePlugin
 						onChange={ editorState => {
 							editorState.read(() => {
-								// const textBeforeCursor = $getTextBeforeCursor();
-
-								// eslint-disable-next-line no-console
-								// console.log(
-								// 	'Text before cursor:',
-								// 	textBeforeCursor
-								// );
-
 								const docContext = $getDocContext();
-								// eslint-disable-next-line no-console
-								// console.log(JSON.stringify(docContext));
-
-								// eslint-disable-next-line no-console
-								// console.log(
-								// 	'Full document:',
-								// 	$getRoot().getTextContent()
-								// );
 
 								updateDocContext(docContext);
 

--- a/frontend/src/editor/editor.tsx
+++ b/frontend/src/editor/editor.tsx
@@ -18,6 +18,11 @@ import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin';
 
 import classes from './editor.module.css';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function $getDocContext() {
+	return;
+}
+
 function $getTextBeforeCursor() {
 	const selection = $getSelection();
 

--- a/frontend/src/editor/editor.tsx
+++ b/frontend/src/editor/editor.tsx
@@ -244,7 +244,7 @@ function LexicalEditor({
 
 								const docContext = $getDocContext();
 								// eslint-disable-next-line no-console
-								console.log(JSON.stringify(docContext));
+								// console.log(JSON.stringify(docContext));
 
 								// eslint-disable-next-line no-console
 								// console.log(

--- a/frontend/src/editor/editor.tsx
+++ b/frontend/src/editor/editor.tsx
@@ -169,7 +169,7 @@ function getCursorText(aNode: any, aOffset: any, mode: string): string {
 }
 
 
-
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function $getTextBeforeCursor() {
 	const selection = $getSelection();
 
@@ -257,7 +257,7 @@ function LexicalEditor({
 					<OnChangePlugin
 						onChange={ editorState => {
 							editorState.read(() => {
-								const textBeforeCursor = $getTextBeforeCursor();
+								// const textBeforeCursor = $getTextBeforeCursor();
 
 								// eslint-disable-next-line no-console
 								// console.log(

--- a/frontend/src/editor/editor.tsx
+++ b/frontend/src/editor/editor.tsx
@@ -227,10 +227,10 @@ function $getTextBeforeCursor() {
 }
 
 function LexicalEditor({
-	updateTextBeforeCursor,
+	updateDocContext,
 	initialState
 }: {
-	updateTextBeforeCursor: (text: string) => void;
+	updateDocContext: (docContext: DocContext) => void;
 	initialState: InitialEditorStateType | null;
 }) {
 	return (
@@ -275,7 +275,7 @@ function LexicalEditor({
 								// 	$getRoot().getTextContent()
 								// );
 
-								updateTextBeforeCursor(textBeforeCursor);
+								updateDocContext(docContext);
 
 								localStorage.setItem(
 									'doc',

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -32,6 +32,7 @@ function App() {
 				await auth0Client.loginWithPopup();
 			}
 			catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('auth0Client.loginWithPopup Error:', error);
 			}
 		},
@@ -40,6 +41,7 @@ function App() {
 				await auth0Client.logout();
 			}
 			catch (error) {
+				// eslint-disable-next-line no-console
 				console.error('auth0Client.logout Error:', error);
 			}
 		},

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -36,7 +36,12 @@ function App() {
 			}
 		},
 		doLogout: async (auth0Client: Auth0ContextInterface) => {
-			await auth0Client.logout();
+			try {
+				await auth0Client.logout();
+			}
+			catch (error) {
+				console.error('auth0Client.logout Error:', error);
+			}
 		},
 		getDocContext: async (): Promise<DocContext> => {
 			return {

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -28,7 +28,12 @@ function App() {
 
 	const editorAPI: EditorAPI = {
 		doLogin: async (auth0Client: Auth0ContextInterface) => {
-			await auth0Client.loginWithPopup();
+			try {
+				await auth0Client.loginWithPopup();
+			}
+			catch (error) {
+				console.error('auth0Client.loginWithPopup Error:', error);
+			}
 		},
 		doLogout: async (auth0Client: Auth0ContextInterface) => {
 			await auth0Client.logout();

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -68,7 +68,7 @@ function App() {
 				/>
 			</div>
 
-			<div>last revision: {  localStorage.getItem('doc-date')|| ''  }</div>
+			{ /* <div>last revision: {  localStorage.getItem('doc-date')|| ''  }</div> */ }
 			<div className={ classes.sidebar }>
 				<Sidebar editorAPI={ editorAPI } />
 			</div>

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useContext } from 'react';
+import { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import { Auth0ContextInterface } from '@auth0/auth0-react';
 import * as SidebarInner from '@/pages/app';

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -38,7 +38,13 @@ function App() {
 		},
 		doLogout: async (auth0Client: Auth0ContextInterface) => {
 			try {
-				await auth0Client.logout();
+				await auth0Client.logout(
+					{
+						logoutParams: {
+							returnTo: `${location.origin}/editor.html`
+						}
+					}
+				);
 			}
 			catch (error) {
 				// eslint-disable-next-line no-console

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -12,7 +12,7 @@ function Sidebar({ editorAPI }: { editorAPI: EditorAPI }) {
 }
 
 function App() {
-	// Needs to be a ref so that we can use docRef.current in the editorAPI
+	// This is a reference to the current document context
 	const docContextRef = useRef<DocContext>({
 		beforeCursor: '',
 		selectedText: '',

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -8,6 +8,7 @@ import LexicalEditor from './editor';
 
 import classes from './styles.module.css';
 import { Auth0ContextInterface } from '@auth0/auth0-react';
+import { getBefore } from '@/utilities/selectionUtil';
 
 function Sidebar({ editorAPI }: { editorAPI: EditorAPI }) {
 	return (
@@ -28,28 +29,10 @@ function App() {
 
 	const editorAPI: EditorAPI = {
 		doLogin: async (auth0Client: Auth0ContextInterface) => {
-			try {
-				await auth0Client.loginWithPopup();
-			}
-			catch (error) {
-				// eslint-disable-next-line no-console
-				console.error('auth0Client.loginWithPopup Error:', error);
-			}
+			await auth0Client.loginWithPopup();
 		},
 		doLogout: async (auth0Client: Auth0ContextInterface) => {
-			try {
-				await auth0Client.logout(
-					{
-						logoutParams: {
-							returnTo: `${location.origin}/editor.html`
-						}
-					}
-				);
-			}
-			catch (error) {
-				// eslint-disable-next-line no-console
-				console.error('auth0Client.logout Error:', error);
-			}
+			await auth0Client.logout();
 		},
 		getDocContext: async (): Promise<DocContext> => {
 			return {
@@ -70,8 +53,8 @@ function App() {
 		},
 	};
 
-	const docUpdated = (content: string) => {
-		docRef.current = content;
+	const docUpdated = (docContext: DocContext) => {
+		docRef.current = getBefore(docContext);
 
 		handleSelectionChange();
 	};
@@ -81,7 +64,7 @@ function App() {
 			<div className={ classes.editor }>
 				<LexicalEditor
 					initialState={ localStorage.getItem('doc') || null }
-					updateTextBeforeCursor={ docUpdated }
+					updateDocContext={ docUpdated }
 				/>
 			</div>
 

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -1,14 +1,9 @@
-import { useRef } from 'react';
+import { useRef, useContext } from 'react';
 import ReactDOM from 'react-dom';
-
-//import Draft from '@/pages/draft';
-import * as SidebarInner from '@/pages/app';
-
-import LexicalEditor from './editor';
-
-import classes from './styles.module.css';
 import { Auth0ContextInterface } from '@auth0/auth0-react';
-import { getBefore } from '@/utilities/selectionUtil';
+import * as SidebarInner from '@/pages/app';
+import LexicalEditor from './editor';
+import classes from './styles.module.css';
 
 function Sidebar({ editorAPI }: { editorAPI: EditorAPI }) {
 	return (
@@ -18,7 +13,11 @@ function Sidebar({ editorAPI }: { editorAPI: EditorAPI }) {
 
 function App() {
 	// Needs to be a ref so that we can use docRef.current in the editorAPI
-	const docRef = useRef('');
+	const docContextRef = useRef<DocContext>({
+		beforeCursor: '',
+		selectedText: '',
+		afterCursor: ''
+	});
 
 	// Since this is a list, a useState would have worked as well
 	const selectionChangeHandlers = useRef<(() => void)[]>([]);
@@ -35,11 +34,7 @@ function App() {
 			await auth0Client.logout();
 		},
 		getDocContext: async (): Promise<DocContext> => {
-			return {
-				beforeCursor: docRef.current,
-				selectedText: '',
-				afterCursor: ''
-			};
+			return docContextRef.current;
 		},
 		addSelectionChangeHandler: (handler: () => void) => {
 			selectionChangeHandlers.current.push(handler);
@@ -54,7 +49,7 @@ function App() {
 	};
 
 	const docUpdated = (docContext: DocContext) => {
-		docRef.current = getBefore(docContext);
+		docContextRef.current = docContext;
 
 		handleSelectionChange();
 	};

--- a/frontend/src/editor/styles.module.css
+++ b/frontend/src/editor/styles.module.css
@@ -5,12 +5,23 @@
 }
 
 .editor {
-	width: 50%;
+	/* width: 60%; */
+	min-width: 60rem;
+}
+
+@media (max-width: 1280px) {
+	.editor {
+		width: 60%;
+		min-width: auto;
+	}
+	.container {
+		justify-content: center;
+	}
 }
 
 .sidebar {
-    max-height: 92vh;
-    margin: 20px;
+	max-height: 92vh;
+	margin: 20px;
 	overflow-y: scroll;
 	width: 30%;
 	box-shadow: -2px 0 5px rgba(0,0,0,0.1);

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -20,7 +20,11 @@ export default function Revise({ editorAPI }: { editorAPI: EditorAPI }) {
 	});
 	const { curParagraphIndex, paragraphTexts } = getCurParagraph(docContext);
 	const { getAccessTokenSilently } = useAuth0();
-	const { getDocContext } = editorAPI;
+	const {
+		addSelectionChangeHandler,
+		removeSelectionChangeHandler,
+		getDocContext
+	} = editorAPI;
 
 	const [reflections, updateReflections] = useState<
 		Map<
@@ -48,7 +52,7 @@ export default function Revise({ editorAPI }: { editorAPI: EditorAPI }) {
 	 *
 	 * @returns {Promise<void>} - A promise that resolves once the selection change is handled.
 	 */
-	async function handleSelectionChange(): Promise<void> {
+	async function handleSelectionChanged(): Promise<void> {
 		const docInfo = await getDocContext();
 		updateDocContext(docInfo);
 	}
@@ -129,20 +133,14 @@ export default function Revise({ editorAPI }: { editorAPI: EditorAPI }) {
 
 	useEffect(() => {
 		// Handle initial selection change
-		handleSelectionChange();
+		handleSelectionChanged();
 
 		// Handle subsequent selection changes
-		Office.context.document.addHandlerAsync(
-			Office.EventType.DocumentSelectionChanged,
-			handleSelectionChange
-		);
+		addSelectionChangeHandler(handleSelectionChanged);
 
 		// Cleanup
 		return () => {
-			Office.context.document.removeHandlerAsync(
-				Office.EventType.DocumentSelectionChanged,
-				handleSelectionChange
-			);
+			removeSelectionChangeHandler(handleSelectionChanged);
 		};
 	}, []);
 

--- a/frontend/src/popup.tsx
+++ b/frontend/src/popup.tsx
@@ -48,7 +48,13 @@ Office.onReady(() => {
 		}
 		setTimeout(
 			() => {
-				Office.context.ui.messageParent(JSON.stringify(message));
+				if (Office.context && Office.context.ui) {
+					Office.context.ui.messageParent(JSON.stringify(message));
+				}
+				else {
+					// eslint-disable-next-line no-console
+					console.error('Could not message parent: Office.context.ui is undefined');
+				}
 			},
 			DEBUG ? 5000 : 0
 		);

--- a/frontend/src/utilities/__tests__/selectionUtil.test.ts
+++ b/frontend/src/utilities/__tests__/selectionUtil.test.ts
@@ -1,0 +1,118 @@
+import { getBefore, getCurParagraph } from '../selectionUtil';
+import { expect } from '@jest/globals';
+
+describe('selectionUtil', () => {
+  describe('getBefore', () => {
+    it('should combine beforeCursor, selectedText and the first word from afterCursor', () => {
+      const docContext: DocContext = {
+        beforeCursor: 'Hello ',
+        selectedText: 'world',
+        afterCursor: ' is great!'
+      };
+      
+      const result = getBefore(docContext);
+      
+      expect(result).toBe('Hello world');
+    });
+    
+    it('should handle empty selectedText', () => {
+      const docContext: DocContext = {
+        beforeCursor: 'Hello ',
+        selectedText: '',
+        afterCursor: 'world is great!'
+      };
+      
+      const result = getBefore(docContext);
+      
+      expect(result).toBe('Hello world');
+    });
+    
+    it('should handle empty afterCursor', () => {
+      const docContext: DocContext = {
+        beforeCursor: 'Hello ',
+        selectedText: 'world',
+        afterCursor: ''
+      };
+      
+      const result = getBefore(docContext);
+      
+      expect(result).toBe('Hello world');
+    });
+    
+    it('should handle paragraph breaks in afterCursor', () => {
+      const docContext: DocContext = {
+        beforeCursor: 'Hello ',
+        selectedText: 'world',
+        afterCursor: '\rNext paragraph'
+      };
+      
+      const result = getBefore(docContext);
+      
+      expect(result).toBe('Hello world');
+    });
+  });
+  
+  describe('getCurParagraph', () => {
+    it('should correctly identify paragraphs and current paragraph index', () => {
+      const docContext: DocContext = {
+        beforeCursor: 'First paragraph\rSecond ',
+        selectedText: 'paragraph',
+        afterCursor: ' content\rThird paragraph'
+      };
+      
+      const result = getCurParagraph(docContext);
+      
+      expect(result.paragraphTexts).toEqual([
+        'First paragraph',
+        'Second paragraph content',
+        'Third paragraph'
+      ]);
+      expect(result.curParagraphIndex).toBe(1);
+    });
+    
+    it('should handle text without paragraph breaks', () => {
+      const docContext: DocContext = {
+        beforeCursor: 'Only ',
+        selectedText: 'one',
+        afterCursor: ' paragraph'
+      };
+      
+      const result = getCurParagraph(docContext);
+      
+      expect(result.paragraphTexts).toEqual(['Only one paragraph']);
+      expect(result.curParagraphIndex).toBe(0);
+    });
+    
+    it('should handle multiple paragraph breaks in beforeCursor', () => {
+      const docContext: DocContext = {
+        beforeCursor: 'First\rSecond\rThird\r',
+        selectedText: 'Fourth',
+        afterCursor: ' paragraph\rFifth'
+      };
+      
+      const result = getCurParagraph(docContext);
+      
+      expect(result.paragraphTexts).toEqual([
+        'First',
+        'Second',
+        'Third',
+        'Fourth paragraph',
+        'Fifth'
+      ]);
+      expect(result.curParagraphIndex).toBe(3);
+    });
+    
+    it('should handle empty paragraphs', () => {
+      const docContext: DocContext = {
+        beforeCursor: 'First\r\r',
+        selectedText: '',
+        afterCursor: 'Third'
+      };
+      
+      const result = getCurParagraph(docContext);
+      
+      expect(result.paragraphTexts).toEqual(['First', '', 'Third']);
+      expect(result.curParagraphIndex).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
This PR includes:
- Rebuilding functions for getting document text
  - It previously had `$getTextBeforeCursor` function to get the document text before the cursor. However, this can only be used for the "Draft" page. To handle that, we created `$getDocContext` function, which returns `beforeCursor, selectedText, afterCursor`, similar to the one in `WordEditorAPI`.

It currently, and for now, uses recursive methods to get docContext, but we would want to minimize it and handle markdown conversions in the future. See: #155 