### PR TITLE
Fixed editor/sidebar's width

### DIFF
--- a/frontend/src/editor/editor.module.css
+++ b/frontend/src/editor/editor.module.css
@@ -1,15 +1,13 @@
 .editorContainer {
     margin: 20px;
-    height: 90vh;
     background: #fff;
     color: #000;
     position: relative;
     line-height: 20px;
     font-weight: 400;
     text-align: left;
-    border: 1px solid rgb(218, 218, 218);
     box-shadow: -2px 0 5px rgba(0, 0, 0, 0.1);
-    padding: 50px 0px 50px 50px;
+    padding: 50px 0 50px 50px;
 }
 
 .editor {
@@ -22,7 +20,28 @@
     caret-color: #444;
     overflow-y: scroll;
     height: 80vh;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.1) transparent;
+    padding-right: 46px;
 }
+
+.editor::-webkit-scrollbar {
+    width: 4px;
+    height: 4px;
+}
+.editor::-webkit-scrollbar-track {
+    background: transparent;
+    margin-right: -4px;
+}
+.editor::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.1);
+    border-radius: 4px;
+    margin-right: -4px;
+}
+.editor::-webkit-scrollbar-thumb:hover {
+    background: rgba(0, 0, 0, 0.4);
+}
+
 .placeholder {
     color: #6b6b6b;
     overflow: hidden;

--- a/frontend/src/editor/styles.module.css
+++ b/frontend/src/editor/styles.module.css
@@ -5,25 +5,23 @@
 }
 
 .editor {
-	/* width: 60%; */
 	min-width: 60rem;
-}
-
-@media (max-width: 1280px) {
-	.editor {
-		width: 60%;
-		min-width: auto;
-	}
-	.container {
-		justify-content: center;
-	}
+	max-width: 60rem;
+	width: 100%;
 }
 
 .sidebar {
-	max-height: 92vh;
 	margin: 20px;
 	overflow-y: scroll;
-	width: 30%;
+	width: 28rem;
+	min-width: 28rem;
 	box-shadow: -2px 0 5px rgba(0,0,0,0.1);
 	font-family: 'Segoe UI', sans-serif, Arial, Helvetica;
+	position: sticky;
+	right: 0;
+	background-color: white;
+}
+
+.sidebar::-webkit-scrollbar {
+	display: none;
 }


### PR DESCRIPTION
This PR includes:
- CSS tweaks to fix the custom editor/sidebar's width.
  - Previously, the editor and sidebar changed when the browser's width changed.
  - Also, it had inconsistent padding when displaying long sentences.
- Scrollbar background is now transparent so that it does not block the view of the interfaces