### PR TITLE
Remove dead proxyToBackend layer from Google Docs add-on

### DIFF
--- a/google-docs-addon/Code.gs
+++ b/google-docs-addon/Code.gs
@@ -1,24 +1,10 @@
 /**
  * Writing Tools - Google Docs Add-on
- * 
- * This Apps Script serves as a thin proxy layer between:
- * 1. The sidebar UI (HTML/JS/React)
- * 2. The Google Docs document (via DocumentApp)
- * 3. The Python backend (via UrlFetchApp)
+ *
+ * This Apps Script bridges the sidebar UI (HTML/JS/React) and the Google Docs
+ * document (via DocumentApp), providing document operations only. The React app
+ * talks to the Python backend directly; Apps Script does not proxy backend calls.
  */
-
-// =============================================================================
-// Configuration
-// =============================================================================
-
-/**
- * Get the backend URL. In production, this should be your deployed backend.
- * For development, you can use ngrok or similar to expose your local server.
- */
-function getBackendUrl() {
-  // TODO: Update this to your production backend URL
-  return PropertiesService.getScriptProperties().getProperty('BACKEND_URL') || 'http://localhost:5001';
-}
 
 // =============================================================================
 // Add-on Entry Points
@@ -303,92 +289,6 @@ function replaceSelection(newText) {
   }
   
   return false;
-}
-
-// =============================================================================
-// Backend Proxy Functions
-// =============================================================================
-
-/**
- * Forwards a request to the Python backend.
- * 
- * @param {string} endpoint - The API endpoint (e.g., '/analyze', '/chat')
- * @param {Object} payload - The request payload
- * @param {string} method - HTTP method (default: 'POST')
- * @returns {Object} The parsed JSON response
- */
-function proxyToBackend(endpoint, payload, method) {
-  method = method || 'POST';
-  const backendUrl = getBackendUrl();
-  const url = backendUrl + '/api' + endpoint;
-  
-  const options = {
-    method: method,
-    contentType: 'application/json',
-    muteHttpExceptions: true,
-    payload: method !== 'GET' ? JSON.stringify(payload) : undefined
-  };
-  
-  try {
-    const response = UrlFetchApp.fetch(url, options);
-    const responseCode = response.getResponseCode();
-    const responseText = response.getContentText();
-    
-    if (responseCode >= 200 && responseCode < 300) {
-      return JSON.parse(responseText);
-    } else {
-      return {
-        error: true,
-        status: responseCode,
-        message: responseText
-      };
-    }
-  } catch (error) {
-    return {
-      error: true,
-      message: error.toString()
-    };
-  }
-}
-
-/**
- * Logs an event to the backend.
- * 
- * @param {Object} logPayload - The log data
- */
-function logEvent(logPayload) {
-  logPayload.timestamp = Date.now() / 1000;
-  return proxyToBackend('/log', logPayload);
-}
-
-/**
- * Sends a chat message to the backend.
- * 
- * @param {Array} messages - The chat message history
- * @param {Object} docContext - The document context
- * @param {string} username - The username
- */
-function sendChatMessage(messages, docContext, username) {
-  return proxyToBackend('/chat', {
-    messages: messages,
-    doc_context: docContext,
-    username: username
-  });
-}
-
-/**
- * Requests text analysis/revision from the backend.
- * 
- * @param {Object} docContext - The document context
- * @param {string} username - The username
- * @param {Object} options - Additional options
- */
-function analyzeText(docContext, username, options) {
-  return proxyToBackend('/revise', {
-    doc_context: docContext,
-    username: username,
-    ...options
-  });
 }
 
 // =============================================================================

--- a/google-docs-addon/README.md
+++ b/google-docs-addon/README.md
@@ -11,30 +11,36 @@ This folder contains the Google Apps Script code for the Writing Tools Google Do
 │  │  HTML/JS Sidebar (React app from frontend/)         │    │
 │  │                                                      │    │
 │  │   google.script.run.getDocContext()  ──────────┐    │    │
-│  │   google.script.run.analyzeText(...)           │    │    │
-│  └────────────────────────────────────────────────│────┘    │
-└───────────────────────────────────────────────────│─────────┘
-                                                    │
-                                                    ▼
+│  │   google.script.run.selectPhrase(...)          │    │    │
+│  │                                                 │    │    │
+│  │   fetch() to Python backend  ───────────────┐  │    │    │
+│  └──────────────────────────────────────────────│──│────┘    │
+└─────────────────────────────────────────────────│──│─────────┘
+                                                   │  │
+       (document operations via google.script.run)│  │ (chat / revise / log
+                                                   │  │  via direct HTTPS fetch)
+                                                   │  ▼
+                                                   │ ┌──────────────────────────┐
+                                                   │ │  Python Backend (backend/)│
+                                                   │ └──────────────────────────┘
+                                                   ▼
 ┌─────────────────────────────────────────────────────────────┐
 │                  Apps Script (Code.gs)                       │
+│                  (document operations only)                  │
 │                                                              │
 │  • getDocContext() → reads doc, returns to sidebar          │
 │  • selectPhrase() → finds and selects text in doc           │
 └─────────────────────────────────────────────────────────────┘
