### PR TITLE
Refactor access token handling

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -59,7 +59,7 @@ export async function getReflection(
 	username: string,
 	paragraph: string,
 	prompt: string,
-	getAccessTokenSilently: () => Promise<string>
+	accessToken: string | null
 ): Promise<ReflectionResponseItem[]> {
 	try {
 		const key = JSON.stringify({ prompt, paragraph });
@@ -68,7 +68,6 @@ export async function getReflection(
 		// ASSUMES that cachedResponse is valid JSON
 
 		if (cachedResponse) return JSON.parse(cachedResponse);
-		const token = await getAccessTokenSilently();
 
 		const data = {
 			username: username,
@@ -80,7 +79,7 @@ export async function getReflection(
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',
-				Authorization: `Bearer ${token}`
+				Authorization: `Bearer ${accessToken || 'none'}`
 			},
 			body: JSON.stringify(data)
 		});
@@ -103,8 +102,9 @@ export async function getReflection(
 	}
 	catch (error) {
 		// TODO: Log errors better
-		// console.error(error);
-		// debugger;
+		// TODO: Handle auth errors (e.g., token expired)
+		// eslint-disable-next-line no-console
+		console.error(error);
 		return [];
 	}
 }

--- a/frontend/src/contexts/accessTokenContext.tsx
+++ b/frontend/src/contexts/accessTokenContext.tsx
@@ -1,0 +1,108 @@
+import React, { createContext, useContext, useState, useCallback } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+
+interface AccessTokenContextType {
+  accessToken: string | null;
+  consentNeeded: boolean;
+  loginNeeded: boolean;
+  refreshAccessToken: () => Promise<{ success: boolean; token?: string; error?: string }>;
+  doConsent: () => Promise<void>;
+  doLogin: () => Promise<void>;
+  errorType: string | null;
+}
+
+const AccessTokenContext = createContext<AccessTokenContextType>({
+  accessToken: null,
+  consentNeeded: false,
+  loginNeeded: false,
+  refreshAccessToken: async () => ({ success: false }),
+  doConsent: async () => {},
+  doLogin: async () => {},
+  errorType: null,
+});
+
+export const AccessTokenProvider = ({ children }: { children: React.ReactNode }) => {
+  const {
+    getAccessTokenSilently,
+    getAccessTokenWithPopup,
+    loginWithPopup,
+    isAuthenticated,
+  } = useAuth0();
+
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [consentNeeded, setConsentNeeded] = useState(false);
+  const [loginNeeded, setLoginNeeded] = useState(false);
+  const [errorType, setErrorType] = useState<string | null>(null);
+
+  // Called after backend says "token invalid/expired"
+  const refreshAccessToken = useCallback(async () => {
+    setConsentNeeded(false);
+    setLoginNeeded(false);
+    setErrorType(null);
+    try {
+      const token = await getAccessTokenSilently();
+      // Successfully got a new token. Clear any previous errors.
+      setAccessToken(token);
+      setLoginNeeded(false);
+      setConsentNeeded(false);
+      setErrorType(null);
+      return { success: true, token };
+    } catch (e: unknown) {
+      const error = e as { error?: string };
+      /* TODO: we might not always need to login again, sometimes we can just ask for consent.
+      But we need to ensure that popup works with the Word API.
+      */
+      if (true /*error.error === "consent_required" || error.error === "missing_refresh_token"*/) {
+          setLoginNeeded(true);
+          setErrorType("login_required");
+        } else if (error.error === "login_required") {
+          setConsentNeeded(true);
+          setErrorType("consent_required");
+      }
+      setAccessToken(null);
+      return { success: false, error: error.error };
+    }
+  }, [getAccessTokenSilently]);
+
+  // UI calls this after user clicks "Allow Access"
+  // TODO: make sure this works with the Word API
+  const doConsent = useCallback(async () => {
+    await getAccessTokenWithPopup();
+    setConsentNeeded(false);
+    setErrorType(null);
+    await refreshAccessToken();
+  }, [getAccessTokenWithPopup, refreshAccessToken]);
+
+  // UI calls this after user clicks "Log in again"
+  const doLogin = useCallback(async () => {
+    // TODO: remove this, we're depending on the caller to call the correct login method
+    await loginWithPopup();
+    setLoginNeeded(false);
+    setErrorType(null);
+    await refreshAccessToken();
+  }, [loginWithPopup, refreshAccessToken]);
+
+  React.useEffect(() => {
+    if (isAuthenticated) {
+      refreshAccessToken();
+    }
+  }, [isAuthenticated, refreshAccessToken]);
+
+  return (
+    <AccessTokenContext.Provider
+      value={{
+        accessToken,
+        consentNeeded,
+        loginNeeded,
+        refreshAccessToken,
+        doConsent,
+        doLogin,
+        errorType,
+      }}
+    >
+      {children}
+    </AccessTokenContext.Provider>
+  );
+};
+
+export const useAccessToken = () => useContext(AccessTokenContext);

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -10,14 +10,15 @@ import { getReflection } from '@/api';
 import classes from './styles.module.css';
 import { getCurParagraph } from '@/utilities/selectionUtil';
 import { useDocContext } from '@/utilities';
+import { useAccessToken } from '@/contexts/accessTokenContext';
 
 
 export default function Revise({ editorAPI }: { editorAPI: EditorAPI }) {
 	const { username } = useContext(UserContext);
 	const docContext = useDocContext(editorAPI);
 	const { curParagraphIndex, paragraphTexts } = getCurParagraph(docContext);
-	const { getAccessTokenSilently } = useAuth0();
-
+	const { accessToken } = useAccessToken();
+	/* TODO: use refreshAccessToken() if we get an expired token error. */
 
 	const [reflections, updateReflections] = useState<
 		Map<
@@ -59,7 +60,7 @@ export default function Revise({ editorAPI }: { editorAPI: EditorAPI }) {
 
 		if (typeof cachedValue === 'undefined') {
 			const reflectionsPromise: Promise<ReflectionResponseItem[]> =
-				getReflection(username, paragraphText, prompt, getAccessTokenSilently);
+				getReflection(username, paragraphText, prompt, accessToken);
 
 			reflectionsPromise
 				.then(newReflections => {

--- a/frontend/src/pages/searchbar/index.tsx
+++ b/frontend/src/pages/searchbar/index.tsx
@@ -12,6 +12,7 @@ import { getReflection } from '@/api';
 import { useAuth0 } from '@auth0/auth0-react';
 
 import classes from './styles.module.css';
+import { useAccessToken } from '@/contexts/accessTokenContext';
 
 export default function SearchBar() {
 	const { username } = useContext(UserContext);
@@ -21,6 +22,9 @@ export default function SearchBar() {
 	const [paragraphTexts, updateParagraphTexts] = useState<string[]>([]);
 	const [curParagraphText, updateCurParagraphText] = useState('');
 
+		const { accessToken, refreshAccessToken } = useAccessToken();
+	
+		
 	const [reflections, updateReflections] = useState<
 		Map<
 			string,
@@ -113,7 +117,7 @@ export default function SearchBar() {
 		const suggestionPrompt = `Write one concise and brief prompt to ask a companion for various points about a piece of academic writing that may warrant reconsideration. The prompt might ask for the main point, important concepts, claims or arguments, possible counterarguments, additional evidence/examples, points of ambiguity, and questions as a reader/writer${rhetCtxt ? rhetCtxtDirections : '\n'}.`;
 
 		const suggestionsPromise: Promise<ReflectionResponseItem[]> =
-			getReflection(username, paragraphText, suggestionPrompt, getAccessTokenSilently);
+			getReflection(username, paragraphText, suggestionPrompt, accessToken);
 
 			suggestionsPromise
 				.then(newPrompts => {
@@ -162,7 +166,7 @@ export default function SearchBar() {
 
 		if (typeof cachedValue === 'undefined') {
 			const reflectionsPromise: Promise<ReflectionResponseItem[]> =
-				getReflection(username, paragraphText, prompt, getAccessTokenSilently);
+				getReflection(username, paragraphText, prompt, accessToken);
 
 			reflectionsPromise
 				.then(newReflections => {


### PR DESCRIPTION
The method that the API was using to get an access token was failing sometimes because the access token is expired or other problems. To resolve that would have needed user interaction to refresh the access token or even to log in again.

This commit adds a new context to handle the access token and a provider to wrap the app with it. If there is a problem with the token, it provides a flag to the view code that triggers a button to be displayed for the user to click and refresh the token.

Upshot: any code can depend on having an up-to-date access token.