### PR TITLE
Fix stale selectors in draft-flows test and add visual-diff tolerance

### DIFF
--- a/frontend/tests/demo-page-visual.spec.ts
+++ b/frontend/tests/demo-page-visual.spec.ts
@@ -9,7 +9,11 @@ test('demo page - visual regression', async ({ page }) => {
 
   await expect(page.getByRole('banner')).toContainText('Thoughtful');
 
+  // Allow a small pixel budget so sub-visible rendering noise (font antialiasing,
+  // subpixel shifts) doesn't fail the test. A real layout regression moves far
+  // more than this many pixels.
   await expect(page).toHaveScreenshot('demo-page.png', {
-    fullPage: true
+    fullPage: true,
+    maxDiffPixels: 100,
   });
 });

--- a/frontend/tests/draft-flows.spec.ts
+++ b/frontend/tests/draft-flows.spec.ts
@@ -81,7 +81,7 @@ const adviceLocator = 'button[title="Get suggestions for next words"]';
     await expect(frame.getByText('First example suggestion')).toBeVisible({ timeout: 5000 });
 
     // Delete example suggestion
-    const deleteButton1 = frame.locator('button[aria-label="Delete saved item"]').first();
+    const deleteButton1 = frame.locator('button[aria-label="Delete suggestion"]').first();
     await deleteButton1.click();
     await expect(frame.getByText('First example suggestion')).not.toBeVisible({ timeout: 2000 });
 
@@ -90,7 +90,7 @@ const adviceLocator = 'button[title="Get suggestions for next words"]';
     await expect(frame.getByText('First reader perspective')).toBeVisible({ timeout: 5000 });
 
     // Delete reader perspective suggestion
-    const deleteButton2 = frame.locator('button[aria-label="Delete saved item"]').first();
+    const deleteButton2 = frame.locator('button[aria-label="Delete suggestion"]').first();
     await deleteButton2.click();
     await expect(frame.getByText('First reader perspective')).not.toBeVisible({ timeout: 2000 });
 
@@ -99,7 +99,7 @@ const adviceLocator = 'button[title="Get suggestions for next words"]';
     await expect(frame.getByText('First piece of advice')).toBeVisible({ timeout: 5000 });
 
     // Delete advice suggestion
-    const deleteButton3 = frame.locator('button[aria-label="Delete saved item"]').first();
+    const deleteButton3 = frame.locator('button[aria-label="Delete suggestion"]').first();
     await deleteButton3.click();
     await expect(frame.getByText('First piece of advice')).not.toBeVisible({ timeout: 2000 });
   });
@@ -140,7 +140,7 @@ const adviceLocator = 'button[title="Get suggestions for next words"]';
     const frame = page.frameLocator('#editor-frame');
 
     // Verify empty state message is shown
-    await expect(frame.getByText('Click the button above to generate a suggestion.')).toBeVisible();
+    await expect(frame.getByText('No suggestions yet')).toBeVisible();
   });
 
 });

--- a/frontend/tests/mockBackend.ts
+++ b/frontend/tests/mockBackend.ts
@@ -61,7 +61,9 @@ export async function fulfillOpenAI(route: Route, result: string) {
 
 export async function setupMockBackend(page: Page) {
   await page.route('**/openai/chat/completions', async (route) => {
-    const messages = route.request().postDataJSON()?.messages ?? [];
+    const messages = (route.request().postDataJSON()?.messages ?? []) as {
+      content: string;
+    }[];
     await fulfillOpenAI(route, resultForMessages(messages));
   });
 }


### PR DESCRIPTION
draft-flows still used the old "Delete saved item" aria-label and the old "Click the button above..." empty-state text, which no longer match the UI (now "Delete suggestion" / "No suggestions yet"), so the test failed.

Also allow a small maxDiffPixels budget in the demo-page visual test so sub-visible rendering noise does not fail it.