-                          │
-                          │ HTTPS (UrlFetchApp)
-                          ▼
-┌─────────────────────────────────────────────────────────────┐
-│              Python Backend (backend/)                       │
-│                      (unchanged)                             │
-└─────────────────────────────────────────────────────────────┘
 ```
+
+The React sidebar calls Apps Script (`google.script.run`) only for document
+operations. All backend traffic (chat, revise, logging) goes from the React app
+**directly** to the Python backend — Apps Script does not proxy it.
 
 ## Files
 
 - `appsscript.json` - Add-on manifest with OAuth scopes and triggers
-- `Code.gs` - Main Apps Script code (document operations + backend proxy)
+- `Code.gs` - Main Apps Script code (document operations only)
 - `sidebar.html` - HTML entry point that loads the React app
 
 ## Development Setup
@@ -127,8 +133,18 @@ npm run build:google-docs
 
 This generates `dist-gdocs/sidebar-bundled.html` with the full React app inlined.
 
+### Development vs. production sidebar
 
-For now, development uses the standalone test functions in `sidebar.html`.
+There is no runtime dev/prod flag — the two modes are just two versions of
+`sidebar.html`:
+
+- **Development:** the `sidebar.html` checked into this repo loads the React bundle
+  and CSS **directly from the local dev server** at `http://localhost:3001`
+  (started by `npm run dev-server:google-docs`). No tunneling/ngrok is needed — the
+  sidebar points straight at localhost.
+- **Production:** `npm run build:google-docs` produces
+  `dist-gdocs/sidebar-bundled.html` with all JS/CSS inlined; that file is what you
+  `clasp push` for a real deployment.
 
 ## Key Differences from Word Add-in
 
@@ -140,11 +156,15 @@ For now, development uses the standalone test functions in `sidebar.html`.
 
 ## OAuth Scopes
 
-The add-on requests these scopes (in `appsscript.json`):
+The add-on requests these scopes (auto-detected from API usage; no explicit
+`oauthScopes` block in `appsscript.json`):
 
 - `documents.currentonly` - Access only the current document
 - `script.container.ui` - Display sidebars and dialogs
-- `script.external_request` - Make HTTP requests to the backend (may not be needed)
+- `userinfo.email` - Identify the current user
+
+Apps Script no longer makes outbound HTTP calls (the backend is called directly by
+the React app), so `script.external_request` is no longer requested.
 
 ## Deployment
 
@@ -168,25 +188,18 @@ The add-on requests these scopes (in `appsscript.json`):
 - Make sure you pushed the latest code: `clasp push`
 - Check the function name matches exactly
 
-### "Access denied" or CORS errors
-- Backend must allow requests from `https://script.google.com`
-- Check the backend URL is correct in Script Properties
-
 ### Selection polling feels slow
 - The polling interval is set to 1 second in `googleDocsEditorAPI.ts`
 - Can be adjusted but shorter intervals increase Apps Script quota usage
 
 ### Quota limits
-- UrlFetchApp: 20,000 calls/day (consumer), 100,000/day (Workspace)
 - Script runtime: 6 minutes max per execution
-- Consider caching responses where appropriate
 
 
 ### Scopes we probably need
 
 | Name | Oauth Scope |
 |---|---|
-| Connect to an external service | https://www.googleapis.com/auth/script.external_request |
 | See, edit, create, and delete all your Google Docs documents | https://www.googleapis.com/auth/documents |
 | Display and run third-party web content in prompts and sidebars inside Google applications | https://www.googleapis.com/auth/script.container.ui |
 | See your primary Google Account email address	| https://www.googleapis.com/auth/userinfo.email |

--- a/google-docs-addon/sidebar.html
+++ b/google-docs-addon/sidebar.html
@@ -118,27 +118,6 @@
       },
       
       /**
-       * Sends a chat message through the backend.
-       */
-      sendChatMessage: function(messages, docContext, username) {
-        return this.run('sendChatMessage', messages, docContext, username);
-      },
-      
-      /**
-       * Requests text analysis from the backend.
-       */
-      analyzeText: function(docContext, username, options) {
-        return this.run('analyzeText', docContext, username, options);
-      },
-      
-      /**
-       * Logs an event to the backend.
-       */
-      logEvent: function(payload) {
-        return this.run('logEvent', payload);
-      },
-      
-      /**
        * Gets the current user's email.
        */
       getCurrentUserEmail: function() {


### PR DESCRIPTION
The Apps Script layer used to proxy backend calls (proxyToBackend ->
getBackendUrl via UrlFetchApp), exposed to the sidebar as sendChatMessage,
analyzeText, and logEvent. The React frontend now calls the Python backend
directly and uses the Apps Script bridge only for document operations, so
these functions were dead code.

- Code.gs: delete proxyToBackend, getBackendUrl, logEvent, sendChatMessage,
  analyzeText and their section banners; update the file header.
- sidebar.html: remove the dead sendChatMessage/analyzeText/logEvent bridge
  wrappers.
- README.md: drop the proxy/ngrok mental model from the architecture diagram,
  file list, troubleshooting, and OAuth scopes; clarify that the dev sidebar
  loads the React bundle directly from localhost:3001 (no ngrok). With the only
  UrlFetchApp call gone, script.external_request is no longer requested.

https://claude.ai/code/session_012LChs9UKmRbjgvYyEVM3Bq