### PR TITLE
Add writing description input to AI Writing Assistant

### DIFF
--- a/experiment/app/api/writing-support/route.ts
+++ b/experiment/app/api/writing-support/route.ts
@@ -69,6 +69,7 @@ export async function POST(req: Request) {
 
   const { beforeCursor, selectedText, afterCursor } = body.editorState;
   const context = (body.context as keyof typeof prompts) || 'proposal_advice';
+  const writingDescription = body.writingDescription;
   const promptTemplate = prompts[context];
 
   try {
@@ -77,6 +78,11 @@ export async function POST(req: Request) {
     const afterCursorTrim = afterCursor.slice(0, 100);
 
     let fullPrompt = promptTemplate;
+
+    if (writingDescription) {
+      fullPrompt += `\n\n# Writer's Intent\n\nThe writer has described what they are trying to write: "${writingDescription}"`;
+    }
+
     fullPrompt += `\n\n# Writer's Document So Far\n\n<document>\n${documentText}</document>\n\n`;
 
     if (selectedText === '') {

--- a/experiment/components/AIPanel.tsx
+++ b/experiment/components/AIPanel.tsx
@@ -87,6 +87,7 @@ export default function AIPanel({
   const [isLoading, setIsLoading] = useState(false);
   const [savedItems, setSavedItems] = useState<SavedItem[]>([]);
   const [errorMsg, setErrorMsg] = useState('');
+  const [writingDescription, setWritingDescription] = useState('');
   const docContextRef = useRef<TextEditorState | null>(null);
   const studyParams = useAtomValue(studyParamsAtom);
   const studyCondition = useAtomValue(studyConditionAtom);
@@ -161,6 +162,7 @@ export default function AIPanel({
             event: `aiRequest:${modeToUse}`,
             extra_data: {
               isAutoRefresh,
+              writingDescription: writingDescription.trim() || undefined,
               // Don't log document content right now; we'll log it with the response
             },
           });
@@ -174,6 +176,7 @@ export default function AIPanel({
           body: JSON.stringify({
             editorState,
             context: modeToUse,
+            ...(writingDescription.trim() && { writingDescription: writingDescription.trim() }),
           }),
           signal: AbortSignal.timeout(API_TIMEOUT_MS),
         });
@@ -207,7 +210,7 @@ export default function AIPanel({
               await log({
                 username: studyParams.username,
                 event: `aiResponse:${modeToUse}`,
-                extra_data: { isAutoRefresh, generation, editorState },
+                extra_data: { isAutoRefresh, generation, editorState, writingDescription: writingDescription.trim() || undefined },
               });
             }
           }
@@ -230,7 +233,7 @@ export default function AIPanel({
         setIsLoading(false);
       }
     },
-    [writingAreaRef, save, mode, isStudyMode, studyParams]
+    [writingAreaRef, save, mode, isStudyMode, studyParams, writingDescription]
   );
 
   // Auto-refresh logic for study mode
@@ -288,6 +291,20 @@ export default function AIPanel({
   return (
     <div className="h-full p-4 text-sm text-gray-700 flex flex-col overflow-hidden">
       <h3 className="text-sm font-bold text-gray-900 mb-3">AI Writing Assistant</h3>
+
+      <div className="mb-3">
+        <label htmlFor="writing-description" className="block text-xs font-semibold text-gray-600 mb-1">
+          What are you trying to write?
+        </label>
+        <textarea
+          id="writing-description"
+          value={writingDescription}
+          onChange={(e) => setWritingDescription(e.target.value)}
+          placeholder='e.g., "telling him we need to move the panel we&#39;d scheduled for tomorrow"'
+          rows={2}
+          className="w-full text-xs text-gray-800 border border-gray-300 rounded px-2 py-1.5 resize-none focus:outline-none focus:ring-1 focus:ring-blue-400 focus:border-blue-400 placeholder:text-gray-400"
+        />
+      </div>
 
       {!isStudyMode && (
         <div className="flex gap-1.5 mb-3 flex-wrap">

--- a/experiment/types/index.ts
+++ b/experiment/types/index.ts
@@ -12,6 +12,7 @@ export interface TextEditorState {
 export interface WritingSupportRequest {
   editorState: TextEditorState;
   context?: string;
+  writingDescription?: string;
 }
 
 export interface WritingSupportResponse {


### PR DESCRIPTION
## Summary
This PR adds a new optional "writing description" feature to the AI Writing Assistant that allows users to provide context about what they're trying to write. This description is then included in the prompt sent to the AI model to improve the quality and relevance of suggestions.

## Key Changes
- **Frontend (AIPanel.tsx)**
  - Added `writingDescription` state to track user input
  - Added a new textarea input field with label "What are you trying to write?" for users to describe their writing intent
  - Updated the API request to include the writing description in the request body
  - Updated logging to capture the writing description in both request and response events
  - Added `writingDescription` to the dependency array of the `handleAIRequest` callback

- **Backend (route.ts)**
  - Extract `writingDescription` from the request body
  - Append the writer's intent to the prompt template when a description is provided, formatted as a "Writer's Intent" section
  - The description is inserted before the document content in the prompt

- **Types (index.ts)**
  - Added optional `writingDescription` field to `WritingSupportRequest` interface

## Implementation Details
- The writing description is optional and only included in the API request if provided
- Empty descriptions are trimmed and treated as undefined to avoid sending unnecessary data
- The description is logged in study mode for research purposes
- The prompt enhancement is done server-side, keeping the implementation clean and maintainable

https://claude.ai/code/session_01BeEBSzBFysATTNMFbRtPWq