### PR TITLE
In demo mode, don't require auth

### DIFF
--- a/frontend/src/contexts/authTokenContext.tsx
+++ b/frontend/src/contexts/authTokenContext.tsx
@@ -1,4 +1,3 @@
-import { useAuth0 } from '@auth0/auth0-react';
 import { createContext, useContext, useState } from 'react';
 
 interface AccessTokenContextType {
@@ -23,11 +22,13 @@ const AccessTokenContext = createContext<AccessTokenContextType>({
   authErrorType: null,
 });
 
-export function AccessTokenProvider({ children }: { children: React.ReactNode }) {
-  const {
-    getAccessTokenSilently,
-  } = useAuth0();
 
+interface AccessTokenProviderProps {
+  children: React.ReactNode;
+  getAccessTokenSilently: () => Promise<string>;
+}
+
+export function AccessTokenProvider({ children, getAccessTokenSilently }: AccessTokenProviderProps) {
   const [authErrorType, setAuthErrorType] = useState<string | null>(null);
 
   return (

--- a/frontend/src/editor/index.tsx
+++ b/frontend/src/editor/index.tsx
@@ -11,9 +11,9 @@ interface EditorProps {
   wordLimit?: number | null;
 }
 
-function Sidebar({ editorAPI }: { editorAPI: EditorAPI }) {
+function Sidebar({ editorAPI, demoMode }: { editorAPI: EditorAPI, demoMode: boolean }) {
 	return (
-		<SidebarInner.default editorAPI={ editorAPI }/>
+		<SidebarInner.default editorAPI={ editorAPI } demoMode={ demoMode } />
 	);
 }
 
@@ -151,7 +151,7 @@ function App(props: EditorProps) {
 			</div>
 
 			<div className={ isDemo ? classes.demosidebar : classes.sidebar }>
-				<Sidebar editorAPI={ editorAPI } />
+				<Sidebar editorAPI={ editorAPI } demoMode={ isDemo } />
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -25,6 +25,7 @@ import { AccessTokenProvider, useAccessToken } from '@/contexts/authTokenContext
 
 export interface HomeProps {
 	editorAPI: EditorAPI;
+	demoMode: boolean;
 }
 
 function usePingServer() {
@@ -61,7 +62,7 @@ function usePingServer() {
 	}, []);
 }
 
-function AppInner({ editorAPI }: HomeProps) {
+function AppInner({ editorAPI, demoMode }: HomeProps) {
 	const auth0Client = useAuth0();
 	const { isLoading, error, isAuthenticated, user } = auth0Client;
 	const [width, _height] = useWindowSize();
@@ -70,7 +71,6 @@ function AppInner({ editorAPI }: HomeProps) {
 		return localStorage.getItem('hasCompletedOnboarding') === 'true';
 	});
 	const { authErrorType } = useAccessToken();
-
 
 	usePingServer();
 
@@ -131,7 +131,7 @@ function AppInner({ editorAPI }: HomeProps) {
 		</div>
 	);
 
-	if (!isAuthenticated || !user) {
+	if (!demoMode && (!isAuthenticated || !user)) {
 		return (
 			<div>
 				{ !hasCompletedOnboarding ? (
@@ -190,9 +190,9 @@ function AppInner({ editorAPI }: HomeProps) {
 	}
 
 	// For the beta, only allow Calvin email addresses and example test user
-	const isUserAllowed = user.email?.endsWith('@calvin.edu') || user.email === 'example-user@textfocals.com';
+	const isUserAllowed = demoMode || user?.email?.endsWith('@calvin.edu') || user?.email === 'example-user@textfocals.com';
 
-	if (!isUserAllowed) {
+	if (!demoMode && !isUserAllowed) {
 		return (
 			<div className={ classes.notAllowedContainer }>
 				<p className={ classes.notAllowedTitle }>Sorry, you are not allowed to access this page.</p>
@@ -234,6 +234,7 @@ function AppInner({ editorAPI }: HomeProps) {
 
 	return (
 		<Layout>
+			{ user && (
 			<div className={ classes.container }>
 				<div className={ classes.profileContainer }>
 					<div className={ classes.profilePicContainer }>
@@ -268,15 +269,22 @@ function AppInner({ editorAPI }: HomeProps) {
 					LogOut
 				</button>
 			</div>
+		) }
 			{ getComponent(page) }
 		</Layout>
 		);
 }
 
-export default function App({ editorAPI }: HomeProps) {
+export default function App({ editorAPI, demoMode }: HomeProps) {
 	if (!editorAPI) {
 		editorAPI = wordEditorAPI;
 	}
+
+	// If demo mode is enabled, we use a mock access token provider
+	const AccessTokenProvider = demoMode
+		? DemoAccessTokenProviderWrapper
+		: Auth0AccessTokenProviderWrapper;
+
 	return (
 		<ChatContextWrapper>
 			<UserContextWrapper>
@@ -296,12 +304,33 @@ export default function App({ editorAPI }: HomeProps) {
 							} }
 						>
 							<AccessTokenProvider>
-							<AppInner editorAPI={ editorAPI } />
+								<AppInner editorAPI={ editorAPI } demoMode={ demoMode } />
 							</AccessTokenProvider>
 						</Auth0Provider>
 					</EditorContextWrapper>
 				</PageContextWrapper>
 			</UserContextWrapper>
 		</ChatContextWrapper>
+	);
+}
+
+function DemoAccessTokenProviderWrapper({ children }: { children: React.ReactNode }) {
+	const getAccessTokenSilently = async () => {
+		// Simulate a token retrieval for demo purposes
+		return 'demo-access-token';
+	};
+	return (
+		<AccessTokenProvider getAccessTokenSilently={ getAccessTokenSilently }>
+			{ children }
+		</AccessTokenProvider>
+	);
+}
+
+function Auth0AccessTokenProviderWrapper({ children }: { children: React.ReactNode }) {
+	const { getAccessTokenSilently } = useAuth0();
+	return (
+		<AccessTokenProvider getAccessTokenSilently={ getAccessTokenSilently }>
+			{ children }
+		</AccessTokenProvider>
 	);
 }


### PR DESCRIPTION
We pass a demo "auth token" to the client in this case.

We still load the auth0 provider and code, but just don't trigger login.