### PR TITLE
google doc proxy to backend

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,4 +1,28 @@
-export const SERVER_URL = '/api';
+/**
+ * Resolves the backend base URL.
+ *
+ * Everywhere except the Google Docs sidebar a relative `/api` works (Word's dev
+ * server and the production web host both serve the API under the same origin).
+ *
+ * The Google Docs sidebar is different: its HTML is served from a Google origin,
+ * so a relative `/api` would hit Google's domain. The React bundle, however, is
+ * loaded from the dev server (e.g. http://localhost:3001), which proxies `/api`
+ * to the Python backend. We derive that origin from this script's own URL, so no
+ * tunnel (ngrok) or hardcoded port is needed.
+ */
+function resolveServerUrl(): string {
+	if (typeof window === 'undefined' || !window.RUNNING_IN_GOOGLE_DOCS) {
+		return '/api';
+	}
+	const script = document.currentScript as HTMLScriptElement | null;
+	if (script?.src) {
+		return `${new URL(script.src).origin}/api`;
+	}
+	// Fallback to the dev server's default origin if currentScript is unavailable.
+	return 'http://localhost:3001/api';
+}
+
+export const SERVER_URL = resolveServerUrl();
 
 // Re-export editor APIs
 export { wordEditorAPI } from './wordEditorAPI';

--- a/frontend/webpack.google-docs.config.js
+++ b/frontend/webpack.google-docs.config.js
@@ -80,7 +80,18 @@ module.exports = (_env = {}, options = {}) => {
 			allowedHosts: 'all',
 			headers: {
 				'Access-Control-Allow-Origin': '*'
-			}
+			},
+			// The Google Docs sidebar fetches the backend through this dev server
+			// (SERVER_URL points at http://localhost:3001/api), so proxy /api to
+			// the Python backend — same approach as the Word config. This removes
+			// the need for an ngrok tunnel during development.
+			proxy: [
+				{
+					context: ['/api'],
+					target: 'http://0.0.0.0:8000',
+					changeOrigin: true
+				}
+			]
 		}
 	};
 };

--- a/google-docs-addon/appsscript.json
+++ b/google-docs-addon/appsscript.json
@@ -1,7 +1,19 @@
 {
   "timeZone": "America/New_York",
-  "dependencies": {
-  },
   "exceptionLogging": "STACKDRIVER",
-  "runtimeVersion": "V8"
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/documents.currentonly",
+    "https://www.googleapis.com/auth/script.container.ui",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/userinfo.email"
+  ],
+  "addOns": {
+    "common": {
+      "name": "Writing Tools",
+      "logoUrl": "https://app.thoughtful-ai.com/assets/logo_black.png",
+      "homepageTrigger": { "runFunction": "onHomepage" }
+    },
+    "docs": {}
+  }
 }


### PR DESCRIPTION
api/index.ts: when running in Google Docs, derive the backend origin
  from the loaded bundle URL (document.currentScript) so requests hit the
  dev server (localhost:3001) instead of a relative path.

webpack.google-docs.config.js: proxy /api to the Python backend (:8000),
