### PR TITLE
Provide the word editor API from the Word entrypoint

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,22 +1,21 @@
+import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-
-import App from './pages/app';
+import App, { HomeProps } from './pages/app';
+import { wordEditorAPI } from '@/api/wordEditorAPI';
 
 import './taskpane.css';
 
 let isOfficeInitialized = false;
 
-// TODO: Fix typing issue
-const render = (Component: any) => {
-	if (!isOfficeInitialized) {
-		Component = () => (
+const render = (Component: React.ComponentType<HomeProps>) => {
+	ReactDOM.render(
+		isOfficeInitialized ? (
+			<Component editorAPI={ wordEditorAPI } />
+		) : (
 			<section className="ms-welcome__progress ms-u-fadeIn500">
 				<p>Please sideload your add-in to see app body.</p>
 			</section>
-		);
-	}
-
-	ReactDOM.render(<Component />,
+		),
 		document.getElementById('container')
 	);
 };

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -19,7 +19,6 @@ import Revise from '../revise';
 import SearchBar from '../searchbar';
 import Chat from '../chat';
 import Draft from '../draft';
-import { wordEditorAPI } from '@/api/wordEditorAPI';
 import { OnboardingCarousel } from '../carousel/OnboardingCarousel';
 import { AccessTokenProvider, useAccessToken } from '@/contexts/authTokenContext';
 
@@ -274,9 +273,6 @@ function AppInner({ editorAPI }: HomeProps) {
 }
 
 export default function App({ editorAPI }: HomeProps) {
-	if (!editorAPI) {
-		editorAPI = wordEditorAPI;
-	}
 	return (
 		<ChatContextWrapper>
 			<UserContextWrapper>


### PR DESCRIPTION
This was messy before, and made the custom editor bundle unnecessarily depend on Word-specific code.