### PR TITLE
refactor: route draft through ai sdk + fix proxy bugs

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -268,6 +268,7 @@ async def openai_chat_completions_proxy(request: Request):
         headers={
             "Authorization": f"Bearer {nlp.openai_api_key}",
             "Content-Type": "application/json",
+            "Accept-Encoding": "identity",
         },
     )
     upstream = await client.send(upstream_req, stream=True)

--- a/frontend/src/api/openai.ts
+++ b/frontend/src/api/openai.ts
@@ -1,9 +1,25 @@
-import { createOpenAI } from "@ai-sdk/openai";
-import { SERVER_URL } from "./index";
+import { createOpenAI } from '@ai-sdk/openai';
+import { SERVER_URL } from './index';
 
-export const openai = createOpenAI({
-	baseURL: `${SERVER_URL}/openai`,
-	apiKey: "unused",
-});
+export const OPENAI_MODEL = 'gpt-4o';
 
-export const OPENAI_MODEL = "gpt-4o";
+export function createAuthenticatedOpenAI(token?: string) {
+	return createOpenAI({
+		baseURL: `${SERVER_URL}/openai`,
+		apiKey: 'unused',
+		fetch: async (input, init) => {
+			const headers = new Headers(init?.headers);
+
+			if (token) {
+				headers.set('Authorization', `Bearer ${token}`);
+			}
+
+			return fetch(input, {
+				...init,
+				headers,
+			});
+		},
+	});
+}
+
+export const openai = createAuthenticatedOpenAI();

