### PR TITLE
Add no-AI and complete-document modes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,18 +66,18 @@ cd backend && uv run pytest && uv run ruff check
 ### Frontend (Office Add-in)
 - **React/TypeScript** application using Office.js APIs
 - **State Management**: Jotai for global state
-- **Styling**: Tailwind CSS with CSS modules
+- **Styling**: a mix of Tailwind CSS and CSS modules
 - **Authentication**: Auth0 integration
 - **Build Tool**: Webpack with TypeScript
 - **Key Entry Points**: 
-  - `src/taskpane.html` - Main task pane interface
+  - `src/taskpane.html` - Main task pane interface for MS Word
+  - `src/editor/editor.html` - Standalone editor for demo and user study
   - `src/editor/editor.tsx` - Document editor integration
   - `src/api/index.ts` - Backend API communication
 
 ### Backend (FastAPI)
 - **Framework**: FastAPI with uvicorn server
 - **AI Integration**: OpenAI API for text processing
-- **NLP Processing**: spaCy for text analysis (`nlp.py`)
 - **Authentication**: auth0 signed JWT tokens (work in progress)
 - **Logging**: Structured logging to `/backend/logs/` directory
 - **Key Files**:
@@ -94,7 +94,7 @@ cd backend && uv run pytest && uv run ruff check
 ### TypeScript Configuration
 - Strict mode enabled with path aliases (`@/*` maps to `./src/*`)
 - React JSX transform configured
