### PR TITLE
Work around Lexical editor bug that was causing errors when the custom editor document was saved when empty

### DIFF
--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -139,7 +139,8 @@ function App(props: EditorProps) {
 		<div className={ isDemo ? classes.democontainer : classes.container }>
 			<div className={ isDemo ? classes.demoeditor : classes.editor }>
 				<LexicalEditor
-					initialState={ localStorage.getItem('doc') || null }
+					//@ts-ignore, see https://github.com/facebook/lexical/issues/5079
+					initialState={ localStorage.getItem('doc') || undefined }
 					updateDocContext={ docUpdated }
 				/>
 				{ isDemo && wordLimit && (


### PR DESCRIPTION
Under certain conditions, the custom editor was throwing an exception:

> `Uncaught Error: setEditorState: the editor state is empty. Ensure the editor state's root node never becomes empty.`

This was due to the editor state getting initialized to `null` when no document was loaded from local storage.

This seems to be a [bug in Lexical](https://github.com/facebook/lexical/issues/5079). According to the linked issue, it can be worked around by changing `null` to `undefined`. 

Note that this causes the type checker to complain because `undefined` is not specified as a valid value for the initial editor state. I suspect that this is a bug in the type specifications or the API, so we disable the error for that line.