--- a/frontend/src/api/prompts.ts
+++ b/frontend/src/api/prompts.ts
@@ -1,0 +1,110 @@
+// How many characters of context to show around the cursor position
+const CONTEXT_CHARS = 100;
+
+// The instructions sent to the AI for each button in the Draft panel.
+// These are copied exactly from the original backend — do not change them.
+const prompts: Record<string, string> = {
+	example_sentences: `You are assisting a writer in drafting a document. Generate three possible options for inspiring and fresh possible next sentences that would help the writer think about what they should write next.
+
+Guidelines:
+- Focus on the area of the document that is closest to the writer's cursor.
+- If the writer is in the middle of a sentence, output three possible continuations of that sentence.
+- If the writer is at the end of a paragraph, output three possible sentences that would start the next paragraph.
+- The three sentences should be three different paths that the writer could take, each starting from the current point in the document; they do **NOT** go in sequence.
+- Each output should be *at most one sentence* long.
+- Use ellipses to truncate sentences that are longer than about **10 words**.
+`,
+
+	proposal_advice: `You are assisting a writer in drafting a document by providing three directive (but not prescriptive) advice to help them develop their work. Your advice must be tailored to the document's genre. Use your best judgment to offer the most relevant and helpful advice, drawing from the following types of support as appropriate for the context:
+- Support the writer in adhering to their stated writing goals or assignment guidelines.
+- Help the writer think about what they could write next.
+- Encourage the writer to maintain focus on their main idea and avoid introducing unrelated material.
+- Recommend strengthening arguments by adding supporting evidence, specific examples, or clear reasoning.
+- Advise on structuring material to achieve a clear and logical flow.
+- Guide the writer in choosing language that is accessible and engaging for the intended audience.
+
+Guidelines:
+- Focus on the area of the document that is closest to the writer's cursor.
+- Keep each piece of advice under 20 words.
+- Express the advice in the form of a directive instruction, not a question.
+- Don't give specific words or phrases for the writer to use.
+- Make each piece of advice very specific to the current document, not general advice that could apply to any document.
+`,
+
+	analysis_readerPerspective: `You are assisting a writer in drafting a document for a specific person. Generate three possible questions the person might have about the document so far.
+
+Guidelines:
+- Avoid suggesting specific words or phrases.
+- Limit each question to under 20 words.
+- Ensure all questions specifically reflect details or qualities from the current document, avoiding broad or generic statements.
+- Each question should be expressed as a perspective describing how the person might feel about the document, not as a directive to the writer.
+- If there is insufficient context to generate genuine questions, return an empty list.
+`,
+
+	complete_document: `You are assisting a writer complete and polish their document. Please provide a completed and polished version of the document that the writer has started writing.
+
+Guidelines:
+- Use the text in the document as a starting point, but make any changes needed to make the document complete and polished.
+- Maintain the writer's tone, style, and voice throughout.
+- Polish the text for clarity and coherence.
+`,
+
+	example_rewording: `You are assisting a writer in drafting a document. Generate three alternative rewordings of the writer's selected text.
+
+Guidelines:
+- Rephrase only the selected text in three different ways while preserving the original meaning.
+- Vary the word choice, and tone across the three options.
+- Maintain the writer's overall voice and style.
+- Each rewording should be approximately the same length as the original selected text.
+- If no text is selected, return an empty list.
+`,
+};
+
+// Builds the messages array that gets sent to OpenAI.
+// Previously this was done in the backend (nlp.py). Now the frontend does it,
+// so the backend only needs to forward the messages to OpenAI.
+export function buildMessages(gtype: string, docContext: DocContext) {
+	const basePrompt = prompts[gtype];
+
+	let userContent = basePrompt;
+
+	// If the user has extra context sections (e.g. assignment instructions), append them
+	if (docContext.contextData?.length) {
+		const sections = docContext.contextData
+			.map((s) => `## ${s.title}\n\n${s.content}`)
+			.join('\n\n');
+		userContent += `\n\n# Additional Context (will *not* be visible to the reader of the document):\n\n${sections}`;
+	}
+
+	// Send the full document text so the AI can see everything the writer has written
+	const documentText =
+		docContext.beforeCursor + docContext.selectedText + docContext.afterCursor;
+	userContent += `\n\n# Writer's Document So Far\n\n<document>\n${documentText}</document>\n\n`;
+
+	// Also highlight exactly where the cursor is (or what text is selected),
+	// so the AI focuses on the right part of the document
+	const beforeCursorTrim = docContext.beforeCursor.slice(-CONTEXT_CHARS);
+	const afterCursorTrim = docContext.afterCursor.slice(0, CONTEXT_CHARS);
+
+	if (!docContext.selectedText) {
+		userContent += `\n\n## Text Right Before the Cursor\n\n"${beforeCursorTrim}"`;
+	} else {
+		userContent += `\n\n## Current Selection\n\n${docContext.selectedText}`;
+		userContent += `\n\n## Text Nearby The Selection\n\n"${beforeCursorTrim}${docContext.selectedText}${afterCursorTrim}"`;
+	}
+
+	// These two prompts say "return an empty list" which causes the AI to output "[]"
+	// as plain text instead of a proper bullet list. This line tells the AI to use
+	// bullet format so we get readable results like "- item" instead of ["item"].
+	if (gtype === 'analysis_readerPerspective' || gtype === 'example_rewording') {
+		userContent += '\n\nFormat your response as a plain bulleted list, one item per line starting with "- ". Do not use JSON or array notation.';
+	}
+
+	return [
+		{
+			role: 'system' as const,
+			content: 'You are a helpful and insightful writing assistant.',
+		},
+		{ role: 'user' as const, content: userContent },
+	];
+}

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -134,7 +134,7 @@ export default function Chat() {
 
 		try {
 			const result = streamText({
-				model: openai(OPENAI_MODEL),
+				model: openai.chat(OPENAI_MODEL),
 				messages: newMessages.slice(0, -1) as ModelMessage[],
 				maxOutputTokens: 1024,
 				abortSignal: requestController.signal,

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -71,7 +71,7 @@ class Fetcher {
 		try {
 			const messages = buildMessages(request.type, request.docContext);
 			const sdkResult = streamText({
-				model: openai(OPENAI_MODEL),
+				model: openai.chat(OPENAI_MODEL),
 				messages: messages as ModelMessage[],
 				maxOutputTokens: 1024,
 			});

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -11,8 +11,10 @@ import {
 	useState,
 } from 'react';
 import { Remark } from 'react-remark';
-import { log, SERVER_URL } from '@/api';
-import { useAccessToken } from '@/contexts/authTokenContext';
+import { streamText, type ModelMessage } from 'ai';
+import { log } from '@/api';
+import { openai, OPENAI_MODEL } from '@/api/openai';
+import { buildMessages } from '@/api/prompts';
 import { EditorContext } from '@/contexts/editorContext';
 import { usernameAtom } from '@/contexts/userContext';
 import { useDocContext } from '@/utilities';
@@ -64,37 +66,23 @@ class Fetcher {
 
 	async fetchSuggestion(
 		request: SuggestionRequest,
-		accessToken: string,
-		username: string,
 	): Promise<GenerationResult> {
 		this.requestInFlight = request;
 		try {
-			const response = await fetch(`${SERVER_URL}/get_suggestion`, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${accessToken}`,
-				},
-				body: JSON.stringify({
-					username: username,
-					gtype: request.type,
-
-					doc_context: request.docContext,
-				}),
-				signal: AbortSignal.timeout(20000),
+			const messages = buildMessages(request.type, request.docContext);
+			const sdkResult = streamText({
+				model: openai(OPENAI_MODEL),
+				messages: messages as ModelMessage[],
+				maxOutputTokens: 1024,
 			});
-			if (!response.ok) {
-				throw new Error(`HTTP error! status: ${response.status}`);
+			let text = '';
+			for await (const delta of sdkResult.textStream) {
+				text += delta;
 			}
-			const generated = (await response.json()) as GenerationResult;
-			// Set previousRequest only when the response is successful
 			this.previousRequest = request;
-			return generated;
+			return { result: text, generation_type: request.type, extra_data: {} };
 		} catch (err: any) {
-			let errMsg = '';
-			if (err.name === 'AbortError')
-				errMsg = `Generating a suggestion took too long, please try again.`;
-			else errMsg = `${err.name}: ${err.message}. Please try again.`;
+			const errMsg = `${err.name}: ${err.message}. Please try again.`;
 			throw new Error(errMsg);
 		} finally {
 			this.requestInFlight = null;
@@ -246,7 +234,6 @@ export default function Draft() {
 	const editorAPI = useContext(EditorContext);
 	const docContextSnapshot = useDocContext(editorAPI);
 	const username = useAtomValue(usernameAtom);
-	const { getAccessToken, authErrorType } = useAccessToken();
 	const [isLoading, setIsLoading] = useState(false);
 	const [savedItems, updateSavedItems] = useState<SavedItem[]>([]);
 	const [errorMsg, updateErrorMsg] = useState('');
@@ -333,11 +320,8 @@ export default function Draft() {
 				setIsLoading(true);
 			}
 			try {
-				const token = await getAccessToken();
 				const suggestion = await getFetcher().fetchSuggestion(
 					suggestionRequest,
-					token,
-					username,
 				);
 				// Suggestion text might be empty
 				if (suggestion.result === '') {
@@ -362,7 +346,7 @@ export default function Draft() {
 
 			setIsLoading(false);
 		},
-		[getAccessToken, getFetcher, username, save],
+		[getFetcher, username, save],
 	);
 
 	const autoRefreshCallback = useCallback(() => {
@@ -404,10 +388,6 @@ export default function Draft() {
 		autoRefreshCallback,
 		autoRefreshInterval,
 	);
-
-	if (authErrorType !== null) {
-		return <div>Please reauthorize.</div>;
-	}
 
 	return (
 		<div className={classes.app}>

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -290,7 +290,7 @@ ${request}
 
 			try {
 				const result = streamText({
-					model: openai(OPENAI_MODEL),
+					model: openai.chat(OPENAI_MODEL),
 					system: systemPrompt,
 					messages,
 					maxOutputTokens: 1024,


### PR DESCRIPTION
## Summary

Builds on top of PR #433 (`claude/nifty-gates-QgzXt`) — adds the missing Draft migration, a forward-compatible auth seam, and two runtime fixes needed to make the proxy actually work.

- **`frontend/src/api/prompts.ts`** — add `buildMessages()` to construct LLM message arrays for all Draft suggestion types (ported from `refactor/prompts-to-frontend`)
- **`frontend/src/pages/draft/index.tsx`** — migrate Draft from manual `/api/get_suggestion` fetch to `streamText()` via the existing proxy, matching Chat and Revise
- **`frontend/src/api/openai.ts`** — add `createAuthenticatedOpenAI(token?)` factory as a future-proof seam for Auth0 or Better-Auth token injection; existing `openai` export is unchanged so Chat/Revise are unaffected
- **`backend/server.py`** — add `Accept-Encoding: identity` to upstream request so OpenAI returns uncompressed SSE instead of gzipped bytes the passthrough proxy cannot decode
- **Chat/Revise/Draft** — change `openai(OPENAI_MODEL)` → `openai.chat(OPENAI_MODEL)`; in AI SDK v5 the bare call routes to the Responses API (`/v1/responses`), but the proxy only implements `/api/openai/chat/completions`

## What was intentionally not changed

- `/api/get_suggestion` — still present for legacy/debug surfaces
- `backend/nlp.py` — no simplification in this PR
- Auth0 login flow
- Chat and Revise structure (only the model call updated)

## Test plan

- [ ] Open the Word add-in and send a message in Chat — response streams in
- [ ] Open Revise and trigger a suggestion — response streams in
- [ ] Open Draft and click any mode button — suggestion appears
- [ ] Verify no console errors related to encoding or 405 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)