### PR TITLE
Add placeholder-based AI suggestions and simplify conversation handling

### DIFF
--- a/experiment/app/api/writing-support/route.ts
+++ b/experiment/app/api/writing-support/route.ts
@@ -19,12 +19,31 @@ Guidelines:
 - Each output should be *at most one sentence* long.
 - Use ellipses to truncate sentences that are longer than about **10 words**.`,
 
-  complete_document: `You are assisting a writer complete and polish their document. Please provide a completed and polished version of the document that the writer has started writing. 
+  example_withblanks: `You are assisting a writer in drafting a document. Generate three possible options for inspiring and fresh possible next sentences that would help the writer think about what they should write next.
+
+Guidelines:
+- Focus on the area of the document that is closest to the writer's cursor.
+- If the writer is in the middle of a sentence, output three possible continuations of that sentence.
+- If the writer is at the end of a paragraph, output three possible sentences that would start the next paragraph.
+- The three sentences should be three different paths that the writer could take, each starting from the current point in the document; they do **NOT** go in sequence.
+- Each output should be *at most one sentence* long.
+- Use ellipses to truncate sentences that are longer than about **10 words**.
+- Where a specific fact or detail from the writer's research would go, use a bracketed placeholder (e.g., [name], [date], [specific detail]) instead of filling in the actual detail. The writer must recall and insert these themselves.`,
+
+  complete_document: `You are assisting a writer complete and polish their document. Please provide a completed and polished version of the document that the writer has started writing.
 
 Guidelines:
 - Use the text in the document as a starting point, but make any changes needed to make the document complete and polished.
 - Maintain the writer's tone, style, and voice throughout.
 - Polish the text for clarity and coherence.`,
+
+  complete_document_withblanks: `You are assisting a writer complete and polish their document. Please provide a completed and polished version of the document that the writer has started writing.
+
+Guidelines:
+- Use the text in the document as a starting point, but make any changes needed to make the document complete and polished.
+- Maintain the writer's tone, style, and voice throughout.
+- Polish the text for clarity and coherence.
+- Where specific facts or details from the writer's research would go, use bracketed placeholders (e.g., [name], [date], [specific detail]) instead of filling in the actual information. The writer must recall and insert these themselves.`,
 
   proposal_advice: `You are assisting a writer in drafting a document by providing three directive (but not prescriptive) advice to help them develop their work. Your advice must be tailored to the document's genre. Use your best judgment to offer the most relevant and helpful advice, drawing from the following types of support as appropriate for the context:
 - Support the writer in adhering to their stated writing goals or assignment guidelines.
@@ -33,23 +52,26 @@ Guidelines:
 - Recommend strengthening arguments by adding supporting evidence, specific examples, or clear reasoning.
 - Advise on structuring material to achieve a clear and logical flow.
 - Guide the writer in choosing language that is accessible and engaging for the intended audience.
+- Guide the writer to think about what information is most important for the document, rather than providing the information directly.
 
 Guidelines:
 - Focus on the area of the document that is closest to the writer's cursor.
 - Keep each piece of advice under 20 words.
 - Express the advice in the form of a directive instruction, not a question.
 - Avoid providing specific words or phrases that the writer could directly copy into their document.
-- Make each piece of advice very specific to the current document, not general advice that could apply to any document.`,
+- Make each piece of advice very specific to the current document, not general advice that could apply to any document.
+- The three pieces of advice should be diverse — each offering a distinct direction, perspective, or approach.`,
 
-  analysis_readerPerspective: `You are assisting a writer in drafting a document for a specific person. Generate three possible reactions (questions, feelings, perspectives, etc.) the person might have about the document.
+  analysis_readerPerspective: `You are assisting a writer in drafting a document for a specific person. Think carefully about the recipient's situation, needs, and concerns, then generate three possible reactions (questions, feelings, perspectives, etc.) the person might have upon receiving this message.
 
 Guidelines:
+- Imagine the reader receiving the final version of this message. What would they genuinely think, feel, or wonder about its content and implications?
 - Limit each perspective to under 20 words.
 - Ensure all perspectives specifically reflect details or qualities from the current document, avoiding broad or generic statements.
 - The three perspectives should be diverse (in emotion, focus, tone, etc.)
 - Each perspective should be expressed in 1st-person ("I like", "I wonder", "I feel", ...)
 - Avoid telling the writer what to do; focus on the reader's viewpoint.
-- The writer may not be finished writing the document; if the last sentence is incomplete, ignore that and focus on the content that is already written.
+- Focus on the substance of what's been written so far, not on whether the document appears complete or polished.
 - Avoid providing specific words or phrases that the writer could directly copy into their document.
 - If there is insufficient context to generate genuine perspectives, return an empty list.`,
 };
