### PR TITLE
Mode name changes

### DIFF
--- a/experiment/components/AIPanel.tsx
+++ b/experiment/components/AIPanel.tsx
@@ -13,9 +13,9 @@ import { studyConditionAtom, studyParamsAtom } from '@/contexts/StudyContext';
 
 const visibleNameForMode = {
   example_sentences: 'Examples of what you could write next:',
-  example_withblanks: 'Examples with blanks to fill in:',
+  example_withblanks: 'Examples of what you could write next:',
   complete_document: 'Completed document suggestion:',
-  complete_document_withblanks: 'Completed document with blanks to fill in:',
+  complete_document_withblanks: 'Completed document suggestion:',
   analysis_readerPerspective: 'Possible perspectives your reader might have:',
   proposal_advice: 'Advice for your next words:',
 };


### PR DESCRIPTION
Make the mode name of the blanked suggestions consistent with non-blanked suggestion counterparts (since it is not the case that blanked suggestions always give blanked suggestions)