-- ES2020 modules with es5 target for IE11 compatibility
+- ES2020 modules with es5 target for IE11 compatibility (but IE is not tested so it's likely to not work)
 
 ### Python Configuration  
 - **Type Checking**: MyPy with Pydantic plugin enabled
@@ -124,11 +124,4 @@ cd backend && uv run pytest && uv run ruff check
 
 ## Testing
 
-### Frontend Tests
-- Jest testing framework configured
-- Test files should be in `__tests__` directories or have `.test.ts` suffix
-
-### Backend Tests  
-- Use pytest with async test support
-- Test files: `*_tests.py` or `test_*.py`
-- Run specific tests: `uv run pytest backend/test_specific.py`
+Testing is not yet well configured in this repo. When editing code, suggest high-value tests to add but wait for approval.

--- a/backend/get_env.py
+++ b/backend/get_env.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-import random, string
+import random
+import string
 from pathlib import Path
 
 backend_path = Path(__file__).parent

--- a/backend/nlp.py
+++ b/backend/nlp.py
@@ -63,16 +63,15 @@ We're helping a writer draft a document. Please output three actionable, inspiri
 - Make each piece of advice very specific to the current document, not general advice that could apply to any document.
 """,
     "analysis_readerPerspective": """\
-We're helping a writer draft a document. Give three reactions that the audience might have to the document so far.
+You are assisting in drafting a document for a specific person. Generate three possible questions the person might have about the document so far.
 
 Guidelines:
 
-- Focus on the area of the document that is closest to the writer's cursor.
-- Don't give specific words or phrases for the writer to use.
-- Keep each reaction concise, less than 20 words.
-- Make each reaction very specific to the current document, not general observations that could apply to any document.
-- Each reaction should be expressed as a sentence describing how the reader or audience might feel about the document, not as a directive to the writer.
-- If there is not enough written in the document to be able to anticipate an audience reaction, simply respond with an empty list.
+- Avoid suggesting specific words or phrases.
+- Limit each question to under 20 words.
+- Ensure all questions specifically reflect details or qualities from the current document, avoiding broad or generic statements.
+- Each question should be expressed as a perspective describing how the person might feel about the document, not as a directive to the writer.
+- If there is insufficient context to generate genuine questions, return an empty list.
 """,
     "complete_document": """\
 We're helping a writer complete and polish their document. Please provide a completed and polished version of the document that the writer has started writing. Guidelines:

--- a/backend/nlp.py
+++ b/backend/nlp.py
@@ -75,14 +75,11 @@ Guidelines:
 - If there is not enough written in the document to be able to anticipate an audience reaction, simply respond with an empty list.
 """,
     "complete_document": """\
-We're helping a writer complete and polish their document. Please provide a complete, polished version of the document. Guidelines:
+We're helping a writer complete and polish their document. Please provide a completed and polished version of the document that the writer has started writing. Guidelines:
 
-- Start with what the writer has already written (if anything).
-- Complete any unfinished sentences or thoughts.
+- Use the text in the document as a starting point, but make any changes needed to make the document complete and polished.
 - Maintain the writer's tone, style, and voice throughout.
 - Polish the text for clarity and coherence.
-- Keep the document focused on the task and context provided.
-- Output the complete document as continuous prose, not as a list.
 """
 }
 

--- a/backend/nlp.py
+++ b/backend/nlp.py
@@ -1,5 +1,4 @@
 import asyncio
-from collections import defaultdict
 import hashlib
 import json
 import os

--- a/frontend/src/editor/studyConfig.ts
+++ b/frontend/src/editor/studyConfig.ts
@@ -1,0 +1,81 @@
+const wave = "wave-2";
+const completionCode = "C728GXTB";
+
+const consentFormURL = 'https://calvin.co1.qualtrics.com/jfe/form/SV_3adI70Zxk7e2ueW';
+
+const studyPageNames = [
+	'study-consentForm',
+	'study-intro',
+	'study-introSurvey',
+	'study-startTask',
+	'study-task',
+	'study-postTask',
+	'study-final',
+];
+
+const summarizeMeetingNotesTask = [
+	{
+		title: 'Task',
+		content: "David had to leave this meeting early, before some bad news was shared. Write an email to David, diplomatically delivering the bad news to him and help him manage client expectations."
+	},
+	{
+		title: 'Meeting Notes',
+		content: `Title: Project Budget Meeting #2 - Q4 Marketing Campaign
+Attendees: you, David (Manager), Lisa (Finance), Tom (Marketing)
+
+Background: follow-up meeting after client feedback
+
+Notes (from AI notetaker):
+- David plans to present the revised plan to client on Thursday
+- Client requested changes: more focus on social media, less on search ads.
+- David presented revised $50k budget split: $30k for social media, $20k for search ads.
+- Lisa seemed concerned about timeline with Q4 freeze coming
+- David got an urgent call and had to leave immediately
+- Lisa revealed new Q4 constraints: can only approve $35k total
+- Have to cut search ads entirely, focus only on social
+- Tom worried: "David was excited about the search-to-social funnel"
+- Tom estimates cutting search ads reduces reach by 40%
+- Lisa emphasized: "We have to stick to the $35k budget"
+- Lisa: "If social performs well, we might add search ads back in Q1"
+
+Next steps:
+- You: update David about constraints and decisions before Thursday client meeting.
+- Lisa: update Q4 budget
+- Tom: draft revised marketing strategy
+`
+	}
+]
+
+const summarizeMeetingNotesTaskFalse = [
+	{
+		title: "Task",
+		content: "Write a follow-up email for this meeting."
+	},
+	{
+		title: "Meeting Notes",
+		content: `\
+Title: Project Budget Meeting #1 - Q4 Marketing Campaign
+Attendees: You, David (Manager), Lisa (Finance), Tom (Marketing)
+
+Background: Initial budget planning meeting
+
+Notes (from AI notetaker):
+- David presented $50K budget: $30K search ads, $20K social media
+- Tom excited about integrated approach: "social and search will work great together"
+- David excited about "search-to-social funnel": use search data to target socials
+- Lisa approved full budget - "looks solid, let's move forward"
+- Full team alignment on dual-channel approach
+- Timeline approved for Q4 launch
+
+Next step: David presenting approved strategy to client
+`
+	}
+]
+
+const letterToCondition = {
+	g: 'example_sentences',
+	a: 'analysis_readerPerspective',
+	p: 'proposal_advice',
+};
+
+export { wave, completionCode, consentFormURL, studyPageNames, summarizeMeetingNotesTask, summarizeMeetingNotesTaskFalse, letterToCondition };

--- a/frontend/src/editor/studyConfig.ts
+++ b/frontend/src/editor/studyConfig.ts
@@ -76,6 +76,8 @@ const letterToCondition = {
 	g: 'example_sentences',
 	a: 'analysis_readerPerspective',
 	p: 'proposal_advice',
+	n: 'no_ai',
+	f: 'complete_document',
 };
 
 export { wave, completionCode, consentFormURL, studyPageNames, summarizeMeetingNotesTask, summarizeMeetingNotesTaskFalse, letterToCondition };

--- a/frontend/src/editor/studyRouter.tsx
+++ b/frontend/src/editor/studyRouter.tsx
@@ -6,88 +6,7 @@ import classes from './styles.module.css';
 import { agreeLikert, type QuestionType, Survey } from '@/surveyViews';
 import * as SurveyData from '@/surveyData';
 import { useEffect } from 'react';
-
-const wave = "wave-2";
-const completionCode = "C728GXTB";
-
-const SURVEY_URLS = {
-	consentForm: 'https://calvin.co1.qualtrics.com/jfe/form/SV_3adI70Zxk7e2ueW',
-};
-
-const studyPageNames = [
-	'study-consentForm',
-	'study-intro',
-	'study-introSurvey',
-	'study-startTask',
-	'study-task',
-	'study-postTask',
-	'study-final',
-];
-
-const summarizeMeetingNotesTask = [
-	{
-		title: 'Task',
-		content: "David had to leave this meeting early, before some bad news was shared. Write an email to David, diplomatically delivering the bad news to him and help him manage client expectations."
-	},
-	{
-		title: 'Meeting Notes',
-		content: `Title: Project Budget Meeting #2 - Q4 Marketing Campaign
-Attendees: you, David (Manager), Lisa (Finance), Tom (Marketing)
-
-Background: follow-up meeting after client feedback
-
-Notes (from AI notetaker):
-- David plans to present the revised plan to client on Thursday
-- Client requested changes: more focus on social media, less on search ads.
-- David presented revised $50k budget split: $30k for social media, $20k for search ads.
-- Lisa seemed concerned about timeline with Q4 freeze coming
-- David got an urgent call and had to leave immediately
-- Lisa revealed new Q4 constraints: can only approve $35k total
-- Have to cut search ads entirely, focus only on social
-- Tom worried: "David was excited about the search-to-social funnel"
-- Tom estimates cutting search ads reduces reach by 40%
-- Lisa emphasized: "We have to stick to the $35k budget"
-- Lisa: "If social performs well, we might add search ads back in Q1"
-
-Next steps:
-- You: update David about constraints and decisions before Thursday client meeting.
-- Lisa: update Q4 budget
-- Tom: draft revised marketing strategy
-`
-	}
-]
-
-const summarizeMeetingNotesTaskFalse = [
-	{
-		title: "Task",
-		content: "Write a follow-up email for this meeting."
-	},
-	{
-		title: "Meeting Notes",
-		content: `\
-Title: Project Budget Meeting #1 - Q4 Marketing Campaign
-Attendees: You, David (Manager), Lisa (Finance), Tom (Marketing)
-
-Background: Initial budget planning meeting
-
-Notes (from AI notetaker):
-- David presented $50K budget: $30K search ads, $20K social media
-- Tom excited about integrated approach: "social and search will work great together"
-- David excited about "search-to-social funnel": use search data to target socials
-- Lisa approved full budget - "looks solid, let's move forward"
-- Full team alignment on dual-channel approach
-- Timeline approved for Q4 launch
-
-Next step: David presenting approved strategy to client
-`
-	}
-]
-
-const letterToCondition = {
-	g: 'example_sentences',
-	a: 'analysis_readerPerspective',
-	p: 'proposal_advice',
-};
+import { letterToCondition, studyPageNames, consentFormURL, wave, summarizeMeetingNotesTask, summarizeMeetingNotesTaskFalse, completionCode } from './studyConfig';
 
 
 function getBrowserMetadata() {
@@ -203,8 +122,6 @@ export function StudyRouter({ page }: { page: string }) {
     const isProlific = urlParams.get('isProlific') === 'true';
 
 	if (page === 'study-consentForm') {
-		const consentFormURL = SURVEY_URLS.consentForm;
-
 		return (
 			<div className='flex flex-col items-center justify-center text-center min-h-full max-w-lg m-auto p-2'>
 				<a

--- a/frontend/src/editor/studyRouter.tsx
+++ b/frontend/src/editor/studyRouter.tsx
@@ -266,46 +266,107 @@ export function StudyRouter({ page }: { page: string }) {
 			</div>
 		);
 	} else if (page.startsWith('study-postTask')) {
-		const postTaskSurveyQuestions = [
-			{
+		const postTaskSurveyQuestions: QuestionType[] = [];
+
+		// Add condition-specific debrief and questions
+		if (conditionName === 'no_ai') {
+			// No AI-specific questions for no_ai condition
+			postTaskSurveyQuestions.push({
 				text: <>
 					<p>
-						A quick debrief: each group of 3 texts included text from two different AI systems.
+						Thank you for completing the writing task without AI assistance.
 					</p>
-					<p>
-						One of those systems was provided with intentionally incorrect information. The other was provided the same information as you were.
-					</p>
-					<p>So some of the texts may have contained inaccuracies. But even the incorrect information may have been helpful to you in some ways.</p>
 					<p>
 						Please answer the following questions about your experience.
 					</p>
 				</>
-			},
-			{
-				text: "Can you recall a specific moment when you read a suggestion and decided not to use it? What made you decide that? Be as specific as you can.",
-				responseType: "text",
-				name: "suggestionNotUsed",
-				flags: { multiline: true }
-			},
-			{
-				text: "Can you recall a specific moment when you read a suggestion and it affected what you wrote next? Be as specific as you can.",
-				responseType: "text",
-				name: "suggestionRecall",
-				flags: { multiline: true }
-			},
-			agreeLikert("easyToUnderstand", "The AI text was easy to understand", 5),
-			agreeLikert("helpedMe", "The AI text helped me with the writing task", 5),
-			agreeLikert("feltPressured", "I felt pressured to do what the AI suggested", 5),
-			agreeLikert("thinkCarefullyAppropriate", "I had to think carefully about whether the AI text was appropriate", 5),
-			agreeLikert("thinkCarefullyHowToUse", "I had to think carefully about how to use the AI text", 5),
-			agreeLikert("newAspects", "The AI text made me consider aspects that I hadn't thought of", 5),
-			agreeLikert("aiShapedFinalText", "The AI text significantly shaped the final text", 5),
-			{
-				text: "How would you describe the text that the AI provided?",
-				responseType: "text",
-				name: "aiTextDescription",
-				flags: { multiline: true }
-			},
+			});
+		} else if (conditionName === 'complete_document') {
+			postTaskSurveyQuestions.push(
+				{
+					text: <>
+						<p>
+							A quick debrief: the AI system that generated complete drafts was provided with intentionally incorrect information.
+						</p>
+						<p>So the drafts may have contained inaccuracies. But even the incorrect information may have been helpful to you in some ways.</p>
+						<p>
+							Please answer the following questions about your experience.
+						</p>
+					</>
+				},
+				{
+					text: "Can you recall a specific moment when you read the AI-generated draft and decided not to use part of it? What made you decide that? Be as specific as you can.",
+					responseType: "text",
+					name: "suggestionNotUsed",
+					flags: { multiline: true }
+				},
+				{
+					text: "Can you recall a specific moment when you read the AI-generated draft and it affected what you wrote next? Be as specific as you can.",
+					responseType: "text",
+					name: "suggestionRecall",
+					flags: { multiline: true }
+				},
+				agreeLikert("easyToUnderstand", "The AI-generated draft was easy to understand", 5),
+				agreeLikert("helpedMe", "The AI-generated draft helped me with the writing task", 5),
+				agreeLikert("feltPressured", "I felt pressured to use what the AI suggested", 5),
+				agreeLikert("thinkCarefullyAppropriate", "I had to think carefully about whether the AI draft was appropriate", 5),
+				agreeLikert("thinkCarefullyHowToUse", "I had to think carefully about how to use the AI draft", 5),
+				agreeLikert("newAspects", "The AI draft made me consider aspects that I hadn't thought of", 5),
+				agreeLikert("aiShapedFinalText", "The AI draft significantly shaped the final text", 5),
+				{
+					text: "How would you describe the draft that the AI provided?",
+					responseType: "text",
+					name: "aiTextDescription",
+					flags: { multiline: true }
+				}
+			);
+		} else {
+			// Original questions for bullet-point conditions
+			postTaskSurveyQuestions.push(
+				{
+					text: <>
+						<p>
+							A quick debrief: each group of 3 texts included text from two different AI systems.
+						</p>
+						<p>
+							One of those systems was provided with intentionally incorrect information. The other was provided the same information as you were.
+						</p>
+						<p>So some of the texts may have contained inaccuracies. But even the incorrect information may have been helpful to you in some ways.</p>
+						<p>
+							Please answer the following questions about your experience.
+						</p>
+					</>
+				},
+				{
+					text: "Can you recall a specific moment when you read a suggestion and decided not to use it? What made you decide that? Be as specific as you can.",
+					responseType: "text",
+					name: "suggestionNotUsed",
+					flags: { multiline: true }
+				},
+				{
+					text: "Can you recall a specific moment when you read a suggestion and it affected what you wrote next? Be as specific as you can.",
+					responseType: "text",
+					name: "suggestionRecall",
+					flags: { multiline: true }
+				},
+				agreeLikert("easyToUnderstand", "The AI text was easy to understand", 5),
+				agreeLikert("helpedMe", "The AI text helped me with the writing task", 5),
+				agreeLikert("feltPressured", "I felt pressured to do what the AI suggested", 5),
+				agreeLikert("thinkCarefullyAppropriate", "I had to think carefully about whether the AI text was appropriate", 5),
+				agreeLikert("thinkCarefullyHowToUse", "I had to think carefully about how to use the AI text", 5),
+				agreeLikert("newAspects", "The AI text made me consider aspects that I hadn't thought of", 5),
+				agreeLikert("aiShapedFinalText", "The AI text significantly shaped the final text", 5),
+				{
+					text: "How would you describe the text that the AI provided?",
+					responseType: "text",
+					name: "aiTextDescription",
+					flags: { multiline: true }
+				}
+			);
+		}
+
+		// Add common questions for all conditions
+		postTaskSurveyQuestions.push(
 			{
 				text: <>
 					<h3>Now a few questions about the task overall.</h3>
@@ -324,7 +385,7 @@ export function StudyRouter({ page }: { page: string }) {
 			},
 			SurveyData.techDiff,
 			SurveyData.otherFinal
-		];
+		);
 
 		return (
 			<SurveyPage

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -28,6 +28,8 @@ const visibleNameForMode = {
 	example_sentences: 'Examples',
 	analysis_readerPerspective: "Reader's Perspective",
 	proposal_advice: 'Advice',
+	complete_document: 'Complete Document',
+	no_ai: 'No AI',
 };
 
 const modes = ['example_sentences', 'analysis_readerPerspective', 'proposal_advice'];
@@ -87,15 +89,18 @@ class Fetcher {
 }
 
 function GenerationResult({ generation }: { generation: GenerationResult }) {
+	const showTitle = generation.generation_type !== 'complete_document';
 	return (
 		<div className="prose">
-			<div className="text-bold">
-				{
-					visibleNameForMode[
-						generation.generation_type as keyof typeof visibleNameForMode
-					]
-				}
-			</div>{' '}
+			{showTitle ? (
+				<div className="text-bold">
+					{
+						visibleNameForMode[
+							generation.generation_type as keyof typeof visibleNameForMode
+						]
+					}
+				</div>
+			) : null}{' '}
 			<Remark>{generation.result}</Remark>
 		</div>
 	);
@@ -260,7 +265,10 @@ export default function Draft() {
 	// });
 
 	const isStudy = studyData !== null;
-	const autoRefreshInterval = isStudy ? studyData.autoRefreshInterval : 0;
+	const currentCondition = isStudy ? studyData.condition : null;
+	const isNoAI = currentCondition === 'no_ai';
+	const isCompleteDocument = currentCondition === 'complete_document';
+	const autoRefreshInterval = isStudy && !isNoAI && !isCompleteDocument ? studyData.autoRefreshInterval : 0;
 	const modesToShow = useMemo(
 		() => (isStudy ? [studyData.condition] : modes),
 		[isStudy, studyData],
@@ -404,6 +412,19 @@ export default function Draft() {
 		return <div>Please reauthorize.</div>;
 	}
 
+	// Handle no_ai condition with static message
+	if (isNoAI) {
+		return (
+			<div className="flex flex-col flex-1">
+				<div className="flex flex-col flex-1 gap-2 relative p-2">
+					<div className="mt-4 ml-4 mr-4 p-4 text-center text-stone-700">
+						AI suggestions are unavailable for this task.
+					</div>
+				</div>
+			</div>
+		);
+	}
+
 	let alerts = null;
 
 	if (errorMsg !== '')
@@ -448,7 +469,7 @@ export default function Draft() {
 											log({
 												username: username,
 												event: 'request_suggestion',
-												 
+
 												generation_type: mode,
 												docContext:
 													docContextRef.current,

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -267,8 +267,7 @@ export default function Draft() {
 	const isStudy = studyData !== null;
 	const currentCondition = isStudy ? studyData.condition : null;
 	const isNoAI = currentCondition === 'no_ai';
-	const isCompleteDocument = currentCondition === 'complete_document';
-	const autoRefreshInterval = isStudy && !isNoAI && !isCompleteDocument ? studyData.autoRefreshInterval : 0;
+	const autoRefreshInterval = isStudy && !isNoAI ? studyData.autoRefreshInterval : 0;
 	const modesToShow = useMemo(
 		() => (isStudy ? [studyData.condition] : modes),
 		[isStudy, studyData],

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -417,7 +417,7 @@ export default function Draft() {
 			<div className="flex flex-col flex-1">
 				<div className="flex flex-col flex-1 gap-2 relative p-2">
 					<div className="mt-4 ml-4 mr-4 p-4 text-center text-stone-700">
-						AI suggestions are unavailable for this task.
+						AI suggestions are unavailable for this task. (Please do not use any other AI systems either.)
 					</div>
 				</div>
 			</div>

--- a/frontend/src/surveyViews.tsx
+++ b/frontend/src/surveyViews.tsx
@@ -8,6 +8,12 @@ export interface QuestionHeaderType {
   text: string | JSX.Element;
 };
 
+interface TextQuestionFlags {
+  multiline?: boolean;
+  type?: string;
+  placeholder?: string;
+}
+
 export interface QuestionBodyType {
   text: string | JSX.Element;
   name: string;
@@ -15,7 +21,7 @@ export interface QuestionBodyType {
   levels?: string[];
   optional?: boolean;
   options?: string[] | { key: string, value: string }[];
-  flags?: Record<string, any>;
+  flags?: TextQuestionFlags;
 };
 
 export type QuestionType = QuestionHeaderType | QuestionBodyType;

--- a/frontend/src/surveyViews.tsx
+++ b/frontend/src/surveyViews.tsx
@@ -177,7 +177,7 @@ interface SurveyProps {
 
 export const Survey = ({ title, basename, questions, onAdvance }: SurveyProps) => {
   const state = useAtomValue(inputStateAtom);
-  const surveyData = questions.reduce((acc, question) => {
+  const surveyData = questions.reduce((acc: Record<string, string>, question) => {
       const responseVarName = `${basename}-${question.name}`;
       if (question.responseType) {
         acc[responseVarName] = state[responseVarName];

--- a/frontend/src/surveyViews.tsx
+++ b/frontend/src/surveyViews.tsx
@@ -14,6 +14,7 @@ export interface QuestionBodyType {
   responseType: string;
   levels?: string[];
   optional?: boolean;
+  options?: string[] | { key: string, value: string }[];
   flags?: Record<string, any>;
 };
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dev = [
     "joblib>=1.5.2",
     "jupyter>=1.1.1",
     "pandas>=2.3.2",
+    "ruff>=0.13.2",
     "scipy>=1.16.1",
     "seaborn>=0.13.2",
     "statsmodels>=0.14.5",

--- a/scripts/log_analysis.qmd
+++ b/scripts/log_analysis.qmd
@@ -44,6 +44,12 @@ for log_file in all_logs:
         #print("Wrong wave", wave, "for file", log_file.name)
         continue
 
+    browserMetadata = study_start_event['extra_data'].get('browserMetadata', {})
+    user_agent = browserMetadata.get('userAgent', '')
+    is_mobile = any(mobile_str in user_agent.lower() for mobile_str in ['mobile', 'iphone', 'ipad', 'android'])
+    if is_mobile:
+        print("Mobile user agent", user_agent)
+
     if num_errors := len(by_event['generation_error']):
         print(f"{username} had {num_errors} generation errors")
 
@@ -101,6 +107,8 @@ for log_file in all_logs:
         'time_spent_writing': time_spent_writing,
         'words_per_minute': words_per_minute,
         'num_errors': num_errors,
+        'browserMetadata': browserMetadata,
+        'is_mobile': is_mobile,
         'event_counts': {event: len(events) for event, events in by_event.items()},
         'suggestions': [e['extra_data']['result'] for e in by_event['ShowSuggestion'] if 'result' in e.get('extra_data', {})],
     }
@@ -125,6 +133,10 @@ for index, row in all_data_df.iterrows():
     print(row['condition'])
     print('-', row['survey-postTask-suggestionRecall'])
     print('-', row['survey-postTask-suggestionNotUsed'])
+```
+
+```{python}
+all_data_df.groupby('condition')['is_mobile'].value_counts()
 ```
 
 ```{python}

--- a/uv.lock
+++ b/uv.lock
@@ -2333,6 +2333,32 @@ wheels = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/df/8d7d8c515d33adfc540e2edf6c6021ea1c5a58a678d8cfce9fae59aabcab/ruff-0.13.2.tar.gz", hash = "sha256:cb12fffd32fb16d32cef4ed16d8c7cdc27ed7c944eaa98d99d01ab7ab0b710ff", size = 5416417, upload-time = "2025-09-25T14:54:09.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/84/5716a7fa4758e41bf70e603e13637c42cfb9dbf7ceb07180211b9bbf75ef/ruff-0.13.2-py3-none-linux_armv6l.whl", hash = "sha256:3796345842b55f033a78285e4f1641078f902020d8450cade03aad01bffd81c3", size = 12343254, upload-time = "2025-09-25T14:53:27.784Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/77/c7042582401bb9ac8eff25360e9335e901d7a1c0749a2b28ba4ecb239991/ruff-0.13.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ff7e4dda12e683e9709ac89e2dd436abf31a4d8a8fc3d89656231ed808e231d2", size = 13040891, upload-time = "2025-09-25T14:53:31.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/15/125a7f76eb295cb34d19c6778e3a82ace33730ad4e6f28d3427e134a02e0/ruff-0.13.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c75e9d2a2fafd1fdd895d0e7e24b44355984affdde1c412a6f6d3f6e16b22d46", size = 12243588, upload-time = "2025-09-25T14:53:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/eb/0093ae04a70f81f8be7fd7ed6456e926b65d238fc122311293d033fdf91e/ruff-0.13.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cceac74e7bbc53ed7d15d1042ffe7b6577bf294611ad90393bf9b2a0f0ec7cb6", size = 12491359, upload-time = "2025-09-25T14:53:35.892Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fe/72b525948a6956f07dad4a6f122336b6a05f2e3fd27471cea612349fedb9/ruff-0.13.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6ae3f469b5465ba6d9721383ae9d49310c19b452a161b57507764d7ef15f4b07", size = 12162486, upload-time = "2025-09-25T14:53:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e3/0fac422bbbfb2ea838023e0d9fcf1f30183d83ab2482800e2cb892d02dfe/ruff-0.13.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f8f9e3cd6714358238cd6626b9d43026ed19c0c018376ac1ef3c3a04ffb42d8", size = 13871203, upload-time = "2025-09-25T14:53:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/82/b721c8e3ec5df6d83ba0e45dcf00892c4f98b325256c42c38ef136496cbf/ruff-0.13.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c6ed79584a8f6cbe2e5d7dbacf7cc1ee29cbdb5df1172e77fbdadc8bb85a1f89", size = 14929635, upload-time = "2025-09-25T14:53:43.953Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a0/ad56faf6daa507b83079a1ad7a11694b87d61e6bf01c66bd82b466f21821/ruff-0.13.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aed130b2fde049cea2019f55deb939103123cdd191105f97a0599a3e753d61b0", size = 14338783, upload-time = "2025-09-25T14:53:46.205Z" },
+    { url = "https://files.pythonhosted.org/packages/47/77/ad1d9156db8f99cd01ee7e29d74b34050e8075a8438e589121fcd25c4b08/ruff-0.13.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1887c230c2c9d65ed1b4e4cfe4d255577ea28b718ae226c348ae68df958191aa", size = 13355322, upload-time = "2025-09-25T14:53:48.164Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8b/e87cfca2be6f8b9f41f0bb12dc48c6455e2d66df46fe61bb441a226f1089/ruff-0.13.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bcb10276b69b3cfea3a102ca119ffe5c6ba3901e20e60cf9efb53fa417633c3", size = 13354427, upload-time = "2025-09-25T14:53:50.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/df/bf382f3fbead082a575edb860897287f42b1b3c694bafa16bc9904c11ed3/ruff-0.13.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:afa721017aa55a555b2ff7944816587f1cb813c2c0a882d158f59b832da1660d", size = 13537637, upload-time = "2025-09-25T14:53:52.887Z" },
+    { url = "https://files.pythonhosted.org/packages/51/70/1fb7a7c8a6fc8bd15636288a46e209e81913b87988f26e1913d0851e54f4/ruff-0.13.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1dbc875cf3720c64b3990fef8939334e74cb0ca65b8dbc61d1f439201a38101b", size = 12340025, upload-time = "2025-09-25T14:53:54.88Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/27/1e5b3f1c23ca5dd4106d9d580e5c13d9acb70288bff614b3d7b638378cc9/ruff-0.13.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b939a1b2a960e9742e9a347e5bbc9b3c3d2c716f86c6ae273d9cbd64f193f22", size = 12133449, upload-time = "2025-09-25T14:53:57.089Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/09/b92a5ccee289f11ab128df57d5911224197d8d55ef3bd2043534ff72ca54/ruff-0.13.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:50e2d52acb8de3804fc5f6e2fa3ae9bdc6812410a9e46837e673ad1f90a18736", size = 13051369, upload-time = "2025-09-25T14:53:59.124Z" },
+    { url = "https://files.pythonhosted.org/packages/89/99/26c9d1c7d8150f45e346dc045cc49f23e961efceb4a70c47dea0960dea9a/ruff-0.13.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3196bc13ab2110c176b9a4ae5ff7ab676faaa1964b330a1383ba20e1e19645f2", size = 13523644, upload-time = "2025-09-25T14:54:01.622Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/00/e7f1501e81e8ec290e79527827af1d88f541d8d26151751b46108978dade/ruff-0.13.2-py3-none-win32.whl", hash = "sha256:7c2a0b7c1e87795fec3404a485096bcd790216c7c146a922d121d8b9c8f1aaac", size = 12245990, upload-time = "2025-09-25T14:54:03.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bd/d9f33a73de84fafd0146c6fba4f497c4565fe8fa8b46874b8e438869abc2/ruff-0.13.2-py3-none-win_amd64.whl", hash = "sha256:17d95fb32218357c89355f6f6f9a804133e404fc1f65694372e02a557edf8585", size = 13324004, upload-time = "2025-09-25T14:54:06.05Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/12/28fa2f597a605884deb0f65c1b1ae05111051b2a7030f5d8a4ff7f4599ba/ruff-0.13.2-py3-none-win_arm64.whl", hash = "sha256:da711b14c530412c827219312b7d7fbb4877fb31150083add7e8c5336549cea7", size = 12484437, upload-time = "2025-09-25T14:54:08.022Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.16.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2731,6 +2757,7 @@ dev = [
     { name = "joblib" },
     { name = "jupyter" },
     { name = "pandas" },
+    { name = "ruff" },
     { name = "scipy" },
     { name = "seaborn" },
     { name = "statsmodels" },
@@ -2758,12 +2785,12 @@ dev = [
     { name = "joblib", specifier = ">=1.5.2" },
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "pandas", specifier = ">=2.3.2" },
+    { name = "ruff", specifier = ">=0.13.2" },
     { name = "scipy", specifier = ">=1.16.1" },
     { name = "seaborn", specifier = ">=0.13.2" },
     { name = "statsmodels", specifier = ">=0.14.5" },
     { name = "tqdm", specifier = ">=4.66.5" },
 ]
-gpu = []
 
 [[package]]
 name = "yarl"


### PR DESCRIPTION
Claude Code's plan:

```
# Implementation Plan: Add No-AI and Complete Document Conditions

## Overview
Add two new study conditions:
- **No-AI (`n`)**: Shows static message, no AI suggestions
- **Complete Document (`f`)**: Generates full revised document using false context only

## Changes Required

### 1. Backend (`/backend/nlp.py`)
- Add new prompt type `"complete_document"` to `prompts` dict
  - Instruction: "Start with what the user has written (if anything), complete/finish it maintaining their tone/style/voice, and polish it"
  - Should work with false context only
  - Return single completed document (not a list)
- Modify `get_suggestion()` to handle single-response format for this prompt type
  - Skip the list wrapping/bullet formatting
  - Return plain markdown text

### 2. Frontend Config (`/frontend/src/editor/studyConfig.ts`)
- Add to `letterToCondition`:
  ```typescript
  n: 'no_ai',
  f: 'complete_document',
  ```

### 3. Frontend Draft Page (`/frontend/src/pages/draft/index.tsx`)
- Update `visibleNameForMode` to include new modes (though `no_ai` won't show title)
- Update `modes` array to include new condition types
- Add conditional rendering in the main return:
  - For `no_ai`: Show static message instead of suggestions area
  - For `complete_document`: Disable auto-refresh
- Modify `GenerationResult` component:
  - Check if `generation_type` is `complete_document` → don't render title
  - Otherwise render title as normal

### 4. Study Router Updates (`/frontend/src/editor/studyRouter.tsx`)
- Update `study-postTask` survey questions:
  - Make questions about "3 texts" conditional (skip for no_ai and complete_document)
  - Adjust wording for complete_document condition (mention "complete draft" instead of "suggestions")
  - For no_ai: maybe skip some AI-specific questions or adjust wording

### 5. Demo Mode Support (optional, low priority)
- Update `App` component or routing to allow `complete_document` in demo mode
- Only if it doesn't complicate things

## Implementation Order
1. Backend prompt (easiest, no dependencies)
2. Frontend config (simple addition)
3. Draft page logic (core functionality)
4. Study router survey adjustments (polish)
5. Demo mode support (if time permits)

## Testing Checklist
- [ ] No-AI condition shows message, no button/suggestions
- [ ] Complete document generates single draft (not list)
- [ ] Complete document uses false context only
- [ ] Refresh button works for complete document
- [ ] Auto-refresh disabled for both new conditions
- [ ] Survey questions adjusted appropriately
- [ ] Demo mode works (if implemented)
```