@@ -58,25 +80,11 @@ const listResponseSchema = z.object({
   responses: z.array(z.string()).describe('List of suggestions'),
 });
 
-// Bridging instructions for when conversation history is provided
-const directBridging: Record<string, string> = {
-  example_sentences: 'The writer gathered information through the conversation below. Use relevant details from this conversation to generate contextually accurate sentence options.',
-  complete_document: 'The writer gathered information through the conversation below. Use relevant details to complete the document accurately.',
-  proposal_advice: 'The writer gathered information through the conversation below. Consider this context when giving advice.',
-  analysis_readerPerspective: 'The writer gathered information through the conversation below. Consider what the reader would think given the facts discussed.',
-};
-
-const nudgeBridging: Record<string, string> = {
-  example_sentences: 'The writer gathered information through the conversation below. Generate sentences with bracketed placeholders (e.g., [room], [time], [name]) where specific facts from the conversation would go. Do NOT fill in the actual details — the writer must recall and insert them.',
-  complete_document: 'The writer gathered information through the conversation below. Complete the document structure but use bracketed placeholders (e.g., [room], [time], [specific detail]) for facts from the conversation. The writer must fill these in themselves.',
-  proposal_advice: 'The writer gathered information through the conversation below. Reference topics from the conversation without revealing specific details. Guide the writer to think about what information matters, without being prescriptive about exact facts.',
-  analysis_readerPerspective: 'The writer gathered information through the conversation below. React to whether the document addresses the reader\'s likely concerns, but do not reveal specific facts from the conversation in your reactions.',
-};
+// Bridging instruction for when conversation history is provided
+const conversationBridge = 'The writer gathered information through a private 1-on-1 conversation with a colleague (shown below). This conversation is not visible to the document\'s reader.';
 
 function formatConversationSection(
   messages: ConversationMessage[],
-  mode: string,
-  historyMode: 'direct' | 'nudge',
 ): string {
   // Truncate to fit within token budget
   let transcript = '';
@@ -93,11 +101,7 @@ function formatConversationSection(
     }
   }
 
