### PR TITLE
Fix streaming responses on Chat and Revise

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,12 +11,12 @@
 			"dependencies": {
 				"@auth0/auth0-react": "^2.2.4",
 				"@lexical/react": "^0.16.1",
-				"@microsoft/fetch-event-source": "^2.0.1",
 				"@posthog/react": "^1.9.0",
 				"@react-hook/window-size": "^3.1.1",
 				"@types/node": "^24.6.2",
 				"@types/react-transition-group": "^4.4.12",
 				"core-js": "^3.37.1",
+				"eventsource-parser": "^3.0.8",
 				"jotai": "^2.12.5",
 				"lexical": "^0.16.1",
 				"mini-css-extract-plugin": "^2.9.4",
@@ -5722,12 +5722,6 @@
 				"debug": "^4.1.1",
 				"vscode-jsonrpc": "^4.0.0"
 			}
-		},
-		"node_modules/@microsoft/fetch-event-source": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
-			"integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
-			"license": "MIT"
 		},
 		"node_modules/@microsoft/kiota": {
 			"version": "1.26.1",
@@ -12168,6 +12162,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.x"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+			"integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/execa": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,12 +46,12 @@
 	"dependencies": {
 		"@auth0/auth0-react": "^2.2.4",
 		"@lexical/react": "^0.16.1",
-		"@microsoft/fetch-event-source": "^2.0.1",
 		"@posthog/react": "^1.9.0",
 		"@react-hook/window-size": "^3.1.1",
 		"@types/node": "^24.6.2",
 		"@types/react-transition-group": "^4.4.12",
 		"core-js": "^3.37.1",
+		"eventsource-parser": "^3.0.8",
 		"jotai": "^2.12.5",
 		"lexical": "^0.16.1",
 		"mini-css-extract-plugin": "^2.9.4",

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -2,7 +2,7 @@ import { useState, useContext, useEffect, useRef, useCallback } from 'react';
 import { Remark } from 'react-remark';
 
 import { AiOutlineArrowDown, AiOutlineSend } from 'react-icons/ai';
-import { fetchEventSource } from '@microsoft/fetch-event-source';
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
 
 import { ChatContext } from '@/contexts/chatContext';
 import { usernameAtom } from '@/contexts/userContext';
@@ -127,30 +127,66 @@ export default function Chat() {
 		setShowScrollButton(false);
 		updateMessage('');
 
-		const token = await getAccessToken();
-		await fetchEventSource(`${SERVER_URL}/chat`, {
-			method: 'POST',
-			headers: {
-				'Content-Type': 'application/json',
-				Authorization: `Bearer ${token}`,
-			},
-			body: JSON.stringify({
-				messages: newMessages.slice(0, -1),
-				username: username,
-			}),
-			onmessage(msg) {
-				const message = JSON.parse(msg.data);
-				const choice = message.choices[0];
-				if (choice.finish_reason === 'stop') return;
-				const newContent = choice.delta.content;
-				// need to make a new "newMessages" object to force React to update :(
-				newMessages = newMessages.slice();
-				newMessages[newMessages.length - 1].content += newContent;
-				updateChatMessages(newMessages);
-			},
-		});
+		try {
+			const token = await getAccessToken();
+			const response = await fetch(`${SERVER_URL}/chat`, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${token}`,
+				},
+				body: JSON.stringify({
+					messages: newMessages.slice(0, -1),
+					username: username,
+				}),
+			});
 
-		updateSendingMessage(false);
+			if (!response.ok || !response.body) {
+				console.error('Chat request failed:', response.status, response.statusText);
+				return;
+			}
+
+			const decoder = new TextDecoder();
+			const reader = response.body.getReader();
+			let shouldStop = false;
+
+			const parser = createParser({
+				onEvent(event: EventSourceMessage) {
+					try {
+						const parsed = JSON.parse(event.data);
+						const choice = parsed.choices?.[0];
+						if (choice?.finish_reason === 'stop') {
+							shouldStop = true;
+							return;
+						}
+
+						const newContent = choice?.delta?.content;
+						if (typeof newContent !== 'string' || newContent.length === 0) {
+							return;
+						}
+
+						// Need to make a new object to force React to update.
+						newMessages = newMessages.slice();
+						newMessages[newMessages.length - 1].content += newContent;
+						updateChatMessages(newMessages);
+					} catch (error) {
+						console.error('Error parsing chat stream message:', error);
+					}
+				},
+			});
+
+			while (!shouldStop) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				parser.feed(decoder.decode(value, { stream: true }));
+			}
+
+			parser.reset({ consume: true });
+		} catch (error) {
+			console.error('Error while streaming chat response:', error);
+		} finally {
+			updateSendingMessage(false);
+		}
 	}
 
 	async function sendMessage(e: React.FormEvent<HTMLFormElement>) {

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -27,6 +27,7 @@ export default function Chat() {
 	const username = useAtomValue(usernameAtom);
 	const editorAPI = useContext(EditorContext);
 	const { getAccessToken, authErrorType } = useAccessToken();
+	const activeRequestControllerRef = useRef<AbortController | null>(null);
 	const messagesContainerRef = useRef<HTMLDivElement>(null);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const [showScrollButton, setShowScrollButton] = useState(false);
@@ -114,7 +115,19 @@ export default function Chat() {
 		resizeTextarea();
 	}, [message, resizeTextarea]);
 
+	useEffect(() => {
+		return () => {
+			// Cleanup on unmount: stop any in-flight stream to avoid post-unmount updates.
+			activeRequestControllerRef.current?.abort();
+		};
+	}, []);
+
 	async function submitMessage(text: string) {
+		// Only one active request is allowed; cancel any previous stream first.
+		activeRequestControllerRef.current?.abort();
+		const requestController = new AbortController();
+		activeRequestControllerRef.current = requestController;
+
 		updateSendingMessage(true);
 
 		let newMessages = [
@@ -131,6 +144,7 @@ export default function Chat() {
 			const token = await getAccessToken();
 			const response = await fetch(`${SERVER_URL}/chat`, {
 				method: 'POST',
+				signal: requestController.signal,
 				headers: {
 					'Content-Type': 'application/json',
 					Authorization: `Bearer ${token}`,
@@ -183,9 +197,16 @@ export default function Chat() {
 
 			parser.reset({ consume: true });
 		} catch (error) {
+			if (requestController.signal.aborted) {
+				return;
+			}
 			console.error('Error while streaming chat response:', error);
 		} finally {
-			updateSendingMessage(false);
+			// Ignore stale completions from older requests that were already replaced.
+			if (activeRequestControllerRef.current === requestController) {
+				activeRequestControllerRef.current = null;
+				updateSendingMessage(false);
+			}
 		}
 	}
 

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -2,7 +2,7 @@
  * @format
  */
 
-import { fetchEventSource } from '@microsoft/fetch-event-source';
+import { createParser, type EventSourceMessage } from 'eventsource-parser';
 import { useAtomValue } from 'jotai';
 import { useCallback, useContext, useMemo, useRef, useState } from 'react';
 import { Remark } from 'react-remark';
@@ -270,7 +270,6 @@ export default function Revise() {
 
 			const newViz = new Visualization(request, docContext);
 			setVisualizations((prev) => [...prev, newViz]);
-			/* Kick off a streaming request to the server to get the visualization response */
 
 			const docTextAsPrompt = getDocTextAsPrompt(docContext);
 
@@ -289,57 +288,84 @@ ${request}
 </request>`,
 				},
 			];
+
 			setLoading(true);
-			fetchEventSource(`${SERVER_URL}/chat`, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${token}`,
-				},
-				body: JSON.stringify({
-					messages: chatMessages,
-					username: username,
-				}),
-				onmessage(msg) {
-					try {
-						if (!msg.data) {
-							// I'm not sure why this happens.
-							return;
-						}
-						const message = JSON.parse(msg.data);
-						const choice = message.choices[0];
-						if (choice.finish_reason === 'stop') {
-							setLoading(false);
-							console.log(
-								'Visualization response complete:',
-								newViz.response,
-							);
-							return;
-						}
-						const newContent = choice.delta.content;
-						newViz.response += newContent;
-						setVisualizations((prev) => {
-							// Force React to update by creating a new array
-							const updatedViz = [...prev];
-							const index = updatedViz.findIndex(
-								(v) => v.id === newViz.id,
-							);
-							if (index !== -1) {
-								updatedViz[index] = newViz;
+
+			try {
+				const response = await fetch(`${SERVER_URL}/chat`, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${token}`,
+					},
+					body: JSON.stringify({
+						messages: chatMessages,
+						username: username,
+					}),
+				});
+
+				if (!response.ok || !response.body) {
+					console.error(
+						'Visualization request failed:',
+						response.status,
+						response.statusText,
+					);
+					return;
+				}
+
+				const decoder = new TextDecoder();
+				const reader = response.body.getReader();
+				let shouldStop = false;
+
+				const parser = createParser({
+					onEvent(event: EventSourceMessage) {
+						try {
+							if (!event.data) {
+								return;
 							}
-							return updatedViz;
-						});
-					} catch (error) {
-						console.error('Error parsing message:', error);
-						setLoading(false);
-					}
-				},
-				onerror(err) {
-					console.error('Error fetching visualization:', err);
-					setLoading(false);
-					// TODO: maybe auth error?
-				},
-			});
+
+							const message = JSON.parse(event.data);
+							const choice = message.choices?.[0];
+							if (choice?.finish_reason === 'stop') {
+								shouldStop = true;
+								console.log('Visualization response complete:', newViz.response);
+								return;
+							}
+
+							const newContent = choice?.delta?.content;
+							if (typeof newContent !== 'string' || newContent.length === 0) {
+								return;
+							}
+
+							newViz.response += newContent;
+							setVisualizations((prev) => {
+								// Force React to update by creating a new array
+								const updatedViz = [...prev];
+								const index = updatedViz.findIndex((v) => v.id === newViz.id);
+								if (index !== -1) {
+									updatedViz[index] = newViz;
+								}
+								return updatedViz;
+							});
+						} catch (error) {
+							console.error('Error parsing message:', error);
+						}
+					},
+				});
+
+				while (!shouldStop) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					parser.feed(decoder.decode(value, { stream: true }));
+				}
+
+				parser.reset({ consume: true });
+			} catch (err) {
+				console.error('Error fetching visualization:', err);
+				// TODO: maybe auth error?
+			} finally {
+				setLoading(false);
+			}
 		},
 		[docContext, getAccessToken, username],
 	);

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -4,7 +4,7 @@
 
 import { createParser, type EventSourceMessage } from 'eventsource-parser';
 import { useAtomValue } from 'jotai';
