### PR TITLE
feat: rate-limit of 20 hits/min

### DIFF
--- a/experiment/app/api/auth/[...all]/route.ts
+++ b/experiment/app/api/auth/[...all]/route.ts
@@ -1,0 +1,9 @@
+/**
+ * Required Better Auth handler. Mounts the Better Auth API at /api/auth/*.
+ * Even though no auth features are in use, this route must exist for
+ * Better Auth to initialise correctly.
+ */
+import { auth } from '@/lib/auth';
+import { toNextJsHandler } from 'better-auth/next-js';
+
+export const { GET, POST } = toNextJsHandler(auth);

--- a/experiment/components/AIPanel.tsx
+++ b/experiment/components/AIPanel.tsx
@@ -178,6 +178,13 @@ export default function AIPanel({
           signal: AbortSignal.timeout(API_TIMEOUT_MS),
         });
 
+        if (response.status === 429) {
+          const retryAfter = response.headers.get('X-Retry-After');
+          const waitMsg = retryAfter ? ` Try again in ${retryAfter} seconds.` : ' Please wait a minute.';
+          setErrorMsg(`Suggestion limit reached.${waitMsg}`);
+          return;
+        }
+
         if (!response.ok) {
           throw new Error(`HTTP error! status: ${response.status}`);
         }

--- a/experiment/lib/auth.ts
+++ b/experiment/lib/auth.ts
@@ -1,0 +1,24 @@
+import { betterAuth } from 'better-auth';
+
+/**
+ * Better Auth instance used solely for rate limiting.
+ * No authentication features are enabled — the auth handler at
+ * /api/auth/[...all] is required boilerplate for Better Auth to initialise.
+ *
+ * Rate limiting works by passing a bodyless probe request through
+ * auth.handler() at the top of each protected route. Better Auth tracks
+ * requests per IP using the customRules below and returns 429 when the
+ * limit is exceeded, including an X-Retry-After header.
+ */
+export const auth = betterAuth({
+  secret: process.env.BETTER_AUTH_SECRET ?? 'dev-secret',
+  rateLimit: {
+    enabled: true,
+    window: 60,  // seconds
+    max: 100,    // default limit (not used — customRules override per-path)
+    customRules: {
+      // Allow up to 20 suggestion requests per IP per minute
+      '/api/writing-support': { window: 60, max: 20 },
+    },
+  },
+});


### PR DESCRIPTION
Prototyped rate-limiting in NextJS app (`experiment`) using Better Auth service (See #290)
- Rate limit requests to backend (20 reqs/min)
- Next steps: 
  - Discuss: What rate do we actually want? 
  - Manage secrets for prod
  - Implement in main app
<img width="1892" height="905" alt="Screenshot 2026-02-24 000355" src="https://github.com/user-attachments/assets/7439c6aa-2872-42b7-86db-13fc174de94e" />