-  const bridging = historyMode === 'nudge'
-    ? (nudgeBridging[mode] || '')
-    : (directBridging[mode] || '');
-
-  return `\n\n# Conversation Between Writer and Colleague\n\n${bridging}\n\n<conversation>\n${transcript.trim()}\n</conversation>\n\n`;
+  return `\n\n# Conversation Between Writer and Colleague\n\n${conversationBridge}\n\n<conversation>\n${transcript.trim()}\n</conversation>\n\n`;
 }
 
 export async function POST(req: Request) {
@@ -115,7 +119,6 @@ export async function POST(req: Request) {
   const context = (body.context as keyof typeof prompts) || 'proposal_advice';
   const promptTemplate = prompts[context];
   const conversationHistory = body.conversationHistory;
-  const conversationHistoryMode = body.conversationHistoryMode || 'direct';
 
   try {
     const documentText = `${beforeCursor}${selectedText}${afterCursor}`;
@@ -126,7 +129,7 @@ export async function POST(req: Request) {
 
     // Insert conversation history between the system prompt and document
     if (conversationHistory && conversationHistory.length > 0) {
-      fullPrompt += formatConversationSection(conversationHistory, context, conversationHistoryMode);
+      fullPrompt += formatConversationSection(conversationHistory);
     }
 
     fullPrompt += `\n\n# Writer's Document So Far\n\n<document>\n${documentText}</document>\n\n`;

--- a/experiment/app/api/writing-support/route.ts
+++ b/experiment/app/api/writing-support/route.ts
@@ -28,7 +28,7 @@ Guidelines:
 - The three sentences should be three different paths that the writer could take, each starting from the current point in the document; they do **NOT** go in sequence.
 - Each output should be *at most one sentence* long.
 - Use ellipses to truncate sentences that are longer than about **10 words**.
-- Where a specific fact or detail from the writer's research would go, use a bracketed placeholder (e.g., [name], [date], [specific detail]) instead of filling in the actual detail. The writer must recall and insert these themselves.`,
+- Where a specific fact or detail would go, use a bracketed placeholder (e.g., [name], [date], [specific detail]) instead of filling in the actual detail. This applies both to details mentioned in the conversation and to details that could reasonably be asked for later in the conversation. The writer must recall and insert these themselves.`,
 
   complete_document: `You are assisting a writer complete and polish their document. Please provide a completed and polished version of the document that the writer has started writing.
 
@@ -43,7 +43,7 @@ Guidelines:
 - Use the text in the document as a starting point, but make any changes needed to make the document complete and polished.
 - Maintain the writer's tone, style, and voice throughout.
 - Polish the text for clarity and coherence.
-- Where specific facts or details from the writer's research would go, use bracketed placeholders (e.g., [name], [date], [specific detail]) instead of filling in the actual information. The writer must recall and insert these themselves.`,
+- Where a specific fact or detail would go, use a bracketed placeholder (e.g., [name], [date], [specific detail]) instead of filling in the actual detail. This applies both to details mentioned in the conversation and to details that could reasonably be asked for later in the conversation. The writer must recall and insert these themselves.`,
 
   proposal_advice: `You are assisting a writer in drafting a document by providing three directive (but not prescriptive) advice to help them develop their work. Your advice must be tailored to the document's genre. Use your best judgment to offer the most relevant and helpful advice, drawing from the following types of support as appropriate for the context:
 - Support the writer in adhering to their stated writing goals or assignment guidelines.

--- a/experiment/app/study/page.tsx
+++ b/experiment/app/study/page.tsx
@@ -52,7 +52,6 @@ function parseStudyParams(searchParams: URLSearchParams): StudyParams | string {
 
   const experiment = searchParams.get('experiment');
   const autoRefreshStr = searchParams.get('autoRefreshInterval');
-  const chm = searchParams.get('chm');
 
   return {
     username,
@@ -63,7 +62,6 @@ function parseStudyParams(searchParams: URLSearchParams): StudyParams | string {
     autoRefreshInterval: autoRefreshStr ? parseInt(autoRefreshStr, 10) : DEFAULT_AUTO_REFRESH_INTERVAL,
     scenario: searchParams.get('scenario') || DEFAULT_SCENARIO_ID,
     conversationHistory: searchParams.get('ch') === '1',
-    conversationHistoryMode: chm === 'nudge' ? 'nudge' : 'direct',
   };
 }
 

--- a/experiment/components/AIPanel.tsx
+++ b/experiment/components/AIPanel.tsx
@@ -5,7 +5,6 @@ import type { RefObject } from 'react';
 import type { WritingAreaRef } from '@/components/WritingArea';
 import type { UIMessage } from '@ai-sdk/react';
 import type { ConversationMessage, GenerationResult, SavedItem, TextEditorState } from '@/types';
-import type { ConversationHistoryMode } from '@/types/study';
 import { log } from '@/lib/logging';
 import { API_TIMEOUT_MS } from '@/lib/studyConfig';
 import { parseMessageContent } from '@/lib/chatUtils';
@@ -14,12 +13,14 @@ import { studyConditionAtom, studyParamsAtom } from '@/contexts/StudyContext';
 
 const visibleNameForMode = {
   example_sentences: 'Examples of what you could write next:',
+  example_withblanks: 'Examples with blanks to fill in:',
   complete_document: 'Completed document suggestion:',
+  complete_document_withblanks: 'Completed document with blanks to fill in:',
   analysis_readerPerspective: 'Possible perspectives your reader might have:',
   proposal_advice: 'Advice for your next words:',
 };
 
-const modes = ['example_sentences', 'complete_document', 'analysis_readerPerspective', 'proposal_advice'] as const;
+const modes = ['example_sentences', 'example_withblanks', 'complete_document', 'complete_document_withblanks', 'analysis_readerPerspective', 'proposal_advice'] as const;
 const MIN_TEXT_LENGTH_FOR_SUGGESTION = 25;
 
 function getMessageText(message: UIMessage): string {
@@ -110,14 +111,12 @@ interface AIPanelProps {
   writingAreaRef?: RefObject<WritingAreaRef | null>;
   isStudyMode?: boolean;
   chatMessages?: UIMessage[];
-  conversationHistoryMode?: ConversationHistoryMode;
 }
 
 export default function AIPanel({
   writingAreaRef,
   isStudyMode = false,
   chatMessages,
-  conversationHistoryMode,
 }: AIPanelProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [savedItems, setSavedItems] = useState<SavedItem[]>([]);
@@ -204,7 +203,6 @@ export default function AIPanel({
             extra_data: {
               isAutoRefresh,
               conversationHistoryEnabled: !!conversationHistory,
-              conversationHistoryMode: conversationHistoryMode ?? null,
               conversationHistoryMessageCount: chatMessageCount,
             },
           });
@@ -218,10 +216,7 @@ export default function AIPanel({
           body: JSON.stringify({
             editorState,
             context: modeToUse,
-            ...(conversationHistory && {
-              conversationHistory,
-              conversationHistoryMode: conversationHistoryMode ?? 'direct',
-            }),
+            ...(conversationHistory && { conversationHistory }),
           }),
           signal: AbortSignal.timeout(API_TIMEOUT_MS),
         });
@@ -260,7 +255,6 @@ export default function AIPanel({
                   generation,
                   editorState,
                   conversationHistoryEnabled: !!conversationHistory,
-                  conversationHistoryMode: conversationHistoryMode ?? null,
                   conversationHistoryMessageCount: chatMessageCount,
                 },
               });
@@ -285,7 +279,7 @@ export default function AIPanel({
         setIsLoading(false);
       }
     },
-    [writingAreaRef, save, mode, isStudyMode, studyParams, chatMessages, conversationHistoryMode]
+    [writingAreaRef, save, mode, isStudyMode, studyParams, chatMessages]
   );
 
   // Auto-refresh logic for study mode
@@ -357,11 +351,15 @@ export default function AIPanel({
               >
                 {mode === 'example_sentences'
                   ? 'Examples'
-                  : mode === 'analysis_readerPerspective'
-                    ? 'Reader Perspectives'
-                    : mode === 'complete_document'
-                      ? 'Complete Document'
-                    : 'Advice'}
+                  : mode === 'example_withblanks'
+                    ? 'Examples (Blanks)'
+                    : mode === 'analysis_readerPerspective'
+                      ? 'Reader Perspectives'
+                      : mode === 'complete_document'
+                        ? 'Complete Document'
+                        : mode === 'complete_document_withblanks'
+                          ? 'Complete (Blanks)'
+                          : 'Advice'}
               </button>
             </Fragment>
           ))}

--- a/experiment/components/study/TaskPage.tsx
+++ b/experiment/components/study/TaskPage.tsx
@@ -163,7 +163,6 @@ export default function TaskPage() {
             writingAreaRef={writingAreaRef}
             isStudyMode={true}
             chatMessages={studyParams.conversationHistory ? chatMessages : undefined}
-            conversationHistoryMode={studyParams.conversationHistory ? studyParams.conversationHistoryMode : undefined}
           />
         </div>
       )}

--- a/experiment/contexts/StudyContext.tsx
+++ b/experiment/contexts/StudyContext.tsx
@@ -16,7 +16,6 @@ export const studyParamsAtom = atom<StudyParams>({
   isProlific: true,
   scenario: 'roomDoubleBooking',
   conversationHistory: false,
-  conversationHistoryMode: 'direct',
 });
 
 /**

--- a/experiment/lib/studyConfig.ts
+++ b/experiment/lib/studyConfig.ts
@@ -37,6 +37,10 @@ export const letterToCondition: Record<ConditionCode, ConditionName> = {
   // Study 2: Type of AI
   a: 'analysis_readerPerspective',
   p: 'proposal_advice',
+
+  // With-blanks variants (placeholder-based suggestions)
+  b: 'example_withblanks',
+  d: 'complete_document_withblanks',
 };
 
 // Consent form URL (Qualtrics)

--- a/experiment/types/index.ts
+++ b/experiment/types/index.ts
@@ -16,7 +16,7 @@ export interface ConversationMessage {
 
 export interface WritingSupportRequest {
   editorState: TextEditorState;
-  context?: string;
+  context?: GenerationType;
   conversationHistory?: ConversationMessage[];
 }
 

--- a/experiment/types/index.ts
+++ b/experiment/types/index.ts
@@ -18,14 +18,13 @@ export interface WritingSupportRequest {
   editorState: TextEditorState;
   context?: string;
   conversationHistory?: ConversationMessage[];
-  conversationHistoryMode?: 'direct' | 'nudge';
 }
 
 export interface WritingSupportResponse {
   suggestions: string[];
 }
 
-export type GenerationType = 'example_sentences' | 'analysis_readerPerspective' | 'proposal_advice';
+export type GenerationType = 'example_sentences' | 'example_withblanks' | 'complete_document' | 'complete_document_withblanks' | 'analysis_readerPerspective' | 'proposal_advice';
 
 export interface GenerationResult {
   result: string;

--- a/experiment/types/study.ts
+++ b/experiment/types/study.ts
@@ -32,16 +32,16 @@ export interface LogEntry extends LogPayload {
   gitCommit: string;
 }
 
-export type ConditionCode = 'n' | 'c' | 'e' | 'a' | 'p';
+export type ConditionCode = 'n' | 'c' | 'e' | 'a' | 'p' | 'b' | 'd';
 
 export type ConditionName =
   | 'no_ai'
   | 'complete_document'
   | 'example_sentences'
+  | 'example_withblanks'
+  | 'complete_document_withblanks'
   | 'analysis_readerPerspective'
   | 'proposal_advice';
-
-export type ConversationHistoryMode = 'direct' | 'nudge';
 
 export interface StudyParams {
   username: string;
@@ -52,7 +52,6 @@ export interface StudyParams {
   autoRefreshInterval: number;
   scenario: string; // Scenario ID (e.g., 'roomDoubleBooking', 'demoRescheduling')
   conversationHistory: boolean; // Whether AI assistant receives chat transcript (ch=0/1)
-  conversationHistoryMode: ConversationHistoryMode; // How AI uses conversation: 'direct' or 'nudge' (chm=direct/nudge)
 }
 
 export interface BrowserMetadata extends Record<string, unknown> {


### PR DESCRIPTION
## Summary
This PR introduces two new AI assistance modes that use bracketed placeholders for facts the writer must fill in themselves, and simplifies the conversation history integration by removing the direct/nudge distinction.

## Key Changes

- **New AI modes with placeholders**: Added `example_withblanks` and `complete_document_withblanks` modes that generate suggestions with bracketed placeholders (e.g., `[name]`, `[date]`) instead of filling in specific details from research or conversation
- **Simplified conversation handling**: Removed the `conversationHistoryMode` parameter (`direct`/`nudge`) throughout the codebase. Conversation context is now always provided with a single, consistent bridge instruction that explains the conversation is private and not visible to the reader
- **Updated prompts**: 
  - Added new prompt templates for the placeholder-based modes
  - Enhanced `proposal_advice` prompt with guidance to help writers think about important information rather than providing it directly
  - Improved `analysis_readerPerspective` prompt with clearer instructions about imagining the reader's genuine reactions
- **Updated UI**: Added mode buttons and labels for the new placeholder-based suggestion types
- **Updated study configuration**: Added condition codes `b` and `d` for the new modes, removed `conversationHistoryMode` from study parameters

## Implementation Details

- The new placeholder modes follow the same pattern as existing modes but include explicit guidelines about using bracketed placeholders instead of actual details
- Conversation bridge instruction is now unified across all modes, removing the need for mode-specific bridging logic
- The `formatConversationSection` function signature was simplified to remove the `mode` and `historyMode` parameters
- All references to `conversationHistoryMode` have been removed from component props, API requests, and logging

https://claude.ai/code/session_01Fgr9EmsbbeeVjTNQ62wTQj