### PR TITLE
Fix TypeError: use chat.completions.parse() for structured output

### DIFF
--- a/backend/nlp.py
+++ b/backend/nlp.py
@@ -192,7 +192,7 @@ async def _get_suggestions_from_context(
         if trace_id:
             ph_kwargs["posthog_trace_id"] = trace_id
 
-    completion = await openai_client.chat.completions.create(
+    completion = await openai_client.chat.completions.parse(
         **MODEL_PARAMS,
         messages=[
             {
@@ -205,10 +205,9 @@ async def _get_suggestions_from_context(
         **ph_kwargs,
     )
 
-    content = completion.choices[0].message.content
-    if not content:
+    suggestion_response = completion.choices[0].message.parsed
+    if not suggestion_response:
         return []
-    suggestion_response = ListResponse.model_validate_json(content)
     return suggestion_response.responses
 
 
@@ -252,7 +251,7 @@ async def get_suggestion(
         full_prompt = get_full_prompt(prompt_name, doc_context)
         if DEBUG_PROMPTS:
             print(f"Prompt for {prompt_name} (baseline):\n{full_prompt}\n")
-        completion = await openai_client.chat.completions.create(
+        completion = await openai_client.chat.completions.parse(
             **MODEL_PARAMS,
             messages=[
                 {
@@ -265,10 +264,9 @@ async def get_suggestion(
             **({"posthog_distinct_id": distinct_id, "posthog_trace_id": trace_id} if ph_client is not None else {}),
         )
 
-        content = completion.choices[0].message.content
-        if not content:
+        suggestion_response = completion.choices[0].message.parsed
+        if not suggestion_response:
             raise ValueError("No suggestions found in the response.")
-        suggestion_response = ListResponse.model_validate_json(content)
         markdown_response = "\n\n".join(
             [f"- {item}" for item in suggestion_response.responses]
         )


### PR DESCRIPTION
Both call sites in nlp.py were passing a Pydantic BaseModel class (ListResponse) to chat.completions.create(), which raises a TypeError in the modern OpenAI SDK. Switch both to chat.completions.parse() and use .message.parsed instead of manual model_validate_json(). This also resolves the rapid-repeat response behavior caused by the frontend retrying on each failed request.
