### PR TITLE
Add missing RMove icon

### DIFF
--- a/frontend/src/pages/draft/iconFunc.tsx
+++ b/frontend/src/pages/draft/iconFunc.tsx
@@ -1,4 +1,4 @@
-import { AiOutlineAlignLeft, AiOutlineQuestion, AiOutlineHighlight } from 'react-icons/ai';
+import { AiOutlineAlignLeft, AiOutlineQuestion, AiOutlineHighlight, AiOutlineBank } from 'react-icons/ai';
 
 export const iconFunc = (generationType: string) => {
     switch (generationType) {
@@ -8,6 +8,8 @@ export const iconFunc = (generationType: string) => {
             return <AiOutlineQuestion />;
         case 'Keywords':
             return <AiOutlineHighlight />;
+        case 'RMove':
+            return <AiOutlineBank />;
         default:
             return null;
     }


### PR DESCRIPTION
This PR includes:
- Add missing icon for Rhetorical Move Generation. Previously, it was not defined in the [iconFunc](https://github.com/AIToolsLab/writing-tools/blob/main/frontend/src/pages/draft/iconFunc.tsx)