### PR TITLE
fix in gdocs

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,21 +5,32 @@
  * server and the production web host both serve the API under the same origin).
  *
  * The Google Docs sidebar is different: its HTML is served from a Google origin,
- * so a relative `/api` would hit Google's domain. The React bundle, however, is
- * loaded from the dev server (e.g. http://localhost:3001), which proxies `/api`
- * to the Python backend. We derive that origin from this script's own URL, so no
- * tunnel (ngrok) or hardcoded port is needed.
+ * so a relative `/api` would hit Google's domain instead of the backend:
+ *
+ * - Production: the bundle is inlined into the Apps Script HTML (no script src to
+ *   read), so the deployed backend origin is baked in at build time via
+ *   `GDOCS_BACKEND_URL`. The sidebar calls that backend directly (it allows CORS).
+ * - Development: the bundle is loaded from the dev server (e.g. localhost:3001),
+ *   which proxies `/api` to the Python backend. We derive that origin from this
+ *   script's own URL, so no tunnel (ngrok) or hardcoded port is needed.
  */
 function resolveServerUrl(): string {
 	if (typeof window === 'undefined' || !window.RUNNING_IN_GOOGLE_DOCS) {
 		return '/api';
 	}
+	// Production: deployed backend origin injected at build time (see the Google
+	// Docs webpack config's DefinePlugin). Empty string in dev builds.
+	const deployed = process.env.GDOCS_BACKEND_URL;
+	if (deployed) {
+		return `${deployed}/api`;
+	}
+	// Development: the bundle's own origin is the dev server, which proxies /api.
 	const script = document.currentScript as HTMLScriptElement | null;
 	if (script?.src) {
 		return `${new URL(script.src).origin}/api`;
 	}
-	// Fallback to the dev server's default origin if currentScript is unavailable.
-	return 'http://localhost:3001/api';
+	// No script src to read (e.g. inlined bundle): fall back to a relative /api.
+	return '/api';
 }
 
 export const SERVER_URL = resolveServerUrl();

--- a/frontend/webpack.google-docs.config.js
+++ b/frontend/webpack.google-docs.config.js
@@ -56,7 +56,14 @@ module.exports = (_env = {}, options = {}) => {
 			new webpack.DefinePlugin({
 				'process.env.AUTH0_DOMAIN': JSON.stringify('dev-rbroo1fvav24wamu.us.auth0.com'),
 				'process.env.AUTH0_CLIENT_ID': JSON.stringify('YZhokQZRgE2YUqU5Is9LcaMiCzujoaVr'),
-				'process.env.NODE_ENV': JSON.stringify(options.mode || 'development')
+				'process.env.NODE_ENV': JSON.stringify(options.mode || 'development'),
+				// Backend origin for the Google Docs sidebar. Empty in dev (the sidebar
+				// reaches the backend through this dev server's /api proxy); in prod the
+				// bundle is inlined into the Apps Script HTML, so bake in the deployed
+				// backend that the sidebar calls directly.
+				'process.env.GDOCS_BACKEND_URL': JSON.stringify(
+					dev ? '' : 'https://app.thoughtful-ai.com'
+				)
 			}),
 			// Generate a standalone HTML file for testing
 			new HtmlWebpackPlugin({


### PR DESCRIPTION
In prod the sidebar is inlined into Google's HTML, so a relative /api hits Google instead of our backend. Bake the backend URL in at build time (GDOCS_BACKEND_URL); dev still uses the local /api proxy. Also drop the hardcoded localhost fallback for a relative /api (review feedback)."