### PR TITLE
poc: add Better Auth device authorization 

### DIFF
--- a/playgrounds/better-auth-hono/package-lock.json
+++ b/playgrounds/better-auth-hono/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hono/node-server": "^2.0.4",
-        "better-auth": "^1.2.0",
+        "better-auth": "1.6.14",
         "better-sqlite3": "^12.0.0",
         "dotenv": "^17.4.2",
         "hono": "^4.7.0"

--- a/playgrounds/better-auth-hono/package.json
+++ b/playgrounds/better-auth-hono/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "tsx watch --env-file .env src/index.ts",
-    "start": "tsx --env-file .env src/index.ts"
+    "start": "tsx --env-file .env src/index.ts",
+    "dev:taskpane": "tsx watch src/taskpane-server.ts"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.4",
-    "better-auth": "^1.2.0",
+    "better-auth": "1.6.14",
     "better-sqlite3": "^12.0.0",
     "dotenv": "^17.4.2",
     "hono": "^4.7.0"

--- a/playgrounds/better-auth-hono/public/device.html
+++ b/playgrounds/better-auth-hono/public/device.html
@@ -32,8 +32,27 @@
     const content = document.getElementById("content");
     const statusEl = document.getElementById("status");
 
-    function show(html) { content.innerHTML = html; }
-    function setStatus(html) { statusEl.innerHTML = html; }
+    // Build helpers — dynamic values always go through textContent, never innerHTML.
+    function el(tag, cls, text) {
+      const e = document.createElement(tag);
+      if (cls) e.className = cls;
+      if (text !== undefined) e.textContent = text;
+      return e;
+    }
+    function btn(cls, id, label, handler) {
+      const b = el("button", cls);
+      b.id = id;
+      b.textContent = label;
+      b.onclick = handler;
+      return b;
+    }
+
+    function showContent(...nodes) {
+      content.replaceChildren(...nodes);
+    }
+    function setStatus(...nodes) {
+      statusEl.replaceChildren(...nodes);
+    }
 
     async function getSession() {
       const res = await fetch(`${BASE}/api/auth/get-session`, { credentials: "include" });
@@ -42,7 +61,6 @@
       return data?.user ? data : null;
     }
 
-    // Hitting GET /device while signed in "claims" the code for this user.
     async function claimAndGetStatus() {
       const res = await fetch(
         `${BASE}/api/auth/device?user_code=${encodeURIComponent(userCode)}`,
@@ -52,7 +70,6 @@
     }
 
     async function signIn() {
-      // Return to this same device page (with the code) after Google login.
       const callbackURL = window.location.href;
       const res = await fetch(`${BASE}/api/auth/sign-in/social`, {
         method: "POST",
@@ -62,7 +79,7 @@
       });
       const data = await res.json();
       if (data?.url) window.location.href = data.url;
-      else setStatus(`<span class="err">Sign-in error:</span> ${JSON.stringify(data)}`);
+      else setStatus(el("span", "err", "Sign-in error: " + JSON.stringify(data)));
     }
 
     async function approve() {
@@ -74,10 +91,10 @@
       });
       const data = await res.json();
       if (res.ok && data?.success) {
-        show("");
-        setStatus(`<p class="ok">Authorization complete.</p><p>You can close this tab and return to Word.</p>`);
+        showContent();
+        setStatus(el("p", "ok", "Authorization complete. You can close this tab and return to Word."));
       } else {
-        setStatus(`<span class="err">Approve failed:</span> ${JSON.stringify(data)}`);
+        setStatus(el("span", "err", "Approve failed: " + JSON.stringify(data)));
       }
     }
 
