### PR TITLE
Remove stale jest.config.js reference from eslint config

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -16,7 +16,7 @@ export default [
   
   // Node.js config files
   {
-    files: ['*.config.js', 'jest.config.js', 'tailwind.config.js'],
+    files: ['*.config.js', 'tailwind.config.js'],
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'commonjs',


### PR DESCRIPTION
The jest.config.js file was deleted in the jest->vitest migration, but eslint.config.js still listed it in a `files` glob. Removing the dead
reference — the last literal jest remnant in the source.

No behavior change: *.config.js already covers the remaining .js config
files, and .ts configs (vitest/playwright) are linted by the TS blocks.