-import { useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Remark } from 'react-remark';
 import {
 	AiOutlineFileText,
@@ -209,6 +209,7 @@ export default function Revise() {
 	const username = useAtomValue(usernameAtom);
 	const docContext = useDocContext(editorAPI);
 	const { getAccessToken, reportAuthError: _reportAuthError, authErrorType: _authErrorType } = useAccessToken();
+	const activeRequestControllerRef = useRef<AbortController | null>(null);
 	const [_loading, setLoading] = useState(false);
 	const [_customPrompts, _setCustomPrompts] = useState<Prompt[]>([]);
 	const [_selectedCustomPrompt, _setSelectedCustomPrompt] = useState<
@@ -256,11 +257,26 @@ export default function Revise() {
 		[],
 	);
 
+	useEffect(() => {
+		return () => {
+			// Cleanup on unmount: stop any in-flight stream to avoid post-unmount updates.
+			activeRequestControllerRef.current?.abort();
+		};
+	}, []);
+
 	const requestVisualization = useCallback(
 		async (prompt: Prompt) => {
+			// Only one active request is allowed; cancel any previous stream first.
+			activeRequestControllerRef.current?.abort();
+			const requestController = new AbortController();
+			activeRequestControllerRef.current = requestController;
+
 			const token = await getAccessToken();
 			if (!token) {
 				console.error('No access token available');
+				if (activeRequestControllerRef.current === requestController) {
+					activeRequestControllerRef.current = null;
+				}
 				return;
 			}
 
@@ -294,6 +310,7 @@ ${request}
 			try {
 				const response = await fetch(`${SERVER_URL}/chat`, {
 					method: 'POST',
+					signal: requestController.signal,
 					headers: {
 						'Content-Type': 'application/json',
 						Authorization: `Bearer ${token}`,
@@ -361,10 +378,17 @@ ${request}
 
 				parser.reset({ consume: true });
 			} catch (err) {
+				if (requestController.signal.aborted) {
+					return;
+				}
 				console.error('Error fetching visualization:', err);
 				// TODO: maybe auth error?
 			} finally {
-				setLoading(false);
+				// Ignore stale completions from older requests that were already replaced.
+				if (activeRequestControllerRef.current === requestController) {
+					activeRequestControllerRef.current = null;
+					setLoading(false);
+				}
 			}
 		},
 		[docContext, getAccessToken, username],


### PR DESCRIPTION
We were seeing infinite retries on the Chat page.

I'm not sure what the root cause was, but fetchEventSource was swallowing any errors and blindly re-requesting, which was definitely wrong.

It also seemed unmaintained. So I had Opus 4.6 do an analysis of alternatives and then GPT-5.3-Codex did the switch to a simple parser.

I haven't tested this yet so it's not ready to merge. But maybe ready for testing.