@@ -90,51 +107,44 @@
       });
       const data = await res.json();
       if (res.ok && data?.success) {
-        show("");
-        setStatus(`<p class="err">Authorization denied.</p><p>The device will not be granted access.</p>`);
+        showContent();
+        setStatus(el("p", "err", "Authorization denied. The device will not be granted access."));
       } else {
-        setStatus(`<span class="err">Deny failed:</span> ${JSON.stringify(data)}`);
+        setStatus(el("span", "err", "Deny failed: " + JSON.stringify(data)));
       }
     }
 
     async function init() {
       if (!userCode) {
-        show(`<p class="err">No user_code in the URL.</p>`);
+        showContent(el("p", "err", "No user_code in the URL."));
         return;
       }
 
       const session = await getSession();
 
       if (!session) {
-        show(`
-          <p>You are verifying code: <span class="code">${userCode}</span></p>
-          <p>Sign in to continue.</p>
-          <button class="approve" id="signin">Sign in with Google</button>
-        `);
-        document.getElementById("signin").onclick = signIn;
+        const codeSpan = el("span", "code", userCode);
+        const p1 = el("p"); p1.append("You are verifying code: ", codeSpan);
+        showContent(p1, el("p", null, "Sign in to continue."), btn("approve", "signin", "Sign in with Google", signIn));
         return;
       }
 
-      // Signed in — claim the code, then show approve/deny.
       const { ok, data } = await claimAndGetStatus();
       if (!ok) {
-        show(`<p class="err">${data?.error_description ?? "Invalid or expired code."}</p>`);
+        showContent(el("p", "err", data?.error_description ?? "Invalid or expired code."));
         return;
       }
 
       if (data.status !== "pending") {
-        show(`<p>This code has already been <strong>${data.status}</strong>.</p>`);
+        const p = el("p"); p.append("This code has already been "); const s = el("strong", null, data.status); p.append(s, "."); showContent(p);
         return;
       }
 
-      show(`
-        <p>Signed in as <strong>${session.user.email}</strong></p>
-        <p>Approve access for code: <span class="code">${userCode}</span></p>
-        <button class="approve" id="approve">Approve</button>
-        <button class="deny" id="deny">Deny</button>
-      `);
-      document.getElementById("approve").onclick = approve;
-      document.getElementById("deny").onclick = deny;
+      const emailStrong = el("strong", null, session.user.email);
+      const p1 = el("p"); p1.append("Signed in as ", emailStrong);
+      const codeSpan = el("span", "code", userCode);
+      const p2 = el("p"); p2.append("Approve access for code: ", codeSpan);
+      showContent(p1, p2, btn("approve", "approve", "Approve", approve), btn("deny", "deny", "Deny", deny));
     }
 
     init();

