### PR TITLE
Feat/gdoc bundle

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,12 +9,16 @@ RUN npm ci
 
 COPY . ./
 
-RUN npm run build && ls -la
+RUN npm run build && npm run build:google-docs && ls -la
 
 # Production stage
 FROM nginx:alpine
 
 COPY --from=build /app/dist /usr/share/nginx/html
+# Google Docs sidebar bundle, served at /gdocs/google-docs.bundle.js so the
+# Apps Script sidebar can load it via an absolute URL (it can't run a 1.5MB
+# inline script). The sidebar's PROD_BASE points here.
+COPY --from=build /app/dist-gdocs /usr/share/nginx/html/gdocs
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -7,12 +7,12 @@
  * The Google Docs sidebar is different: its HTML is served from a Google origin,
  * so a relative `/api` would hit Google's domain instead of the backend:
  *
- * - Production: the bundle is inlined into the Apps Script HTML (no script src to
- *   read), so the deployed backend origin is baked in at build time via
- *   `GDOCS_BACKEND_URL`. The sidebar calls that backend directly (it allows CORS).
- * - Development: the bundle is loaded from the dev server (e.g. localhost:3001),
- *   which proxies `/api` to the Python backend. We derive that origin from this
- *   script's own URL, so no tunnel (ngrok) or hardcoded port is needed.
+ * - Production: the bundle is loaded from an external URL (see the Apps Script sidebar). If
+ *   `GDOCS_BACKEND_URL` is provided at build time, use it; otherwise derive the backend origin
+ *   from the bundle script's own URL.
+ * - Development: the bundle is loaded from the dev server (e.g. localhost:3001), which proxies
+ *   `/api` to the Python backend. We derive that origin from this script's own URL, so no
+ *   tunnel (ngrok) or hardcoded port is needed.
  */
 function resolveServerUrl(): string {
 	if (typeof window === 'undefined' || !window.RUNNING_IN_GOOGLE_DOCS) {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -5,21 +5,32 @@
  * server and the production web host both serve the API under the same origin).
  *
  * The Google Docs sidebar is different: its HTML is served from a Google origin,
- * so a relative `/api` would hit Google's domain. The React bundle, however, is
- * loaded from the dev server (e.g. http://localhost:3001), which proxies `/api`
- * to the Python backend. We derive that origin from this script's own URL, so no
- * tunnel (ngrok) or hardcoded port is needed.
+ * so a relative `/api` would hit Google's domain instead of the backend:
+ *
+ * - Production: the bundle is inlined into the Apps Script HTML (no script src to
+ *   read), so the deployed backend origin is baked in at build time via
+ *   `GDOCS_BACKEND_URL`. The sidebar calls that backend directly (it allows CORS).
+ * - Development: the bundle is loaded from the dev server (e.g. localhost:3001),
+ *   which proxies `/api` to the Python backend. We derive that origin from this
+ *   script's own URL, so no tunnel (ngrok) or hardcoded port is needed.
  */
 function resolveServerUrl(): string {
 	if (typeof window === 'undefined' || !window.RUNNING_IN_GOOGLE_DOCS) {
 		return '/api';
 	}
+	// Production: deployed backend origin injected at build time (see the Google
+	// Docs webpack config's DefinePlugin). Empty string in dev builds.
+	const deployed = process.env.GDOCS_BACKEND_URL;
+	if (deployed) {
+		return `${deployed}/api`;
+	}
+	// Development: the bundle's own origin is the dev server, which proxies /api.
 	const script = document.currentScript as HTMLScriptElement | null;
 	if (script?.src) {
 		return `${new URL(script.src).origin}/api`;
 	}
-	// Fallback to the dev server's default origin if currentScript is unavailable.
-	return 'http://localhost:3001/api';
+	// No script src to read (e.g. inlined bundle): fall back to a relative /api.
+	return '/api';
 }
 
 export const SERVER_URL = resolveServerUrl();

--- a/frontend/webpack.google-docs.config.js
+++ b/frontend/webpack.google-docs.config.js
@@ -7,7 +7,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = (_env = {}, options = {}) => {
 	const dev = options.mode === 'development';
@@ -59,18 +58,11 @@ module.exports = (_env = {}, options = {}) => {
 				'process.env.NODE_ENV': JSON.stringify(options.mode || 'development'),
 				// Backend origin for the Google Docs sidebar. Empty in dev (the sidebar
 				// reaches the backend through this dev server's /api proxy); in prod the
-				// bundle is inlined into the Apps Script HTML, so bake in the deployed
-				// backend that the sidebar calls directly.
+				// bundle is served from our host and calls the deployed backend directly,
+				// so bake that origin in here.
 				'process.env.GDOCS_BACKEND_URL': JSON.stringify(
 					dev ? '' : 'https://app.thoughtful-ai.com'
 				)
-			}),
-			// Generate a standalone HTML file for testing
-			new HtmlWebpackPlugin({
-				filename: 'sidebar-bundled.html',
-				template: path.resolve(__dirname, '../google-docs-addon/sidebar.html'),
-				inject: 'body',
-				scriptLoading: 'blocking'
 			})
 		],
 		optimization: {

--- a/frontend/webpack.google-docs.config.js
+++ b/frontend/webpack.google-docs.config.js
@@ -56,7 +56,14 @@ module.exports = (_env = {}, options = {}) => {
 			new webpack.DefinePlugin({
 				'process.env.AUTH0_DOMAIN': JSON.stringify('dev-rbroo1fvav24wamu.us.auth0.com'),
 				'process.env.AUTH0_CLIENT_ID': JSON.stringify('YZhokQZRgE2YUqU5Is9LcaMiCzujoaVr'),
-				'process.env.NODE_ENV': JSON.stringify(options.mode || 'development')
+				'process.env.NODE_ENV': JSON.stringify(options.mode || 'development'),
+				// Backend origin for the Google Docs sidebar. Empty in dev (the sidebar
+				// reaches the backend through this dev server's /api proxy); in prod the
+				// bundle is inlined into the Apps Script HTML, so bake in the deployed
+				// backend that the sidebar calls directly.
+				'process.env.GDOCS_BACKEND_URL': JSON.stringify(
+					dev ? '' : 'https://app.thoughtful-ai.com'
+				)
 			}),
 			// Generate a standalone HTML file for testing
 			new HtmlWebpackPlugin({

--- a/google-docs-addon/Code.gs
+++ b/google-docs-addon/Code.gs
@@ -433,6 +433,16 @@ function getDocumentId() {
 }
 
 /**
+ * Gets the title of the active document. The sidebar uses this to decide
+ * whether to load the dev bundle (title contains a dev marker) or production.
+ *
+ * @returns {string} The document title
+ */
+function getDocumentName() {
+  return DocumentApp.getActiveDocument().getName();
+}
+
+/**
  * Gets all tabs in the active document with their text content.
  * Falls back to a single entry representing the whole document if the
  * Tabs API is unavailable (older documents / Apps Script environments).

--- a/google-docs-addon/appsscript.json
+++ b/google-docs-addon/appsscript.json
@@ -8,6 +8,9 @@
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/userinfo.email"
   ],
+  "urlFetchWhitelist": [
+    "https://app.thoughtful-ai.com/"
+  ],
   "addOns": {
     "common": {
       "name": "Writing Tools",

--- a/google-docs-addon/sidebar.html
+++ b/google-docs-addon/sidebar.html
@@ -187,23 +187,31 @@
   
   <!--
     Load the React bundle from an EXTERNAL url (Apps Script can't run a huge
-    inline script). Dev vs prod is decided by the DOCUMENT TITLE, so no emails
-    are hard-coded and any team member can develop locally:
+    inline script). The source is chosen by the DOCUMENT TITLE, so no emails are
+    hard-coded:
 
-      - title contains [dev]  -> load from the localhost dev server (live reload)
-      - otherwise             -> load the hosted production bundle
+      - title contains [dev]  -> show a picker (localhost / staging / prod) so a
+                                 developer can choose which build to load
+      - otherwise             -> load the production bundle automatically
 
-    To develop locally: rename your test doc to include [dev], e.g. "Scratch [dev]".
+    To develop, rename your test doc to include [dev], then pick a source:
+    "localhost" needs `npm run dev-server:google-docs` running; "staging" is the
+    latest merge to main; "prod" is the released version.
   -->
   <script>
     (function () {
       var DEV_MARKER = '[dev]';
-      var DEV_BASE = 'http://localhost:3001';
-      // Production bundle, served by the frontend nginx container (see
-      // frontend/Dockerfile, which copies dist-gdocs into /gdocs).
-      var PROD_BASE = 'https://app.thoughtful-ai.com/gdocs';
+      var SOURCES = {
+        localhost: 'http://localhost:3001',
+        staging: 'https://staging.thoughtful-ai.com/gdocs',
+        prod: 'https://app.thoughtful-ai.com/gdocs'
+      };
 
       function loadFrom(base) {
+        document.getElementById('root').innerHTML =
+          '<div class="loading-container"><div class="loading-spinner"></div>' +
+          '<div class="loading-text">Loading Writing Tools…</div></div>';
+
         var link = document.createElement('link');
         link.rel = 'stylesheet';
         link.href = base + '/google-docs.css';
@@ -219,12 +227,32 @@
         document.body.appendChild(s);
       }
 
+      function showPicker() {
+        var root = document.getElementById('root');
+        root.innerHTML =
+          '<div style="padding:20px;color:#202124;">' +
+          '<p style="margin:0 0 12px;font-weight:600;">Dev mode — load Writing Tools from:</p>' +
+          '<div id="srcButtons"></div></div>';
+        var box = document.getElementById('srcButtons');
+        Object.keys(SOURCES).forEach(function (key) {
+          var b = document.createElement('button');
+          b.textContent = key;
+          b.style.cssText =
+            'display:block;width:100%;margin:0 0 8px;padding:10px 12px;text-align:left;' +
+            'border:1px solid #dadce0;border-radius:6px;background:#f8f9fa;cursor:pointer;' +
+            'font-size:14px;color:#1a73e8;';
+          b.onclick = function () { loadFrom(SOURCES[key]); };
+          box.appendChild(b);
+        });
+      }
+
       window.GoogleAppsScript.getDocumentName()
         .then(function (name) {
           var isDev = (name || '').toLowerCase().indexOf(DEV_MARKER) !== -1;
-          loadFrom(isDev ? DEV_BASE : PROD_BASE);
+          if (isDev) showPicker();
+          else loadFrom(SOURCES.prod);
         })
-        .catch(function () { loadFrom(PROD_BASE); });
+        .catch(function () { loadFrom(SOURCES.prod); });
     })();
   </script>
   

--- a/google-docs-addon/sidebar.html
+++ b/google-docs-addon/sidebar.html
@@ -167,6 +167,13 @@
       },
 
       /**
+       * Gets the title of the active document.
+       */
+      getDocumentName: function() {
+        return this.run('getDocumentName');
+      },
+
+      /**
        * Gets all tabs in the document with their text content.
        */
       getAllTabs: function() {
@@ -178,24 +185,47 @@
     window.RUNNING_IN_GOOGLE_DOCS = true;
   </script>
   
-  <!-- 
-    DEVELOPMENT: Load from local dev server
+  <!--
+    Load the React bundle from an EXTERNAL url (Apps Script can't run a huge
+    inline script). Dev vs prod is decided by the DOCUMENT TITLE, so no emails
+    are hard-coded and any team member can develop locally:
+
+      - title contains [dev]  -> load from the localhost dev server (live reload)
+      - otherwise             -> load the hosted production bundle
+
+    To develop locally: rename your test doc to include [dev], e.g. "Scratch [dev]".
   -->
-  <link rel="stylesheet" href="http://localhost:3001/google-docs.css">
   <script>
-    // Development mode: load React app from local dev server
-    const script = document.createElement('script');
-    script.src = 'http://localhost:3001/google-docs.bundle.js';
-    script.onerror = function() {
-      document.getElementById('root').innerHTML = `
-        <div class="error-container">
-          <h3>Development server not running</h3>
-          <p>Make sure the dev server is running:</p>
-          <code>npm run dev-server:google-docs</code>
-        </div>
-      `;
-    };
-    document.body.appendChild(script);
+    (function () {
+      var DEV_MARKER = '[dev]';
+      var DEV_BASE = 'http://localhost:3001';
+      // Production bundle, served by the frontend nginx container (see
+      // frontend/Dockerfile, which copies dist-gdocs into /gdocs).
+      var PROD_BASE = 'https://app.thoughtful-ai.com/gdocs';
+
+      function loadFrom(base) {
+        var link = document.createElement('link');
+        link.rel = 'stylesheet';
+        link.href = base + '/google-docs.css';
+        document.head.appendChild(link);
+
+        var s = document.createElement('script');
+        s.src = base + '/google-docs.bundle.js';
+        s.onerror = function () {
+          document.getElementById('root').innerHTML =
+            '<div class="error-container"><h3>Could not load Writing Tools</h3>' +
+            '<p>Failed to load the app from <code>' + base + '</code>.</p></div>';
+        };
+        document.body.appendChild(s);
+      }
+
+      window.GoogleAppsScript.getDocumentName()
+        .then(function (name) {
+          var isDev = (name || '').toLowerCase().indexOf(DEV_MARKER) !== -1;
+          loadFrom(isDev ? DEV_BASE : PROD_BASE);
+        })
+        .catch(function () { loadFrom(PROD_BASE); });
+    })();
   </script>
   
   <!-- 


### PR DESCRIPTION
Apps Script won't execute a ~1.5MB inline <script>, so have to load it from an external URL instead:
- frontend/Dockerfile: also run build:google-docs and serve the output at/gdocs, so the bundle is reachable at <host>/gdocs/google-docs.bundle.js
- sidebar.html: load bundle/css from an external base. Dev vs prod is chosen by the document title -- a title containing [dev] loads from the localhost dev server (live reload); everything else loads the production bundle.
- Code.gs: add getDocumentName() so the sidebar can read the doc title
- appsscript.json: add urlFetchWhitelist (required for UrlFetchApp in
  published Workspace add-ons)
