### PR TITLE
add example generation on chat page

### DIFF
--- a/backend/nlp.py
+++ b/backend/nlp.py
@@ -73,17 +73,25 @@ async def chat(messages: Iterable[ChatCompletionMessageParam], temperature: floa
     # FIXME: figure out why result might ever be None
     return result or ""
 
-def chat_stream(messages: Iterable[ChatCompletionMessageParam], temperature: float):
-    return openai_client.chat.completions.create(
-        model=MODEL_NAME,
-        messages=messages,
-        temperature=temperature,
-        max_tokens=1024,
-        top_p=1,
-        frequency_penalty=0,
-        presence_penalty=0,
-        stream=True,
-    )
+def chat_stream(messages: Iterable[ChatCompletionMessageParam], temperature: float, tools=None, tool_choice=None):
+    params = {
+        "model": MODEL_NAME,
+        "messages": messages,
+        "temperature": temperature,
+        "max_tokens": 1024,
+        "top_p": 1,
+        "frequency_penalty": 0,
+        "presence_penalty": 0,
+        "stream": True,
+    }
+    
+    if tools:
+        params["tools"] = tools
+    
+    if tool_choice:
+        params["tool_choice"] = tool_choice
+        
+    return openai_client.chat.completions.create(**params)
 
 
 async def completion(prompt: str):

--- a/backend/server.py
+++ b/backend/server.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, Field, ConfigDict
 import os
 import json
 
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 from pathlib import Path
 from datetime import datetime
 
@@ -65,6 +65,8 @@ class ReflectionResponses(BaseModel):
 class ChatRequestPayload(BaseModel):
     messages: List[Dict[str, str]]
     username: str
+    tools: Optional[List[Dict[str, Any]]] = None
+    tool_choice: Optional[str] = None
 
 
 class Log(BaseModel):
@@ -173,6 +175,8 @@ async def chat(payload: ChatRequestPayload):
     response = await nlp.chat_stream(
         messages=payload.messages,
         temperature=0.7,
+        tools=payload.tools,
+        tool_choice=payload.tool_choice
     )
 
     # TODO: Fix logging

--- a/frontend/src/components/navbar/index.tsx
+++ b/frontend/src/components/navbar/index.tsx
@@ -20,7 +20,7 @@ const pageNames: Page[] = [
 	{ name: PageName.Draft, title: 'Draft' },
 	{ name: PageName.Revise, title: 'Revise' },
 	// { name: 'searchbar', title: 'SearchBar' },
-	// { name: 'chat', title: 'Chat' },
+	{ name: PageName.Chat, title: 'Chat' },
 ];
 
 export default function Navbar() {

--- a/frontend/src/contexts/editorContext.tsx
+++ b/frontend/src/contexts/editorContext.tsx
@@ -1,0 +1,25 @@
+import { type PropsWithChildren, createContext } from 'react';
+
+// Provides editor API functionality through context
+export const EditorContext = createContext<EditorAPI>({
+  doLogin: async () => {},
+  doLogout: async () => {},
+  getDocContext: async () => ({
+    beforeCursor: '',
+    selectedText: '',
+    afterCursor: ''
+  }),
+  addSelectionChangeHandler: () => {},
+  removeSelectionChangeHandler: () => {}
+});
+
+export default function EditorContextWrapper({
+  children,
+  editorAPI
+}: PropsWithChildren<{ editorAPI: EditorAPI }>) {
+  return (
+    <EditorContext.Provider value={ editorAPI }>
+      { children }
+    </EditorContext.Provider>
+  );
+}

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -221,7 +221,7 @@ function AppInner({ editorAPI }: HomeProps) {
 			case PageName.SearchBar:
 				return <SearchBar />;
 			case PageName.Chat:
-				return <Chat />;
+				return <Chat editorAPI={ editorAPI } />;
 			case PageName.Draft:
 				return <Draft editorAPI={ editorAPI } />;
 		}

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -9,6 +9,7 @@ import { useAuth0, Auth0Provider } from '@auth0/auth0-react';
 import PageContextWrapper, { PageName, PageContext } from '@/contexts/pageContext';
 import UserContextWrapper from '@/contexts/userContext';
 import ChatContextWrapper from '@/contexts/chatContext';
+import EditorContextWrapper from '@/contexts/editorContext';
 
 import classes from './styles.module.css';
 
@@ -217,13 +218,13 @@ function AppInner({ editorAPI }: HomeProps) {
 	function getComponent(pageName: PageName): JSX.Element | null {
 		switch (pageName) {
 			case PageName.Revise:
-				return <Revise editorAPI={ editorAPI } />;
+				return <Revise />;
 			case PageName.SearchBar:
 				return <SearchBar />;
 			case PageName.Chat:
-				return <Chat editorAPI={ editorAPI } />;
+				return <Chat />;
 			case PageName.Draft:
-				return <Draft editorAPI={ editorAPI } />;
+				return <Draft />;
 		}
 		return null;
 	}
@@ -269,20 +270,23 @@ export default function App({ editorAPI }: HomeProps) {
 		<ChatContextWrapper>
 			<UserContextWrapper>
 				<PageContextWrapper>
-				<Auth0Provider
-						domain={ process.env.AUTH0_DOMAIN! }
-						clientId={ process.env.AUTH0_CLIENT_ID! }
-						cacheLocation="localstorage"
-						useRefreshTokens={ true }
-						authorizationParams= { {
-							// eslint-disable-next-line camelcase
-							redirect_uri: `${window.location.origin}/popup.html`,
-							scope: 'openid profile email read:posts',
-							audience: 'textfocals.com',
-							leeway: 10
-						} }
-					>		<AppInner editorAPI={ editorAPI } />
-				</Auth0Provider>
+					<EditorContextWrapper editorAPI={ editorAPI }>
+						<Auth0Provider
+							domain={ process.env.AUTH0_DOMAIN! }
+							clientId={ process.env.AUTH0_CLIENT_ID! }
+							cacheLocation="localstorage"
+							useRefreshTokens={ true }
+							authorizationParams= { {
+								// eslint-disable-next-line camelcase
+								redirect_uri: `${window.location.origin}/popup.html`,
+								scope: 'openid profile email read:posts',
+								audience: 'textfocals.com',
+								leeway: 10
+							} }
+						>
+							<AppInner editorAPI={ editorAPI } />
+						</Auth0Provider>
+					</EditorContextWrapper>
 				</PageContextWrapper>
 			</UserContextWrapper>
 		</ChatContextWrapper>

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -7,15 +7,16 @@ import ChatMessage from '@/components/chatMessage';
 
 import { ChatContext } from '@/contexts/chatContext';
 import { UserContext } from '@/contexts/userContext';
+import { EditorContext } from '@/contexts/editorContext';
 
 import { SERVER_URL } from '@/api';
 
 import classes from './styles.module.css';
-import { getCurParagraph } from '@/utilities/selectionUtil';
 
-export default function Chat({ editorAPI }: { editorAPI: EditorAPI }) {
+export default function Chat() {
 	const { chatMessages, updateChatMessages } = useContext(ChatContext);
 	const { username } = useContext(UserContext);
+	const editorAPI = useContext(EditorContext);
 
 	/* Document Context (FIXME: make this a hook) */
 	const {
@@ -59,10 +60,11 @@ export default function Chat({ editorAPI }: { editorAPI: EditorAPI }) {
 
 			const initialAssistantMessage = {
 				role: 'assistant',
-				content: "What do you think about your document so far?"
+				content: 'What do you think about your document so far?'
 			};
 			newMessages = [systemMessage, docContextMessage, initialAssistantMessage];
-		} else {
+		}
+ 		else {
 			// Update the document context message with the current selection.
 			newMessages[1].content = docContextMessageContent;
 		}

--- a/frontend/src/pages/chat/styles.module.css
+++ b/frontend/src/pages/chat/styles.module.css
@@ -1,11 +1,30 @@
 .container {
-	margin: 10px;
 	display: flex;
 	flex-direction: column;
-	gap: 16px;
+	height: 100%;
+	padding: 1rem;
+	overflow: hidden;
+}
+
+.messageContainer {
+	flex: 1;
+	overflow-y: auto;
+	padding-bottom: 1rem;
+}
+
+.controlsContainer {
+	border-top: 1px solid #e9ecef;
+	padding-top: 1rem;
+	margin-top: auto;
+}
+
+.sendMessage {
+	margin-bottom: 1rem;
 }
 
 .label {
+	position: relative;
+	width: 100%;
 	display: flex;
 	align-items: center;
 	border: 1px solid grey;
@@ -37,18 +56,46 @@
 }
 
 .clearChat {
-	background: none;
+	margin-top: 1rem;
+	padding: 0.5rem 1rem;
+	border-radius: 0.5rem;
+	background-color: #f8f9fa;
+	color: #212529;
 	cursor: pointer;
-	border: 1px solid black;
-	padding: 5px 10px;
-	bottom: 0;
-	transition: 0.15s;
-	align-self: flex-end;
+	transition: all 0.2s ease-in-out;
 }
 
 .clearChat:hover {
-	background: black;
+	background-color: #e9ecef;
+}
+
+.buttonContainer {
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+	gap: 1rem;
+}
+
+.exampleButton {
+	padding: 0.75rem 1rem;
+	border-radius: 0.5rem;
+	background-color: #0a84ff;
 	color: white;
+	cursor: pointer;
+	transition: all 0.2s ease-in-out;
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	flex: 1;
+}
+
+.exampleButton:hover {
+	background-color: #0074e8;
+}
+
+.exampleButton:disabled {
+	background-color: #a5caff;
+	cursor: not-allowed;
 }
 
 .systemPrompt {

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useContext, Fragment } from 'react';
 import { UserContext } from '@/contexts/userContext';
+import { EditorContext } from '@/contexts/editorContext';
 import { Remark } from 'react-remark';
 import { FcCheckmark } from 'react-icons/fc';
 import {
@@ -43,8 +44,10 @@ function GenerationResult({ generation }: { generation: GenerationResult }) {
 	return <Remark>{ generation.result }</Remark>;
 }
 
-export default function Draft({ editorAPI }: { editorAPI: EditorAPI }) {
+export default function Draft() {
+	const editorAPI = useContext(EditorContext);
 	const { username } = useContext(UserContext);
+	
 	const {
 		addSelectionChangeHandler,
 		removeSelectionChangeHandler,

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -9,9 +9,10 @@ import { UserContext } from '@/contexts/userContext';
 import { getReflection } from '@/api';
 import classes from './styles.module.css';
 import { getCurParagraph } from '@/utilities/selectionUtil';
+import { EditorContext } from '@/contexts/editorContext';
 
-
-export default function Revise({ editorAPI }: { editorAPI: EditorAPI }) {
+export default function Revise() {
+	const editorAPI = useContext(EditorContext);
 	const { username } = useContext(UserContext);
 	const [docContext, updateDocContext] = useState<DocContext>({
 		beforeCursor: '',

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -11,6 +11,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const urlDev = 'https://localhost:3000';
 const urlProd = 'https://app.thoughtful-ai.com';
 
+const backendServer = (process.env.USE_AZURE === "false") ? 'http://0.0.0.0:8000/' : 'https://textfocals.azurewebsites.net/';
+
 async function getHttpsOptions() {
 	const httpsOptions = await devCerts.getHttpsServerOptions();
 	return {
@@ -165,7 +167,7 @@ module.exports = async (env, options) => {
 			proxy: [
 				{
 					context: ['/api'],
-					target: 'https://textfocals.azurewebsites.net/',
+					target: backendServer,
 					changeOrigin: true
 				}
 			],


### PR DESCRIPTION
## Description
Added an example generation function on the chat tab based on the [Content Heavy Prototype](https://docs.google.com/document/d/1TAoxfthBycM_lF7Cs3cuca8iF4mLbAUDaeOEQg1rmJY/edit?tab=t.rjj0o0lb1wuy).

## Implementation Details
### `frontend/src/pages/chat/index.tsx`
When the user clicks the example generation button, a `suggestExamples()` request is sent.

### `backend/nlp.py` & `backend/server.py`
Added payload support required for future web search requests.

Although the current example request is a plain generation request, there is support for [web search requests](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses).  
Web search requests require an additional payload, such as:  

`tools: [{ type: "web_search_preview" }]`


## Problems
The original plan for example generation focused on providing reliable links. However, the current OpenAI model used in our app does not seem to support URL-related functionality.

According to the official documentation, a [web search request](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses) response should include an `annotations` object. However, when implementing a web search preview request, the response did not contain the `annotations` object.

For this reason, a plain generation request was implemented for this branch. However, URL gernation have failed again. It appears that the model currently used by our app does not support web search functionality.

---

![Screenshot](https://github.com/user-attachments/assets/073b47db-7900-44d5-9026-acad33621ea4)