--- a/playgrounds/better-auth-hono/public/device.html
+++ b/playgrounds/better-auth-hono/public/device.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Device Authorization — Writing Tools</title>
+  <style>
+    body { font-family: sans-serif; max-width: 520px; margin: 3rem auto; padding: 0 1.5rem; line-height: 1.5; }
+    h1 { font-size: 1.4rem; }
+    .code { font-family: monospace; font-size: 1.6rem; letter-spacing: 0.15em; background: #f4f4f4; padding: 0.5rem 1rem; border-radius: 6px; display: inline-block; }
+    button { padding: 0.6rem 1.5rem; cursor: pointer; font-size: 1rem; border-radius: 6px; border: 1px solid #ccc; margin-right: 0.75rem; }
+    .approve { background: #16a34a; color: white; border-color: #16a34a; }
+    .deny { background: #dc2626; color: white; border-color: #dc2626; }
+    .muted { color: #666; font-size: 0.9rem; }
+    #status { margin-top: 1.5rem; padding: 1rem; border-radius: 6px; background: #f9f9f9; }
+    .ok { color: #16a34a; font-weight: bold; }
+    .err { color: #dc2626; font-weight: bold; }
+  </style>
+</head>
+<body>
+  <h1>Device Authorization</h1>
+  <p class="muted">A device (e.g. the Word add-in) is requesting access to your account.</p>
+
+  <div id="content">Loading…</div>
+  <div id="status"></div>
+
+  <script>
+    const BASE = window.location.origin; // same origin as backend (3001)
+    const params = new URLSearchParams(window.location.search);
+    const userCode = params.get("user_code");
+
+    const content = document.getElementById("content");
+    const statusEl = document.getElementById("status");
+
+    function show(html) { content.innerHTML = html; }
+    function setStatus(html) { statusEl.innerHTML = html; }
+
+    async function getSession() {
+      const res = await fetch(`${BASE}/api/auth/get-session`, { credentials: "include" });
+      if (!res.ok) return null;
+      const data = await res.json();
+      return data?.user ? data : null;
+    }
+
+    // Hitting GET /device while signed in "claims" the code for this user.
+    async function claimAndGetStatus() {
+      const res = await fetch(
+        `${BASE}/api/auth/device?user_code=${encodeURIComponent(userCode)}`,
+        { credentials: "include" }
+      );
+      return { ok: res.ok, data: await res.json() };
+    }
+
+    async function signIn() {
+      // Return to this same device page (with the code) after Google login.
+      const callbackURL = window.location.href;
+      const res = await fetch(`${BASE}/api/auth/sign-in/social`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "google", callbackURL }),
+      });
+      const data = await res.json();
+      if (data?.url) window.location.href = data.url;
+      else setStatus(`<span class="err">Sign-in error:</span> ${JSON.stringify(data)}`);
+    }
+
+    async function approve() {
+      const res = await fetch(`${BASE}/api/auth/device/approve`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userCode }),
+      });
+      const data = await res.json();
+      if (res.ok && data?.success) {
+        show("");
+        setStatus(`<p class="ok">Authorization complete.</p><p>You can close this tab and return to Word.</p>`);
+      } else {
+        setStatus(`<span class="err">Approve failed:</span> ${JSON.stringify(data)}`);
+      }
+    }
+
+    async function deny() {
+      const res = await fetch(`${BASE}/api/auth/device/deny`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userCode }),
+      });
+      const data = await res.json();
+      if (res.ok && data?.success) {
+        show("");
+        setStatus(`<p class="err">Authorization denied.</p><p>The device will not be granted access.</p>`);
+      } else {
+        setStatus(`<span class="err">Deny failed:</span> ${JSON.stringify(data)}`);
+      }
+    }
+
+    async function init() {
+      if (!userCode) {
+        show(`<p class="err">No user_code in the URL.</p>`);
+        return;
+      }
+
+      const session = await getSession();
+
+      if (!session) {
+        show(`
+          <p>You are verifying code: <span class="code">${userCode}</span></p>
+          <p>Sign in to continue.</p>
+          <button class="approve" id="signin">Sign in with Google</button>
+        `);
+        document.getElementById("signin").onclick = signIn;
+        return;
+      }
+
+      // Signed in — claim the code, then show approve/deny.
+      const { ok, data } = await claimAndGetStatus();
+      if (!ok) {
+        show(`<p class="err">${data?.error_description ?? "Invalid or expired code."}</p>`);
+        return;
+      }
+
+      if (data.status !== "pending") {
+        show(`<p>This code has already been <strong>${data.status}</strong>.</p>`);
+        return;
+      }
+
+      show(`
+        <p>Signed in as <strong>${session.user.email}</strong></p>
+        <p>Approve access for code: <span class="code">${userCode}</span></p>
+        <button class="approve" id="approve">Approve</button>
+        <button class="deny" id="deny">Deny</button>
+      `);
+      document.getElementById("approve").onclick = approve;
+      document.getElementById("deny").onclick = deny;
+    }
+
+    init();
+  </script>
+</body>
+</html>

--- a/playgrounds/better-auth-hono/public/index.html
+++ b/playgrounds/better-auth-hono/public/index.html
@@ -71,8 +71,8 @@
     }
 
     async function signOut() {
-      await fetch(`${BASE}/api/auth/sign-out`, { method: "POST", credentials: "include" });
-      window.location.reload();
+      const res = await fetch(`${BASE}/api/auth/sign-out`, { method: "POST", credentials: "include", headers: { "Content-Type": "application/json" }, body: "{}" });
+      if (res.ok) window.location.reload();
     }
 
     async function callProtected(mode) {

--- a/playgrounds/better-auth-hono/src/auth.ts
+++ b/playgrounds/better-auth-hono/src/auth.ts
@@ -1,17 +1,36 @@
 import { betterAuth } from "better-auth";
-import { bearer } from "better-auth/plugins";
+import { bearer, deviceAuthorization } from "better-auth/plugins";
 import Database from "better-sqlite3";
 import path from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Device-flow client identifier. This is the app's own ID for the device
+// authorization grant — it is NOT the Google OAuth client ID.
+export const DEVICE_CLIENT_ID = "writing-tools-word-poc";
+
 export const auth = betterAuth({
   // Run `npx @better-auth/cli migrate` after adding or changing plugins.
   database: new Database(path.join(__dirname, "../db/auth.db")),
   baseURL: process.env.BETTER_AUTH_URL ?? "http://localhost:3001",
   secret: process.env.BETTER_AUTH_SECRET,
-  plugins: [bearer()],
+  plugins: [
+    bearer(),
+    deviceAuthorization({
+      // Browser-facing approval page the user is sent to.
+      verificationUri: "/device.html",
+      // Device codes expire after 10 minutes if never approved.
+      expiresIn: "10m",
+      // Task pane must not poll faster than every 5 seconds.
+      interval: "5s",
+      // Only issue device codes for this app's known client ID.
+      validateClient: (clientId) => clientId === DEVICE_CLIENT_ID,
+      // Required by this plugin version's runtime options schema even though
+      // the TS type marks it optional. Empty = use the default deviceCode table.
+      schema: {},
+    }),
+  ],
   socialProviders: {
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID ?? "",

--- a/playgrounds/better-auth-hono/src/index.ts
+++ b/playgrounds/better-auth-hono/src/index.ts
@@ -10,11 +10,14 @@ import chat from "./routes/chat.js";
 const app = new Hono();
 const PORT = 3001;
 
-// CORS — allow the static test page and future frontend origins.
+// CORS — allow the backend's own static pages (3001) AND the separate
+// task-pane simulator origin (3002). The 3002 origin reproduces the Word
+// task-pane / browser split: it has NO Better Auth cookie and must rely
+// entirely on the bearer token returned by the device flow.
 app.use(
   "*",
   cors({
-    origin: [`http://localhost:${PORT}`],
+    origin: ["http://localhost:3001", "http://localhost:3002"],
     allowHeaders: ["Content-Type", "Authorization"],
     allowMethods: ["GET", "POST", "OPTIONS"],
     credentials: true,

--- a/playgrounds/better-auth-hono/src/taskpane-server.ts
+++ b/playgrounds/better-auth-hono/src/taskpane-server.ts
@@ -1,0 +1,17 @@
+import { Hono } from "hono";
+import { serve } from "@hono/node-server";
+import { serveStatic } from "@hono/node-server/serve-static";
+
+// Standalone static server for the task-pane simulator.
+// Runs on a DIFFERENT origin (3002) than the backend (3001) so that
+// cookies set during browser login never reach this origin. The simulator
+// must succeed using only the bearer token from the device flow.
+const app = new Hono();
+const PORT = 3002;
+
+app.use("/*", serveStatic({ root: "./taskpane" }));
+
+serve({ fetch: app.fetch, port: PORT }, () => {
+  console.log(`Task-pane simulator at http://localhost:${PORT}`);
+  console.log(`(backend expected at http://localhost:3001)`);
+});

--- a/playgrounds/better-auth-hono/taskpane/index.html
+++ b/playgrounds/better-auth-hono/taskpane/index.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Task-Pane Simulator (Device Flow)</title>
+  <style>
+    body { font-family: sans-serif; max-width: 560px; margin: 2.5rem auto; padding: 0 1.5rem; line-height: 1.5; }
+    h1 { font-size: 1.3rem; }
+    button { padding: 0.6rem 1.5rem; cursor: pointer; font-size: 1rem; border-radius: 6px; border: 1px solid #ccc; margin: 0.25rem 0.5rem 0.25rem 0; }
+    .primary { background: #2563eb; color: white; border-color: #2563eb; }
+    .muted { color: #666; font-size: 0.85rem; }
+    .code { font-family: monospace; font-size: 1.4rem; letter-spacing: 0.15em; background: #f4f4f4; padding: 0.35rem 0.8rem; border-radius: 6px; }
+    pre { background: #f4f4f4; padding: 0.75rem; border-radius: 6px; white-space: pre-wrap; word-break: break-all; font-size: 0.8rem; }
+    .ok { color: #16a34a; font-weight: bold; }
+    .err { color: #dc2626; font-weight: bold; }
+    #log { margin-top: 1rem; }
+    .row { margin-top: 1rem; }
+  </style>
+</head>
+<body>
+  <h1>Task-Pane Simulator</h1>
+  <p class="muted">
+    Origin <strong>http://localhost:3002</strong> — no Better Auth cookie here.
+    Backend is <strong>http://localhost:3001</strong>. Success depends only on the
+    bearer token from the device flow.
+  </p>
+
+  <div class="row">
+    <button class="primary" id="start">Start device login</button>
+    <button id="check">Call /api/protected with stored token</button>
+    <button id="clear">Clear token</button>
+  </div>
+
+  <div id="status"></div>
+  <div id="log"></div>
+
+  <script>
+    const BACKEND = "http://localhost:3001";
+    const CLIENT_ID = "writing-tools-word-poc"; // must match DEVICE_CLIENT_ID on server
+    const GRANT = "urn:ietf:params:oauth:grant-type:device_code";
+    const TOKEN_KEY = "writing-tools-poc-token";
+
+    const statusEl = document.getElementById("status");
+    const logEl = document.getElementById("log");
+    let polling = false;
+
+    function setStatus(html) { statusEl.innerHTML = html; }
+    function log(html) { logEl.innerHTML = `<pre>${html}</pre>` + logEl.innerHTML; }
+
+    // 1. Ask the backend for a device + user code.
+    async function startFlow() {
+      if (polling) return;
+      setStatus("Requesting device code…");
+      const res = await fetch(`${BACKEND}/api/auth/device/code`, {
+        method: "POST",
+        credentials: "omit",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id: CLIENT_ID, scope: "openid profile email" }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setStatus(`<span class="err">device/code failed:</span> ${JSON.stringify(data)}`);
+        return;
+      }
+
+      log(`device/code →\n${JSON.stringify(data, null, 2)}`);
+
+      // 2. Show the approval link — user clicks to open in a new tab.
+      //    (Future Word adapter uses Office.context.ui.openBrowserWindow.)
+      setStatus(`
+        User code: <span class="code">${data.user_code}</span><br>
+        <a href="${data.verification_uri_complete}" target="_blank" rel="noopener">Open approval page →</a><br>
+        <span class="muted">Polling every ${data.interval}s once you approve…</span>
+      `);
+
+      // 3. Poll for the token, respecting the interval.
+      pollForToken(data.device_code, data.interval);
+    }
+
+    async function pollForToken(deviceCode, intervalSec) {
+      polling = true;
+      let interval = intervalSec;
+
+      const tick = async () => {
+        if (!polling) return;
+        const res = await fetch(`${BACKEND}/api/auth/device/token`, {
+          method: "POST",
+          credentials: "omit",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            grant_type: GRANT,
+            device_code: deviceCode,
+            client_id: CLIENT_ID,
+          }),
+        });
+        const data = await res.json();
+
+        if (res.ok && data.access_token) {
+          polling = false;
+          localStorage.setItem(TOKEN_KEY, data.access_token);
+          log(`device/token → SUCCESS\n${JSON.stringify(data, null, 2)}`);
+          setStatus(`<span class="ok">Token received and stored.</span> Now click "Call /api/protected".`);
+          return;
+        }
+
+        // RFC 8628 error handling
+        switch (data.error) {
+          case "authorization_pending":
+            setTimeout(tick, interval * 1000);
+            break;
+          case "slow_down":
+            interval += 5; // back off per spec
+            log(`slow_down → backing off to ${interval}s`);
+            setTimeout(tick, interval * 1000);
+            break;
+          case "access_denied":
+            polling = false;
+            setStatus(`<span class="err">Access denied.</span> The user denied the request.`);
+            break;
+          case "expired_token":
+            polling = false;
+            setStatus(`<span class="err">Code expired.</span> Start the flow again.`);
+            break;
+          default:
+            polling = false;
+            setStatus(`<span class="err">Stopped:</span> ${JSON.stringify(data)}`);
+        }
+      };
+
+      setTimeout(tick, interval * 1000);
+    }
+
+    // 4. Prove the stored bearer token authenticates against the backend,
+    //    with NO cookie (credentials: "omit").
+    async function callProtected() {
+      const token = localStorage.getItem(TOKEN_KEY);
+      if (!token) {
+        setStatus(`<span class="err">No stored token.</span> Run the device login first.`);
+        return;
+      }
+      const res = await fetch(`${BACKEND}/api/protected`, {
+        credentials: "omit",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const data = await res.json();
+      log(`/api/protected → ${res.status}\n${JSON.stringify(data, null, 2)}`);
+      setStatus(
+        res.ok
+          ? `<span class="ok">${res.status}</span> — authenticated as ${data.email}`
+          : `<span class="err">${res.status}</span> — ${JSON.stringify(data)}`
+      );
+    }
+
+    function clearToken() {
+      localStorage.removeItem(TOKEN_KEY);
+      setStatus("Token cleared. Back to signed-out state.");
+    }
+
+    document.getElementById("start").onclick = startFlow;
+    document.getElementById("check").onclick = callProtected;
+    document.getElementById("clear").onclick = clearToken;
+  </script>
+</body>
+</html>

--- a/playgrounds/better-auth-hono/taskpane/index.html
+++ b/playgrounds/better-auth-hono/taskpane/index.html
@@ -45,8 +45,17 @@
     const logEl = document.getElementById("log");
     let polling = false;
 
-    function setStatus(html) { statusEl.innerHTML = html; }
-    function log(html) { logEl.innerHTML = `<pre>${html}</pre>` + logEl.innerHTML; }
+    function setStatus(...nodes) {
+      statusEl.replaceChildren(...nodes.map(n => typeof n === "string" ? document.createTextNode(n) : n));
+    }
+    function statusEl2(tag, cls, text) {
+      const e = document.createElement(tag); if (cls) e.className = cls; e.textContent = text; return e;
+    }
+    function log(text) {
+      const pre = document.createElement("pre");
+      pre.textContent = text;
+      logEl.prepend(pre);
+    }
 
     // 1. Ask the backend for a device + user code.
     async function startFlow() {
@@ -60,7 +69,7 @@
       });
       const data = await res.json();
       if (!res.ok) {
-        setStatus(`<span class="err">device/code failed:</span> ${JSON.stringify(data)}`);
+        setStatus(statusEl2("span", "err", "device/code failed: " + JSON.stringify(data)));
         return;
       }
 
@@ -68,11 +77,14 @@
 
       // 2. Show the approval link — user clicks to open in a new tab.
       //    (Future Word adapter uses Office.context.ui.openBrowserWindow.)
-      setStatus(`
-        User code: <span class="code">${data.user_code}</span><br>
-        <a href="${data.verification_uri_complete}" target="_blank" rel="noopener">Open approval page →</a><br>
-        <span class="muted">Polling every ${data.interval}s once you approve…</span>
-      `);
+      const codeSpan = statusEl2("span", "code", data.user_code);
+      const link = document.createElement("a");
+      link.href = data.verification_uri_complete;
+      link.target = "_blank"; link.rel = "noopener";
+      link.textContent = "Open approval page →";
+      const muted = statusEl2("span", "muted", `Polling every ${data.interval}s once you approve…`);
+      const p1 = document.createElement("span"); p1.append("User code: ", codeSpan);
+      setStatus(p1, document.createElement("br"), link, document.createElement("br"), muted);
 
       // 3. Poll for the token, respecting the interval.
       pollForToken(data.device_code, data.interval);
@@ -100,7 +112,7 @@
           polling = false;
           localStorage.setItem(TOKEN_KEY, data.access_token);
           log(`device/token → SUCCESS\n${JSON.stringify(data, null, 2)}`);
-          setStatus(`<span class="ok">Token received and stored.</span> Now click "Call /api/protected".`);
+          setStatus(statusEl2("span", "ok", "Token received and stored."), " Now click \"Call /api/protected\".");
           return;
         }
 
@@ -110,21 +122,21 @@
             setTimeout(tick, interval * 1000);
             break;
           case "slow_down":
-            interval += 5; // back off per spec
+            interval += 5;
             log(`slow_down → backing off to ${interval}s`);
             setTimeout(tick, interval * 1000);
             break;
           case "access_denied":
             polling = false;
-            setStatus(`<span class="err">Access denied.</span> The user denied the request.`);
+            setStatus(statusEl2("span", "err", "Access denied."), " The user denied the request.");
             break;
           case "expired_token":
             polling = false;
-            setStatus(`<span class="err">Code expired.</span> Start the flow again.`);
+            setStatus(statusEl2("span", "err", "Code expired."), " Start the flow again.");
             break;
           default:
             polling = false;
-            setStatus(`<span class="err">Stopped:</span> ${JSON.stringify(data)}`);
+            setStatus(statusEl2("span", "err", "Stopped: " + JSON.stringify(data)));
         }
       };
 
@@ -136,7 +148,7 @@
     async function callProtected() {
       const token = localStorage.getItem(TOKEN_KEY);
       if (!token) {
-        setStatus(`<span class="err">No stored token.</span> Run the device login first.`);
+        setStatus(statusEl2("span", "err", "No stored token."), " Run the device login first.");
         return;
       }
       const res = await fetch(`${BACKEND}/api/protected`, {
@@ -145,11 +157,11 @@
       });
       const data = await res.json();
       log(`/api/protected → ${res.status}\n${JSON.stringify(data, null, 2)}`);
-      setStatus(
-        res.ok
-          ? `<span class="ok">${res.status}</span> — authenticated as ${data.email}`
-          : `<span class="err">${res.status}</span> — ${JSON.stringify(data)}`
-      );
+      if (res.ok) {
+        setStatus(statusEl2("span", "ok", String(res.status)), " — authenticated as " + data.email);
+      } else {
+        setStatus(statusEl2("span", "err", String(res.status)), " — " + JSON.stringify(data));
+      }
     }
 
     function clearToken() {


### PR DESCRIPTION
## Summary

- Adds Better Auth's Device Authorization plugin
- Adds a browser approval page with explicit Approve/Deny
- Adds a separate-origin taskpane simulator
- Polls for a Bearer token and verifies it through `/api/protected`

## What This Proves

- The taskpane can initiate login without a session cookie
- The browser can authenticate and approve a public user code
- The taskpane can receive a Bearer token by polling with its private device code
- The token authenticates a protected Hono route

## Out Of Scope

- Production backend integration
- Real Word taskpane integration
- Google Docs integration
- Production token storage

## Test Plan

- [ ] Start backend on port 3001
- [ ] Start taskpane simulator on port 3002
- [ ] Complete Google login and explicit approval
- [ ] Confirm polling returns an access token
- [ ] Confirm `/api/protected` returns the signed-in user using Bearer auth only