### PR TITLE
feat(frontend): Better Auth device flow in standalone editor (Auth0 still default)

### DIFF
--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -39,7 +39,9 @@ export const auth = betterAuth({
 		bearer(),
 		deviceAuthorization({
 			verificationUri: '/api/device', // nginx forwards /api/* to Hono
-			expiresIn: '10m',
+			// Short expiry shrinks the brute-force window for the manually-entered
+			// user code (default length 8). No per-code attempt lockout yet.
+			expiresIn: '4m',
 			interval: '5s',
 			schema: {}, // workaround for https://github.com/better-auth/better-auth/issues/9422
 			validateClient: (clientId) => deviceClientIds().includes(clientId),
@@ -49,6 +51,9 @@ export const auth = betterAuth({
 		google: {
 			clientId: googleClientId(),
 			clientSecret: googleClientSecret(),
+			// Always show Google's account chooser so the user consciously picks which
+			// account authorizes the device (avoids silently reusing a wrong session).
+			prompt: 'select_account',
 		},
 	},
 });

--- a/backend/src/routes/device-approval.ts
+++ b/backend/src/routes/device-approval.ts
@@ -13,6 +13,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
     body { font-family: sans-serif; max-width: 520px; margin: 3rem auto; padding: 0 1.5rem; line-height: 1.5; }
     h1 { font-size: 1.4rem; }
     .code { font-family: monospace; font-size: 1.6rem; letter-spacing: 0.15em; background: #f4f4f4; padding: 0.5rem 1rem; border-radius: 6px; display: inline-block; }
+    .code-input { font-family: monospace; font-size: 1.3rem; letter-spacing: 0.12em; text-transform: uppercase; padding: 0.6rem 0.8rem; border-radius: 6px; border: 1px solid #ccc; width: 100%; box-sizing: border-box; margin-bottom: 0.9rem; }
     button { padding: 0.6rem 1.5rem; cursor: pointer; font-size: 1rem; border-radius: 6px; border: 1px solid #ccc; margin-right: 0.75rem; }
     .approve { background: #16a34a; color: white; border-color: #16a34a; }
     .deny { background: #dc2626; color: white; border-color: #dc2626; }
@@ -31,8 +32,6 @@ const DEVICE_HTML = `<!DOCTYPE html>
 
   <script>
     const BASE = window.location.origin;
-    const params = new URLSearchParams(window.location.search);
-    const userCode = params.get('user_code');
     const content = document.getElementById('content');
     const statusEl = document.getElementById('status');
 
@@ -51,6 +50,12 @@ const DEVICE_HTML = `<!DOCTYPE html>
     function showContent(...nodes) { content.replaceChildren(...nodes); }
     function setStatus(...nodes) { statusEl.replaceChildren(...nodes); }
 
+    // The user code is typed here, never carried in the URL. That forces the user to
+    // read it from the requesting device (their taskpane), which is what proves intent.
+    function normalizeCode(raw) {
+      return (raw || '').toUpperCase().replace(/[\\s-]/g, '');
+    }
+
     async function getSession() {
       const res = await fetch(BASE + '/api/auth/get-session', { credentials: 'include' });
       if (!res.ok) return null;
@@ -58,7 +63,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
       return data?.user ? data : null;
     }
 
-    async function claimCode() {
+    async function claimCode(userCode) {
       const res = await fetch(
         BASE + '/api/auth/device?user_code=' + encodeURIComponent(userCode),
         { credentials: 'include' }
@@ -67,18 +72,38 @@ const DEVICE_HTML = `<!DOCTYPE html>
     }
 
     async function signIn() {
+      // Return to this same page (without any query) after Google sign-in.
+      const callbackURL = window.location.origin + window.location.pathname;
       const res = await fetch(BASE + '/api/auth/sign-in/social', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'google', callbackURL: window.location.href }),
+        body: JSON.stringify({ provider: 'google', callbackURL }),
       });
       const data = await res.json();
       if (data?.url) window.location.href = data.url;
       else setStatus(el('span', 'err', 'Sign-in error: ' + JSON.stringify(data)));
     }
 
-    async function approve() {
+    async function switchAccount() {
+      // Drop the current Better Auth session, then re-run Google sign-in. The provider
+      // is configured with prompt=select_account, so the user can pick a different
+      // account instead of silently reusing the current one.
+      setStatus(el('span', 'muted', 'Switching account…'));
+      try {
+        await fetch(BASE + '/api/auth/sign-out', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: '{}',
+        });
+      } catch {
+        // Ignore sign-out failure; re-running sign-in still lets them choose.
+      }
+      await signIn();
+    }
+
+    async function approve(userCode) {
       const res = await fetch(BASE + '/api/auth/device/approve', {
         method: 'POST',
         credentials: 'include',
@@ -94,7 +119,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
       }
     }
 
-    async function deny() {
+    async function deny(userCode) {
       const res = await fetch(BASE + '/api/auth/device/deny', {
         method: 'POST',
         credentials: 'include',
@@ -110,41 +135,91 @@ const DEVICE_HTML = `<!DOCTYPE html>
       }
     }
 
-    async function init() {
+    // Signed in: show the approve/deny step for a claimed, pending code.
+    function showApproval(session, userCode) {
+      setStatus();
+      const emailStrong = el('strong', null, session.user.email);
+      const p1 = el('p'); p1.append('Signed in as ', emailStrong);
+      const codeSpan = el('span', 'code', userCode);
+      const p2 = el('p'); p2.append('Authorize access for code: ', codeSpan);
+      showContent(p1, p2,
+        btn('approve', 'Approve', () => approve(userCode)),
+        btn('deny', 'Deny', () => deny(userCode)));
+    }
+
+    async function submitCode(session, raw) {
+      const userCode = normalizeCode(raw);
       if (!userCode) {
-        showContent(el('p', 'err', 'No user_code in the URL.'));
+        setStatus(el('span', 'err', 'Enter the code first.'));
         return;
       }
-
-      const session = await getSession();
-
-      if (!session) {
-        const codeSpan = el('span', 'code', userCode);
-        const p1 = el('p'); p1.append('You are authorizing code: ', codeSpan);
-        showContent(p1, el('p', null, 'Sign in with Google to continue.'), btn('approve', 'Sign in with Google', signIn));
-        return;
-      }
-
-      const { ok, data } = await claimCode();
+      setStatus(el('span', 'muted', 'Checking code…'));
+      const { ok, data } = await claimCode(userCode);
       if (!ok) {
-        showContent(el('p', 'err', data?.error_description ?? 'Invalid or expired code.'));
+        // Keep the input on screen so the user can correct and retry.
+        setStatus(el('span', 'err', data?.error_description ?? 'Invalid or expired code. Check it and try again.'));
         return;
       }
-
       if (data.status !== 'pending') {
         const p = el('p');
         p.append('This code has already been ');
         p.append(el('strong', null, data.status));
         p.append('.');
+        setStatus();
         showContent(p);
         return;
       }
+      showApproval(session, userCode);
+    }
 
-      const emailStrong = el('strong', null, session.user.email);
-      const p1 = el('p'); p1.append('Signed in as ', emailStrong);
-      const codeSpan = el('span', 'code', userCode);
-      const p2 = el('p'); p2.append('Authorize access for code: ', codeSpan);
-      showContent(p1, p2, btn('approve', 'Approve', approve), btn('deny', 'Deny', deny));
+    // A button styled as an inline text link.
+    function linkButton(label, handler) {
+      const b = el('button', null, label);
+      b.style.background = 'none';
+      b.style.border = 'none';
+      b.style.padding = '0';
+      b.style.margin = '0';
+      b.style.color = '#2563eb';
+      b.style.textDecoration = 'underline';
+      b.style.cursor = 'pointer';
+      b.style.fontSize = '0.9rem';
+      b.onclick = handler;
+      return b;
+    }
+
+    // Signed in: prompt for the code shown on the requesting device.
+    function showCodeEntry(session) {
+      // Show which account is about to authorize the device, and let the user switch
+      // if it's the wrong one.
+      const who = el('p', 'muted');
+      who.append('Signed in as ', el('strong', null, session.user.email));
+      const switchP = el('p');
+      switchP.append(linkButton('Use a different account', switchAccount));
+
+      const p = el('p', null, 'Enter the code shown in Writing Tools:');
+      const input = el('input', 'code-input');
+      input.type = 'text';
+      input.setAttribute('autocomplete', 'one-time-code');
+      input.setAttribute('autocapitalize', 'characters');
+      input.setAttribute('spellcheck', 'false');
+      const cont = btn('approve', 'Continue', () => submitCode(session, input.value));
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') submitCode(session, input.value);
+      });
+      showContent(who, switchP, p, input, cont);
+      input.focus();
+    }
+
+    async function init() {
+      const session = await getSession();
+      if (!session) {
+        showContent(
+          el('p', null, 'Sign in with Google, then enter the code shown in Writing Tools.'),
+          btn('approve', 'Sign in with Google', signIn),
+        );
+        return;
+      }
+      showCodeEntry(session);
     }
 
     init();

--- a/backend/src/routes/device-taskpane.ts
+++ b/backend/src/routes/device-taskpane.ts
@@ -90,14 +90,16 @@ function buildDebugDeviceHtml(serializedClientId: string) {
       log('device/code →\\n' + JSON.stringify(data, null, 2));
 
       // Show the approval link — user clicks to open in external browser.
-      // In production Word opens new tab in the external system browser
+      // In production Word opens new tab in the external system browser.
+      // Open the generic verification_uri (no code) so the user must read the code
+      // here and type it on the approval page — matches the manual-entry flow.
       const codeSpan = el('span', 'code', data.user_code);
       const link = document.createElement('a');
-      link.href = data.verification_uri_complete;
+      link.href = data.verification_uri;
       link.target = '_blank';
       link.rel = 'noopener';
       link.textContent = 'Open approval page →';
-      const muted = el('span', 'muted', 'Polling every ' + data.interval + 's once you approve…');
+      const muted = el('span', 'muted', 'Enter the code above on the approval page, then polling continues every ' + data.interval + 's…');
       const p1 = document.createElement('span'); p1.append('User code: ', codeSpan);
       setStatus(p1, document.createElement('br'), link, document.createElement('br'), muted);
 

--- a/docs/auth-plan.md
+++ b/docs/auth-plan.md
@@ -1,239 +1,433 @@
 # Auth Plan
 
-Replacement for Auth0 in the writing-tools add-in. Scope was narrowed via conversation in PR #433.
+Plan for replacing Auth0 in the writing-tools add-in.
 
-> **Status:** under evaluation alongside `docs/js-backend-plan.md`. That plan proposes rewriting the backend in TypeScript and adopting Better-Auth instead of rolling auth in FastAPI. A Stage 0 POC there will decide which plan we commit to.
+> **Status:** The production backend is now TypeScript/Hono after PR #448.
+> Auth0 is still active in the frontend. Better Auth has been proven in an
+> isolated Hono playground, but it is not yet integrated into production.
+> The next implementation step is backend-first and must not change current
+> Chat, Draft, or Revise behavior.
+
+## Current State
+
+The production application currently has two separate auth-related realities:
+
+- The frontend uses Auth0 for login, logout, session caching, and access-token
+  retrieval.
+- The Hono backend does not validate those Auth0 tokens or require any other
+  authentication.
+
+Relevant files:
+
+- `frontend/src/pages/app/index.tsx`
+  - Mounts `Auth0Provider`.
+  - Controls authenticated and unauthenticated UI state.
+  - Provides Auth0's `getAccessTokenSilently` through the existing token
+    context.
+- `frontend/src/contexts/authTokenContext.tsx`
+  - Defines the current token-provider interface.
+  - Does not own or persist the Auth0 session.
+- `frontend/src/api/wordEditorAPI.ts`
+  - Implements the current Word-specific Auth0 login and logout flow.
+- `frontend/src/api/googleDocsEditorAPI.ts`
+  - Contains incomplete Google Docs authentication behavior.
+- `frontend/src/api/openai.ts`
+  - Configures the AI SDK client.
+  - Does not currently attach an Auth0 or Better Auth token.
+- `backend/src/app.ts`
+  - Hosts the Hono API, OpenAI proxy, logging routes, and PostHog middleware.
+  - Uses permissive CORS because backend authentication is not implemented.
+  - Currently allows unauthenticated calls to
+    `/api/openai/chat/completions`.
+
+The isolated Hono + Better Auth playground established that:
+
+- Better Auth can mount inside a Hono server at `/api/auth/*`.
+- Google OAuth can complete and create a Better Auth session.
+- `auth.api.getSession({ headers })` can validate cookie and Bearer sessions.
+- A protected Hono route can return `401` without authentication.
+- A Bearer-authenticated request can identify the signed-in user.
+- An auth guard can run before an OpenAI-compatible streaming response.
+
+The playground did not prove the complete device-authorization flow inside the
+real Word or Google Docs surfaces.
 
 ## Goals
 
-- **Identify users** for logging, analytics, and per-user data (saved prompts, settings, history).
-- **Tag study participants** distinctly from production users.
-- **Allow limited anonymous use** so first-time visitors can try the tool before being asked to sign in.
-- **Work uniformly across all three surfaces**: Word task pane, Google Docs sidebar, standalone editor.
-- **Sign in once per device**, stay signed in for at least 30 days, silent refresh.
+- Identify authenticated users for logging, analytics, and future per-user
+  features.
+- Support a backend-issued token that embedded clients can send as
+  `Authorization: Bearer <token>`.
+- Use one backend auth implementation for Word, Google Docs, and standalone
+  surfaces where practical.
+- Open Google sign-in in the user's normal browser instead of embedding Google
+  OAuth inside a taskpane or iframe.
+- Ensure the taskpane that begins login receives the token for that same device
+  authorization request.
+- Keep existing AI and study workflows working while auth is introduced.
+- Preserve the ability to revoke sessions.
+- Keep Auth0 operational until its replacement works end to end.
 
-## Non-Goals (MVP)
+## Non-Goals For The First Integration
 
-- Multiple sign-in providers. Google OAuth only for v1. Microsoft, magic link, and email/password are deferred.
-- Self-service study cohort assignment. Manual DB flag is acceptable for the MVP; UI/invite-code flows are future work.
-- Migration of existing Auth0 users. Treat as a clean start; current test users re-sign-in.
-- Account linking when the same person signs in with different providers. Deferred until a second provider exists.
+- Removing Auth0.
+- Rewriting the production login UI.
+- Protecting `/api/openai/chat/completions` before the frontend sends Better
+  Auth tokens.
+- Requiring authentication for logging or researcher routes before their
+  intended policies are decided.
+- Supporting multiple OAuth providers.
+- Migrating existing Auth0 users.
+- Implementing account deletion, export, study cohorts, or anonymous-use
+  limits in the first backend PR.
+- Solving Word desktop and Google Docs integration before the standalone and
+  Word web flows are proven.
 
-## Decisions
+## Proposed Direction
 
-| Question | Decision | Rationale |
+| Question | Current direction | Notes |
 |---|---|---|
-| Flow shape | Device-code / login-link, opens browser tab | Avoids OAuth-in-iframe pain across Word and GDocs with a single implementation |
-| Identity model | Single shared identity, merged by verified email | Same person on Word and GDocs is the same user |
-| Provider (MVP) | Google OAuth | Covers GDocs users natively, works fine for Word users with a Gmail account |
-| Database | SQLite, on the existing persistent volume | Already have a volume for study logs; SQLite is zero-ops and upgradable later |
-| Session token storage | `localStorage` on each surface | Simplest; per-iframe-origin scoping is fine |
-| Session lifetime | 30 days, silent refresh | Matches VS Code / Claude Code expectations |
-| Token format | Opaque session ID, validated against DB | We have a DB; enables instant revoke without JWT rotation complexity |
-| Anonymous use | Allowed up to a per-device limit, tracked client-side in `localStorage` | No anon user records, no DB write per anon request |
-| Account deletion / data export | In MVP | Good for IRB approval and future-proofs us against GDPR-style requests |
+| Backend | Existing TypeScript/Hono backend | PR #448 is merged; no new backend service is needed |
+| Auth library | Better Auth | Avoids maintaining custom OAuth and session implementations |
+| Initial provider | Google OAuth | Microsoft and other providers remain future work |
+| Embedded login | Better Auth Device Authorization plugin | Implements OAuth 2.0 Device Authorization Grant behavior |
+| API authentication | Better Auth Bearer plugin | Allows taskpanes and scripts to use `Authorization: Bearer` |
+| Initial persistence | SQLite | Deployment persistence and native addon support must be verified |
+| Migration order | Backend first, frontend second | Keep production behavior unchanged during backend setup |
+| AI route enforcement | Last | Only after every supported frontend can attach a valid token |
 
-## Architecture Overview
+This direction uses Better Auth's documented Device Authorization plugin rather
+than building custom `pending_logins` and polling tables from scratch.
 
-```
-┌────────────────────┐     1. open login URL    ┌──────────────────┐
-│  Sidebar (Word /   │ ───────────────────────▶ │ Browser tab on   │
-│  GDocs / standalone│                          │ backend domain   │
-│  )                 │                          └────────┬─────────┘
-│                    │                                   │ 2. Google OAuth
-│  - device_code     │                                   ▼
-│  - poll session    │                          ┌──────────────────┐
-└────────┬───────────┘                          │ Google           │
-         │                                      └────────┬─────────┘
-         │ 3. GET /auth/poll?code=…                      │ callback
-         │                                               ▼
-         │                                      ┌──────────────────┐
-         └─────────────────────────────────────▶│  FastAPI backend │
-                                                │  + SQLite        │
-                                                └──────────────────┘
-```
+References:
 
-The sidebar never embeds Google's consent screen. All OAuth happens in a normal browser tab on our own domain. The sidebar only ever talks to our backend.
+- <https://better-auth.com/docs/integrations/hono>
+- <https://better-auth.com/docs/plugins/device-authorization>
+- <https://better-auth.com/docs/plugins/bearer>
 
-## Data Model (SQLite)
+## Device Authorization Model
 
-```sql
--- A person. Created on first successful sign-in.
-CREATE TABLE users (
-  id              TEXT PRIMARY KEY,         -- ULID/UUID
-  email           TEXT NOT NULL UNIQUE,
-  email_verified  INTEGER NOT NULL DEFAULT 0,
-  display_name    TEXT,
-  created_at      INTEGER NOT NULL,         -- unix seconds
-  is_study_user   INTEGER NOT NULL DEFAULT 0,
-  study_cohort    TEXT,                     -- nullable; arbitrary string
-  deleted_at      INTEGER                   -- soft delete; null = active
-);
+The Better Auth Device Authorization plugin returns separate values with
+different security roles:
 
--- One row per OAuth identity linked to a user. Future-proofs for multiple providers.
-CREATE TABLE oauth_identities (
-  provider         TEXT NOT NULL,           -- 'google'
-  provider_user_id TEXT NOT NULL,           -- 'sub' claim
-  user_id          TEXT NOT NULL REFERENCES users(id),
-  linked_at        INTEGER NOT NULL,
-  PRIMARY KEY (provider, provider_user_id)
-);
+- `device_code`
+  - Private credential retained by the taskpane.
+  - Used when polling for the resulting access token.
+  - Must not be placed in the browser URL or exposed to the user.
+- `user_code`
+  - Short code intended for browser verification and user confirmation.
+- `verification_uri`
+  - Generic browser page where a user can enter a code.
+- `verification_uri_complete`
+  - Browser URL with the safe `user_code` already included.
+- `interval`
+  - Minimum polling interval the taskpane must respect.
 
--- One row per signed-in device. Opaque session_id is what the client stores.
-CREATE TABLE sessions (
-  id              TEXT PRIMARY KEY,         -- random 32+ bytes, base64url
-  user_id         TEXT NOT NULL REFERENCES users(id),
-  created_at      INTEGER NOT NULL,
-  last_used_at    INTEGER NOT NULL,
-  expires_at      INTEGER NOT NULL,         -- created_at + 30d, slid forward on use
-  user_agent      TEXT,                     -- for the user's "active devices" list
-  revoked_at      INTEGER
-);
+Intended flow:
 
--- Short-lived rows used during the device-code handshake.
-CREATE TABLE pending_logins (
-  device_code     TEXT PRIMARY KEY,         -- random; what the sidebar polls with
-  created_at      INTEGER NOT NULL,
-  expires_at      INTEGER NOT NULL,         -- ~10 minutes
-  session_id      TEXT REFERENCES sessions(id)  -- null until OAuth completes
-);
+```text
+Taskpane                    Hono + Better Auth              Browser / Google
+    |                               |                               |
+    | request device authorization |                               |
+    |------------------------------>|                               |
+    | device_code, user_code,       |                               |
+    | verification_uri_complete     |                               |
+    |<------------------------------|                               |
+    |                               |                               |
+    | open verification_uri_complete ------------------------------>|
+    | retain private device_code    |                    Google login|
+    |                               |<------------------------------>|
+    |                               | authenticated browser session |
+    |                               |<-------------------------------|
+    |                               | verify and approve user_code   |
+    |                               |<-------------------------------|
+    |                               |                               |
+    | poll using private device_code|                               |
+    |------------------------------>|                               |
+    | authorization_pending         |                               |
+    |<------------------------------|                               |
+    |                               |                               |
+    | poll again at allowed interval|                               |
+    |------------------------------>|                               |
+    | access token                  |                               |
+    |<------------------------------|                               |
+    |                               |                               |
+    | Authorization: Bearer token   |                               |
+    |------------------------------>|                               |
+    | protected response            |                               |
+    |<------------------------------|                               |
 ```
 
-`oauth_identities` is overkill for a one-provider MVP but keeps the migration to two providers trivial.
+The plugin's `deviceCode` table owns the mapping between the pending device
+request, its approval state, and the authenticated user. A separate custom
+`device_code -> session_token` table should only be introduced if the official
+plugin cannot satisfy the application flow.
 
-## Flows
+Completing Google login does not automatically imply device approval. The
+browser session must verify and approve the `user_code`, unless the team makes
+an explicit and carefully reviewed decision to auto-approve.
 
-### First-time sign-in (device-code)
+## Backend Phase 1: Better Auth Foundation
 
-1. User clicks **Sign in** in the sidebar.
-2. Sidebar calls `POST /auth/device/start`. Backend creates a `pending_logins` row with a fresh `device_code` and returns `{ device_code, login_url }`.
-3. Sidebar:
-   - Launches `login_url` in a new browser window, using the user's main browser even in the Word desktop app (so it'll probably need to use an `<a>` instead of the Office dialog API).
-   - Begins polling `GET /auth/device/poll?device_code=…` every ~2 seconds.
-4. The browser tab hits `GET /auth/login?device_code=…`. Backend redirects to Google's OAuth consent with `state=device_code`.
-5. Google redirects back to `GET /auth/callback?code=…&state=…`. Backend:
-   - Exchanges the code for tokens.
-   - Looks up `oauth_identities` by `(google, sub)`. If missing, finds-or-creates a `users` row by verified email and inserts an `oauth_identities` row.
-   - Creates a `sessions` row.
-   - Sets `pending_logins.session_id`.
-   - Renders a "You can close this tab" page.
-6. The next sidebar poll sees `session_id` populated, gets `{ session_id, expires_at, user: { id, email, display_name } }`, stores it in `localStorage`, and stops polling.
+Create a feature branch from current `main`.
 
-### Authenticated request
+Add Better Auth to the existing `backend/` service:
 
-- Sidebar adds `Authorization: Bearer <session_id>` to every `/api/*` request.
-- Backend middleware looks up the session, checks `expires_at` and `revoked_at`, slides `last_used_at` forward, and attaches the user to the request context.
+1. Add and pin Better Auth and the selected SQLite adapter dependencies.
+2. Add `backend/src/auth.ts` with:
+   - SQLite database connection.
+   - Google social provider.
+   - Better Auth secret and base URL.
+   - Bearer plugin.
+3. Mount Better Auth before the existing API routes:
 
-### Silent refresh
+   ```ts
+   app.on(["POST", "GET"], "/api/auth/*", (c) =>
+     auth.handler(c.req.raw),
+   );
+   ```
 
-- On every authenticated request, the backend extends `expires_at` to `now + 30 days`. No separate refresh token. (This is the "rolling session" pattern; simpler than refresh-token rotation and fine for this risk level.)
-- If the client sees a `401` from any `/api/*` call, it clears its local session and reverts to the anonymous-limit state.
+4. Add a temporary or explicitly diagnostic `GET /api/protected` route:
 
-### Sign-out
+   ```ts
+   const session = await auth.api.getSession({
+     headers: c.req.raw.headers,
+   });
+   ```
 
-- `POST /auth/logout` with the bearer token sets `revoked_at` on the session row.
-- Client clears `localStorage`.
+5. Add tests proving:
+   - No auth returns `401`.
+   - A valid browser session is accepted.
+   - A valid Bearer session is accepted.
+   - The response identifies the expected user.
+6. Keep all existing production routes, including the OpenAI proxy,
+   behaviorally unchanged.
 
-### Anonymous use + limit
+Phase 1 is successful when Better Auth and the current backend can run together
+without changing frontend behavior.
 
-- All `/api/*` endpoints accept requests without a bearer token.
-- Client tracks `anon_usage_count` in `localStorage`. On reaching the limit (proposal: **5 LLM-backed requests per device**, tunable), the UI swaps the action buttons for a sign-in prompt.
-- The backend does **not** enforce the limit — we explicitly trust the client for anon throttling, since the cost of a determined evader clearing `localStorage` is low and we avoid maintaining anon records.
-- When a user signs in, anon counters are not migrated; they're simply ignored from that point on.
+## Backend Phase 2: Device Authorization
 
-### Account deletion
+After the foundation works:
 
-- `DELETE /auth/account` with bearer token. Backend:
-  - Sets `users.deleted_at = now`.
-  - Revokes all sessions.
-  - Erases `email`, `display_name`, and `oauth_identities` rows for the user (so they can re-sign-up cleanly).
-  - Leaves the `users.id` in place so foreign keys in logs/saved data don't dangle. Future work: a background job that scrubs PII from log rows older than the deletion timestamp.
+1. Add Better Auth's Device Authorization plugin.
+2. Configure a verification page URI owned by the Hono backend.
+3. Validate known device-flow client IDs, beginning with a dedicated
+   writing-tools test client.
+4. Run the Better Auth migration that adds the required `deviceCode` table.
+5. Add a minimal browser verification and approval page.
+6. Add a standalone test client that:
+   - requests device authorization,
+   - opens `verification_uri_complete`,
+   - retains the private `device_code`,
+   - polls at the returned interval,
+   - receives an access token,
+   - calls `/api/protected` with that token.
+7. Test the required error cases:
+   - `authorization_pending`,
+   - `slow_down`,
+   - `access_denied`,
+   - `expired_token`,
+   - invalid device code,
+   - invalid client ID.
 
-### Data export
+Phase 2 is successful when the backend can securely deliver a token to the
+same client that initiated the device request without custom Better Auth
+internals.
 
-- `GET /auth/account/export` returns a JSON blob with:
-  - The user row (minus `id`)
-  - All saved per-user data
-  - All log rows tagged with this user
-- Streamed as a download. No third-party service involvement.
+## Frontend Phase 1: Word Web
 
-## API Surface (new endpoints)
+After the backend device flow passes independently:
 
-| Method | Path | Purpose |
-|---|---|---|
-| `POST` | `/auth/device/start` | Begin device-code flow; returns `{ device_code, login_url }` |
-| `GET`  | `/auth/device/poll`  | Sidebar polls; returns session once OAuth completes |
-| `GET`  | `/auth/login`        | Browser-tab entry point; redirects to Google |
-| `GET`  | `/auth/callback`     | Google OAuth callback; completes the handshake |
-| `GET`  | `/auth/me`           | Current user info (for the sidebar to display) |
-| `POST` | `/auth/logout`       | Revoke current session |
-| `DELETE` | `/auth/account`    | Soft-delete account + scrub PII |
-| `GET`  | `/auth/account/export` | Export the user's data as JSON |
+1. Add a frontend session interface without removing the existing Auth0
+   implementation.
+2. Let the Word web taskpane request a device authorization.
+3. Retain the private `device_code` in taskpane memory while login is pending.
+4. Open `verification_uri_complete` in the user's normal browser.
+5. Poll according to the server-provided interval and error responses.
+6. Store the returned token temporarily for the first integration.
+7. Use the token to call `/api/protected`.
+8. Verify sign-out and expired-session behavior.
 
-All under the same FastAPI app, same domain as `/api/*`. No new infra.
+Longer-term storage may use `localStorage`, but that decision requires a
+security review for each surface. The first integration should avoid assuming
+that every embedded environment has identical storage isolation.
 
-## Frontend Integration
+## Frontend Phase 2: Protected AI Requests
 
-- Replace `@auth0/auth0-react` and the `useAccessToken` context with a small Jotai atom (`sessionAtom`) plus a `useSession()` hook that:
-  - Hydrates from `localStorage` on mount.
-  - Exposes `{ user, signIn(), signOut(), isAuthed }`.
-- `signIn()` runs the device-code flow described above.
-- The AI SDK `openai` client in `frontend/src/api/openai.ts` gets a custom `fetch` wrapper that injects `Authorization: Bearer <session_id>` when a session exists.
-- A small `<SignInGate>` component watches `anon_usage_count` and the session, and switches between "use the tool" and "sign in to continue" UI.
+Only after the taskpane can reliably obtain and use a Better Auth token:
 
-## Provider Setup
+1. Add a token-aware AI SDK client or custom `fetch` boundary in
+   `frontend/src/api/openai.ts`.
+2. Attach `Authorization: Bearer <token>` to AI SDK requests.
+3. Confirm streaming still works with the authorization header.
+4. Add the Better Auth session guard to
+   `/api/openai/chat/completions`.
+5. Update backend tests to cover:
+   - `401` without authentication,
+   - successful authenticated proxy requests,
+   - upstream OpenAI errors,
+   - streaming responses.
+6. Decide whether anonymous AI requests remain supported and where any usage
+   limit is enforced.
 
-- **Google Cloud Console**: register a single OAuth 2.0 Web client.
-  - Authorized JavaScript origins: production + staging domains.
-  - Authorized redirect URIs: `https://<backend-domain>/auth/callback` for each environment.
-- Scopes: `openid email profile` only. No Drive/Gmail scopes — we never call Google APIs on the user's behalf.
+The OpenAI route must not be protected before this frontend phase is ready,
+because current Chat, Draft, and Revise requests do not send Better Auth
+credentials.
 
-## Migration from Auth0
+## Additional Surface Phases
 
-- Remove `@auth0/auth0-react` and the `useAccessToken` / `useAuth0` call sites.
-- Delete `Auth0Provider` wrappers in `frontend/src/pages/app/index.tsx` and the editor entry points.
-- Backend: the JWT validation middleware (if any beyond what we already saw) is removed in favor of the session-lookup middleware.
-- Existing Auth0 test users are not migrated. Document this in the release notes for the rollout.
+### Word Desktop
 
-## Phases
+- Test whether an ordinary external link reliably opens the default browser.
+- Confirm the browser can return to the verification/approval page without
+  relying on Office dialog cookies.
+- Keep the device flow independent of taskpane browser-cookie behavior.
+- Retain Auth0 until the replacement flow is proven in supported desktop
+  environments.
 
-**Phase 1 — Backend skeleton**
-- SQLite schema + SQLAlchemy models
-- `/auth/device/*`, `/auth/login`, `/auth/callback`, `/auth/me`, `/auth/logout`
-- Session middleware
-- Google OAuth via Authlib
+### Google Docs
 
-**Phase 2 — Frontend integration**
-- `useSession()` hook + Jotai atom
-- Sign-in / sign-out UI in the sidebar
-- AI SDK `fetch` wrapper injecting the bearer token
-- `<SignInGate>` for the anon limit
+- Treat the sidebar as a frontend client of the Hono backend.
+- Test external-browser opening, polling, and local token storage directly.
+- Avoid assuming that the older Apps Script proxy remains part of the final AI
+  request path.
+- Confirm Google Docs origin, iframe, and storage behavior before declaring the
+  Word implementation reusable without changes.
 
-**Phase 3 — Account management**
-- `/auth/account` deletion
-- `/auth/account/export`
-- Tiny "Account" panel in the sidebar showing email + sign-out + delete
+### Standalone
 
-**Phase 4 — Study tooling**
-- Admin CLI (or SQL snippets) to flip `is_study_user` and set `study_cohort`
-- Logging integration: every log row carries `user_id` when available
+- A normal cookie-based Better Auth flow may be simpler than device
+  authorization.
+- The team should decide whether consistency across surfaces is worth using the
+  device flow where it is not technically required.
 
-## Future Work / Deferred
+## Database And Deployment
 
-- **Additional providers** — Microsoft OAuth (probable next), magic link (for users without Google accounts).
-- **Account linking UX** — when the second provider lands, let users link both to one account.
-- **Self-service study enrollment** options to evaluate later:
-  - Invite code at signup
-  - Pre-seeded email allowlist
-  - Admin flag after signup *(MVP)*
-  - Separate `/study/signin` route encoding the cohort
-- **Refresh-token rotation** instead of rolling sessions, if we ever care about stolen-token blast radius.
-- **Background PII scrub** for logs after account deletion.
-- **Active devices view** — list of sessions per user with per-session revoke.
-- **Server-side anon rate limiting** if client-side trust proves abusable.
+Better Auth should own its standard auth schema rather than duplicating it in
+hand-written SQL. Expected core data includes users, accounts, sessions,
+verification data, and device authorization records.
+
+Application-specific study metadata may require a separate table or supported
+Better Auth user fields, for example:
+
+```text
+user_id
+is_study_user
+study_cohort
+```
+
+Before production deployment:
+
+- Decide whether SQLite is sufficient for the expected concurrency and hosting
+  model.
+- Persist the database outside the container filesystem.
+- Verify the chosen SQLite Node package builds in the backend's Node slim
+  Docker image.
+- Back up and migrate the database explicitly.
+- Keep auth secrets out of source control.
+- Confirm session expiration, revocation, and cleanup behavior.
+
+## CORS, Cookies, And Origins
+
+The current backend uses permissive CORS because it has no backend auth.
+Better Auth integration requires an explicit origin and cookie strategy.
+
+Questions to resolve:
+
+- Whether production requests are same-origin through nginx.
+- The exact local Word origin, currently HTTPS on localhost.
+- The deployed Word add-in origin.
+- Google Docs sidebar and iframe origins.
+- Whether browser verification pages and auth APIs share a domain.
+- Which routes need cookie credentials versus Bearer authentication.
+- Which origins belong in Better Auth's trusted origin configuration.
+
+Hono CORS middleware must run before Better Auth routes when cross-origin
+cookie requests are supported. Do not copy the playground's localhost CORS
+configuration directly into production.
+
+## Route Protection Policy
+
+Authentication should be added route by route rather than globally.
+
+Initial policy:
+
+| Route | Initial auth policy |
+|---|---|
+| `/api/auth/*` | Managed by Better Auth |
+| `/api/protected` | Always authenticated; diagnostic during integration |
+| `/api/openai/chat/completions` | Remains open until frontend token support is ready |
+| `/api/log` | Separate study/privacy decision |
+| `/api/logs_poll` | Continue using `LOG_SECRET` initially |
+| `/api/download_logs` | Continue using `LOG_SECRET` initially |
+| `/api/ping` | Public |
+
+This prevents an incomplete auth migration from breaking the production add-in
+or researcher tooling.
+
+## Migration From Auth0
+
+Auth0 removal is a final migration step, not part of the backend foundation.
+
+Before removal:
+
+- Better Auth works on every supported surface.
+- Login, logout, session restoration, and expiry are tested.
+- Protected AI requests work reliably.
+- Demo and anonymous behavior is explicitly decided.
+- Current allowed-user and onboarding behavior has a replacement.
+- Existing Auth0 test users have been informed that they must sign in again.
+- Privacy documentation is updated.
+
+Only then should the team remove:
+
+- `@auth0/auth0-react`,
+- `Auth0Provider`,
+- `useAuth0` call sites,
+- Auth0 environment variables,
+- Auth0-specific Word popup/callback code that is no longer needed.
+
+## Deferred Work
+
+- Microsoft OAuth and other providers.
+- Account linking.
+- Account deletion and data export.
+- Self-service study enrollment.
+- Study cohort administration.
+- Anonymous-use limits.
+- Active-device management.
+- Per-session revocation UI.
+- Server-side anonymous rate limiting.
+- Migration of existing Auth0 users.
 
 ## Open Questions
 
-- The exact anon-usage limit (5? 10? per session or per day?) — tune during QA.
-- Backend domain in production needs to be settled before the Google OAuth client can be configured.
-- Whether the standalone editor should *also* show a sign-in prompt or stay demo-mode-forever. Current plan: same `<SignInGate>` everywhere; demo mode is just "haven't hit the anon limit yet."
+- Is explicit device approval required, or is auto-approval acceptable after a
+  user deliberately opens `verification_uri_complete` and signs in?
+- Should standalone users use the device flow or a normal cookie session?
+- Is Google OAuth sufficient for early Word users?
+- How long should Better Auth sessions live?
+- Where should taskpane tokens be stored on each surface?
+- Which routes must require login during research studies?
+- Should logging accept anonymous events?
+- Is SQLite sufficient for production, or only for the initial deployment?
+- What are the production backend and verification-page domains?
+- Does the Word desktop default-browser link work reliably across supported
+  Office versions and operating systems?
+- Does the Google Docs sidebar support the same polling and token-storage model
+  without special handling?
+
+## Implementation Order
+
+1. Better Auth foundation in the existing Hono backend.
+2. Diagnostic protected route and backend tests.
+3. Official Device Authorization plugin and migrations.
+4. Browser verification/approval page.
+5. Standalone device-flow test client.
+6. Word web taskpane integration.
+7. Word desktop and Google Docs surface validation.
+8. Token-aware AI SDK requests.
+9. Protect the OpenAI proxy and update tests.
+10. Decide anonymous/study policies.
+11. Remove Auth0 only after full replacement validation.

--- a/frontend/src/api/__tests__/deviceAuth.test.ts
+++ b/frontend/src/api/__tests__/deviceAuth.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Keep the service off the real ./index (which pulls Office/Google editor APIs);
+// only SERVER_URL is needed.
+vi.mock('../index', () => ({ SERVER_URL: '/api' }));
+
+import {
+	pollForToken,
+	requestDeviceCode,
+	fetchProtectedUser,
+} from '../deviceAuth';
+
+type Json = Record<string, unknown>;
+const resp = (data: Json, ok = false) =>
+	({ ok, json: () => Promise.resolve(data) }) as Response;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+	fetchMock = vi.fn();
+	vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+describe('requestDeviceCode', () => {
+	it('returns the parsed code on success', async () => {
+		fetchMock.mockResolvedValueOnce(
+			resp(
+				{
+					device_code: 'dev',
+					user_code: 'ABCD-1234',
+					verification_uri: '/api/device',
+					verification_uri_complete: '/api/device?user_code=ABCD-1234',
+					expires_in: 600,
+					interval: 5,
+				},
+				true,
+			),
+		);
+		const code = await requestDeviceCode();
+		expect(code.user_code).toBe('ABCD-1234');
+		expect(code.device_code).toBe('dev');
+	});
+
+	it('throws on a non-ok response', async () => {
+		fetchMock.mockResolvedValueOnce(resp({ error: 'invalid_client' }));
+		await expect(requestDeviceCode()).rejects.toThrow(/device\/code failed/);
+	});
+});
+
+describe('pollForToken', () => {
+	it('resolves with the token after authorization_pending', async () => {
+		vi.useFakeTimers();
+		fetchMock
+			.mockResolvedValueOnce(resp({ error: 'authorization_pending' }))
+			.mockResolvedValueOnce(resp({ access_token: 'tok-123' }, true));
+
+		const promise = pollForToken('dev', 1);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toEqual({
+			type: 'token',
+			accessToken: 'tok-123',
+		});
+	});
+
+	it('keeps polling after slow_down and still resolves with the token', async () => {
+		vi.useFakeTimers();
+		fetchMock
+			.mockResolvedValueOnce(resp({ error: 'slow_down' }))
+			.mockResolvedValueOnce(resp({ access_token: 'tok' }, true));
+
+		const promise = pollForToken('dev', 5);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toEqual({
+			type: 'token',
+			accessToken: 'tok',
+		});
+	});
+
+	it('returns denied on access_denied', async () => {
+		vi.useFakeTimers();
+		fetchMock.mockResolvedValueOnce(resp({ error: 'access_denied' }));
+		const promise = pollForToken('dev', 1);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toEqual({ type: 'denied' });
+	});
+
+	it('returns expired on expired_token', async () => {
+		vi.useFakeTimers();
+		fetchMock.mockResolvedValueOnce(resp({ error: 'expired_token' }));
+		const promise = pollForToken('dev', 1);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toEqual({ type: 'expired' });
+	});
+
+	it('returns error on an unexpected error code', async () => {
+		vi.useFakeTimers();
+		fetchMock.mockResolvedValueOnce(resp({ error: 'boom' }));
+		const promise = pollForToken('dev', 1);
+		await vi.runAllTimersAsync();
+		const result = await promise;
+		expect(result.type).toBe('error');
+	});
+
+	it('returns aborted when the signal is already aborted', async () => {
+		const controller = new AbortController();
+		controller.abort();
+		await expect(
+			pollForToken('dev', 1, controller.signal),
+		).resolves.toEqual({ type: 'aborted' });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});
+
+describe('fetchProtectedUser', () => {
+	it('returns the user on 200', async () => {
+		fetchMock.mockResolvedValueOnce(
+			resp({ email: 'a@calvin.edu', name: 'A' }, true),
+		);
+		await expect(fetchProtectedUser('tok')).resolves.toEqual({
+			email: 'a@calvin.edu',
+			name: 'A',
+		});
+	});
+
+	it('throws on 401', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			status: 401,
+			json: () => Promise.resolve({}),
+		} as Response);
+		await expect(fetchProtectedUser('tok')).rejects.toThrow(/protected failed/);
+	});
+});

--- a/frontend/src/api/__tests__/deviceAuth.test.ts
+++ b/frontend/src/api/__tests__/deviceAuth.test.ts
@@ -7,7 +7,7 @@ vi.mock('../index', () => ({ SERVER_URL: '/api' }));
 import {
 	pollForToken,
 	requestDeviceCode,
-	fetchProtectedUser,
+	fetchUserInfo,
 } from '../deviceAuth';
 
 type Json = Record<string, unknown>;
@@ -116,12 +116,12 @@ describe('pollForToken', () => {
 	});
 });
 
-describe('fetchProtectedUser', () => {
+describe('fetchUserInfo', () => {
 	it('returns the user on 200', async () => {
 		fetchMock.mockResolvedValueOnce(
 			resp({ email: 'a@calvin.edu', name: 'A' }, true),
 		);
-		await expect(fetchProtectedUser('tok')).resolves.toEqual({
+		await expect(fetchUserInfo('tok')).resolves.toEqual({
 			email: 'a@calvin.edu',
 			name: 'A',
 		});
@@ -133,6 +133,6 @@ describe('fetchProtectedUser', () => {
 			status: 401,
 			json: () => Promise.resolve({}),
 		} as Response);
-		await expect(fetchProtectedUser('tok')).rejects.toThrow(/protected failed/);
+		await expect(fetchUserInfo('tok')).rejects.toThrow(/protected failed/);
 	});
 });

--- a/frontend/src/api/deviceAuth.ts
+++ b/frontend/src/api/deviceAuth.ts
@@ -1,0 +1,192 @@
+/**
+ * Better Auth device authorization client (RFC 8628).
+ *
+ * Mirrors the proven backend taskpane simulator (backend/src/routes/device-taskpane.ts):
+ * raw fetch with `credentials: 'omit'` throughout, so success depends only on the
+ * Bearer token and never on cookies. No `better-auth` client dependency is needed.
+ *
+ * The interactive half (Google sign-in + approval) happens in the user's normal
+ * browser at `verification_uri_complete`, which Better Auth builds from the backend's
+ * BETTER_AUTH_URL. This module only requests the code and polls for the token.
+ */
+import { SERVER_URL } from './index';
+
+// Supplied at build time via webpack DefinePlugin; must match a value in the backend's
+// BETTER_AUTH_DEVICE_CLIENT_IDS allowlist.
+export const DEVICE_CLIENT_ID =
+	process.env.BETTER_AUTH_DEVICE_CLIENT_ID || 'writing-tools-editor-dev';
+
+const GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+
+/** Successful response of POST /api/auth/device/code. */
+export interface DeviceCodeResponse {
+	device_code: string;
+	user_code: string;
+	verification_uri: string;
+	verification_uri_complete: string;
+	expires_in: number;
+	interval: number;
+}
+
+/** Terminal outcomes of the polling loop. */
+export type PollResult =
+	| { type: 'token'; accessToken: string }
+	| { type: 'denied' }
+	| { type: 'expired' }
+	| { type: 'aborted' }
+	| { type: 'error'; message: string };
+
+/**
+ * Request a device + user code pair. `credentials: 'omit'` proves the token-only path.
+ */
+export async function requestDeviceCode(
+	signal?: AbortSignal,
+): Promise<DeviceCodeResponse> {
+	const res = await fetch(`${SERVER_URL}/auth/device/code`, {
+		method: 'POST',
+		credentials: 'omit',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({
+			client_id: DEVICE_CLIENT_ID,
+			scope: 'openid profile email',
+		}),
+		signal,
+	});
+	const data = await res.json();
+	if (!res.ok) {
+		throw new Error(
+			`device/code failed (${res.status}): ${JSON.stringify(data)}`,
+		);
+	}
+	return data as DeviceCodeResponse;
+}
+
+const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+	new Promise((resolve, reject) => {
+		if (signal?.aborted) {
+			reject(new DOMException('Aborted', 'AbortError'));
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener('abort', onAbort);
+			resolve();
+		}, ms);
+		const onAbort = () => {
+			clearTimeout(timer);
+			reject(new DOMException('Aborted', 'AbortError'));
+		};
+		signal?.addEventListener('abort', onAbort, { once: true });
+	});
+
+/**
+ * Poll POST /api/auth/device/token until the device request resolves.
+ *
+ * Honors the RFC 8628 error set: `authorization_pending` (keep waiting),
+ * `slow_down` (add 5s to the interval), `access_denied`, and `expired_token`.
+ * Cancellable via `signal` — aborting clears the pending timer so a stale tick can
+ * never deliver a token after logout/reset.
+ */
+
+export async function pollForToken(
+	deviceCode: string,
+	intervalSeconds: number,
+	signal?: AbortSignal,
+): Promise<PollResult> {
+	let interval = intervalSeconds;
+
+	while (true) {
+		try {
+			await sleep(interval * 1000, signal);
+		} catch {
+			return { type: 'aborted' };
+		}
+
+		let res: Response;
+		try {
+			res = await fetch(`${SERVER_URL}/auth/device/token`, {
+				method: 'POST',
+				credentials: 'omit',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					grant_type: GRANT_TYPE,
+					device_code: deviceCode,
+					client_id: DEVICE_CLIENT_ID,
+				}),
+				signal,
+			});
+		} catch (e) {
+			if (signal?.aborted) return { type: 'aborted' };
+			return { type: 'error', message: (e as Error).message };
+		}
+
+		const data = await res.json();
+
+		if (res.ok && data.access_token) {
+			return { type: 'token', accessToken: data.access_token as string };
+		}
+
+		switch (data.error) {
+			case 'authorization_pending':
+				break;
+			case 'slow_down':
+				interval += 5;
+				break;
+			case 'access_denied':
+				return { type: 'denied' };
+			case 'expired_token':
+				return { type: 'expired' };
+			default:
+				return {
+					type: 'error',
+					message: JSON.stringify(data),
+				};
+		}
+	}
+}
+
+/** Authenticated user shape returned by GET /api/protected. */
+export interface ProtectedUser {
+	email?: string;
+	name?: string;
+}
+
+/**
+ * Verify a Bearer token and fetch the signed-in user. `credentials: 'omit'` keeps this
+ * on the token-only path. Throws on non-2xx (e.g. 401 once the session expires).
+ */
+export async function fetchProtectedUser(
+	accessToken: string,
+	signal?: AbortSignal,
+): Promise<ProtectedUser> {
+	const res = await fetch(`${SERVER_URL}/protected`, {
+		credentials: 'omit',
+		headers: { Authorization: `Bearer ${accessToken}` },
+		signal,
+	});
+	if (!res.ok) {
+		throw new Error(`protected failed (${res.status})`);
+	}
+	return (await res.json()) as ProtectedUser;
+}
+
+/**
+ * Best-effort Better Auth sign-out using the Bearer token. Returns true if the server
+ * acknowledged. Whether this actually invalidates the device-issued session must be
+ * verified manually (see plan logout semantics).
+ */
+export async function signOut(accessToken: string): Promise<boolean> {
+	try {
+		const res = await fetch(`${SERVER_URL}/auth/sign-out`, {
+			method: 'POST',
+			credentials: 'omit',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${accessToken}`,
+			},
+			body: '{}',
+		});
+		return res.ok;
+	} catch {
+		return false;
+	}
+}

--- a/frontend/src/api/deviceAuth.ts
+++ b/frontend/src/api/deviceAuth.ts
@@ -145,7 +145,7 @@ export async function pollForToken(
 }
 
 /** Authenticated user shape returned by GET /api/protected. */
-export interface ProtectedUser {
+export interface UserInfo {
 	email?: string;
 	name?: string;
 }
@@ -154,10 +154,10 @@ export interface ProtectedUser {
  * Verify a Bearer token and fetch the signed-in user. `credentials: 'omit'` keeps this
  * on the token-only path. Throws on non-2xx (e.g. 401 once the session expires).
  */
-export async function fetchProtectedUser(
+export async function fetchUserInfo(
 	accessToken: string,
 	signal?: AbortSignal,
-): Promise<ProtectedUser> {
+): Promise<UserInfo> {
 	const res = await fetch(`${SERVER_URL}/protected`, {
 		credentials: 'omit',
 		headers: { Authorization: `Bearer ${accessToken}` },
@@ -166,7 +166,7 @@ export async function fetchProtectedUser(
 	if (!res.ok) {
 		throw new Error(`protected failed (${res.status})`);
 	}
-	return (await res.json()) as ProtectedUser;
+	return (await res.json()) as UserInfo;
 }
 
 /**

--- a/frontend/src/contexts/appAuthContext.tsx
+++ b/frontend/src/contexts/appAuthContext.tsx
@@ -18,7 +18,7 @@
  * during migration. Once Better Auth becomes the default, this collapses into a single
  * Better Auth-only provider and the selector/adapters can be removed.
  */
-import { type Auth0ContextInterface, useAuth0 } from '@auth0/auth0-react';
+import { useAuth0 } from '@auth0/auth0-react';
 import { useAtomValue } from 'jotai';
 import {
 	createContext,
@@ -80,9 +80,8 @@ function Auth0AuthProvider({ children }: { children: ReactNode }) {
 	const auth0 = useAuth0();
 	const editorAPI = useContext(EditorContext);
 
-	const session = useMemo<AppAuthSession>(() => {
-		const client = auth0 as Auth0ContextInterface;
-		return {
+	const session = useMemo<AppAuthSession>(
+		() => ({
 			provider: 'auth0',
 			isLoading: auth0.isLoading,
 			isAuthorizing: false,
@@ -92,10 +91,11 @@ function Auth0AuthProvider({ children }: { children: ReactNode }) {
 				: undefined,
 			error: auth0.error,
 			getAccessToken: auth0.getAccessTokenSilently,
-			login: () => editorAPI.doLogin(client),
-			logout: () => editorAPI.doLogout(client),
-		};
-	}, [auth0, editorAPI]);
+			login: () => editorAPI.doLogin(auth0),
+			logout: () => editorAPI.doLogout(auth0),
+		}),
+		[auth0, editorAPI],
+	);
 
 	return (
 		<AppAuthContext.Provider value={session}>
@@ -135,11 +135,16 @@ function BetterAuthProvider({ children }: { children: ReactNode }) {
 			isAuthenticated: device.status === 'success' && !!device.token,
 			user: device.user,
 			authorization,
-			getAccessToken: () =>
-				device.token
-					? Promise.resolve(device.token)
-					: // authTokenContext expects an object with an `error` property.
-						Promise.reject({ error: 'login_required' }),
+			getAccessToken: () => {
+				if (device.token) return Promise.resolve(device.token);
+				// Reject with an Error (lint: prefer-promise-reject-errors) that still
+				// carries the `error` property authTokenContext reads.
+				return Promise.reject(
+					Object.assign(new Error('login_required'), {
+						error: 'login_required',
+					}),
+				);
+			},
 			login: device.start,
 			logout: device.logout,
 		};

--- a/frontend/src/contexts/appAuthContext.tsx
+++ b/frontend/src/contexts/appAuthContext.tsx
@@ -1,0 +1,201 @@
+/**
+ * Provider-neutral auth session.
+ *
+ * `AppInner` consumes `useAppAuth()` instead of calling `useAuth0()` directly, so the
+ * visible login state (loading / authenticated / user / buttons) is decoupled from any
+ * one provider. Three adapters supply the same `AppAuthSession` shape:
+ *
+ *   - Auth0AuthProvider   (default everywhere; preserves current behavior)
+ *   - BetterAuthProvider  (opt-in: standalone editor + ?auth=betterauth)
+ *   - DemoAuthProvider    (OverallMode.demo)
+ *
+ * Hook-rule safety: we never call adapter hooks conditionally. `AppAuthProvider` chooses
+ * WHICH provider component to render; each component unconditionally calls its own hooks
+ * and is only mounted when selected.
+ *
+ * SCAFFOLDING: `Auth0AuthProvider`, `DemoAuthProvider`, and the `AppAuthProvider`
+ * selector are temporary compatibility shims that let Auth0 and Better Auth coexist
+ * during migration. Once Better Auth becomes the default, this collapses into a single
+ * Better Auth-only provider and the selector/adapters can be removed.
+ */
+import { type Auth0ContextInterface, useAuth0 } from '@auth0/auth0-react';
+import { useAtomValue } from 'jotai';
+import {
+	createContext,
+	useContext,
+	useMemo,
+	type ReactNode,
+} from 'react';
+import { detectPlatform } from '@/api';
+import { AccessTokenProvider } from '@/contexts/authTokenContext';
+import { EditorContext } from '@/contexts/editorContext';
+import { OverallMode, overallModeAtom } from '@/contexts/pageContext';
+import { useDeviceAuth } from '@/hooks/useDeviceAuth';
+
+export interface AppAuthSession {
+	provider: 'auth0' | 'betterauth' | 'demo';
+	isLoading: boolean; // initial session/provider loading only
+	isAuthorizing: boolean; // device polling in progress (NOT isLoading)
+	isAuthenticated: boolean; // token present AND user loaded
+	user?: { name?: string; email?: string };
+	error?: Error; // provider-level error (e.g. Auth0 error screen)
+	authorization?: {
+		status: 'pending' | 'polling' | 'error';
+		userCode?: string;
+		verificationUri?: string;
+		error?: string;
+	};
+	getAccessToken: () => Promise<string>;
+	login: () => Promise<void>;
+	logout: () => Promise<void>;
+}
+
+const DEFAULT_SESSION: AppAuthSession = {
+	provider: 'auth0',
+	isLoading: false,
+	isAuthorizing: false,
+	isAuthenticated: false,
+	getAccessToken: () => {
+		console.warn('getAccessToken called before AppAuthProvider initialized');
+		return Promise.resolve('');
+	},
+	login: () => Promise.resolve(),
+	logout: () => Promise.resolve(),
+};
+
+const AppAuthContext = createContext<AppAuthSession>(DEFAULT_SESSION);
+
+export const useAppAuth = (): AppAuthSession => useContext(AppAuthContext);
+
+/** True only on the standalone editor with the explicit opt-in query param. */
+function isBetterAuthOptIn(): boolean {
+	if (typeof window === 'undefined') return false;
+	if (detectPlatform() !== 'standalone') return false;
+	return new URLSearchParams(window.location.search).get('auth') === 'betterauth';
+}
+
+// --- Auth0 adapter -------------------------------------------------------------
+
+function Auth0AuthProvider({ children }: { children: ReactNode }) {
+	const auth0 = useAuth0();
+	const editorAPI = useContext(EditorContext);
+
+	const session = useMemo<AppAuthSession>(() => {
+		const client = auth0 as Auth0ContextInterface;
+		return {
+			provider: 'auth0',
+			isLoading: auth0.isLoading,
+			isAuthorizing: false,
+			isAuthenticated: auth0.isAuthenticated,
+			user: auth0.user
+				? { name: auth0.user.name, email: auth0.user.email }
+				: undefined,
+			error: auth0.error,
+			getAccessToken: auth0.getAccessTokenSilently,
+			login: () => editorAPI.doLogin(client),
+			logout: () => editorAPI.doLogout(client),
+		};
+	}, [auth0, editorAPI]);
+
+	return (
+		<AppAuthContext.Provider value={session}>
+			{children}
+		</AppAuthContext.Provider>
+	);
+}
+
+// --- Better Auth adapter -------------------------------------------------------
+
+function BetterAuthProvider({ children }: { children: ReactNode }) {
+	const device = useDeviceAuth();
+
+	const session = useMemo<AppAuthSession>(() => {
+		const isAuthorizing =
+			device.status === 'pending' || device.status === 'polling';
+
+		// authorization block is present only while a flow is active or errored;
+		// idle/success are represented by omitting it.
+		let authorization: AppAuthSession['authorization'];
+		if (device.status === 'pending') {
+			authorization = { status: 'pending' };
+		} else if (device.status === 'polling') {
+			authorization = {
+				status: 'polling',
+				userCode: device.userCode,
+				verificationUri: device.verificationUri,
+			};
+		} else if (device.status === 'error') {
+			authorization = { status: 'error', error: device.error };
+		}
+
+		return {
+			provider: 'betterauth',
+			isLoading: false,
+			isAuthorizing,
+			isAuthenticated: device.status === 'success' && !!device.token,
+			user: device.user,
+			authorization,
+			getAccessToken: () =>
+				device.token
+					? Promise.resolve(device.token)
+					: // authTokenContext expects an object with an `error` property.
+						Promise.reject({ error: 'login_required' }),
+			login: device.start,
+			logout: device.logout,
+		};
+	}, [device]);
+
+	return (
+		<AppAuthContext.Provider value={session}>
+			{children}
+		</AppAuthContext.Provider>
+	);
+}
+
+// --- Demo adapter --------------------------------------------------------------
+
+function DemoAuthProvider({ children }: { children: ReactNode }) {
+	const session = useMemo<AppAuthSession>(
+		() => ({
+			provider: 'demo',
+			isLoading: false,
+			isAuthorizing: false,
+			isAuthenticated: true,
+			getAccessToken: () => Promise.resolve('demo-access-token'),
+			login: () => Promise.resolve(),
+			logout: () => Promise.resolve(),
+		}),
+		[],
+	);
+
+	return (
+		<AppAuthContext.Provider value={session}>
+			{children}
+		</AppAuthContext.Provider>
+	);
+}
+
+// --- Selector + token bridge ---------------------------------------------------
+
+/** Renders exactly one adapter provider by mode + opt-in. */
+export function AppAuthProvider({ children }: { children: ReactNode }) {
+	const mode = useAtomValue(overallModeAtom);
+
+	if (mode === OverallMode.demo) {
+		return <DemoAuthProvider>{children}</DemoAuthProvider>;
+	}
+	if (isBetterAuthOptIn()) {
+		return <BetterAuthProvider>{children}</BetterAuthProvider>;
+	}
+	return <Auth0AuthProvider>{children}</Auth0AuthProvider>;
+}
+
+/** Feeds the selected session's getAccessToken into the existing token context. */
+export function AppAuthTokenBridge({ children }: { children: ReactNode }) {
+	const session = useAppAuth();
+	return (
+		<AccessTokenProvider getAccessTokenSilently={session.getAccessToken}>
+			{children}
+		</AccessTokenProvider>
+	);
+}

--- a/frontend/src/hooks/useDeviceAuth.ts
+++ b/frontend/src/hooks/useDeviceAuth.ts
@@ -157,14 +157,16 @@ export function useDeviceAuth(): UseDeviceAuth {
 		if (mountedRef.current) setState(INITIAL);
 	}, [abortInFlight]);
 
-	useEffect(
-		() => () => {
+	useEffect(() => {
+		// Set on mount (and reset on StrictMode remount) so safeSet isn't permanently
+		// disabled after StrictMode's mount→unmount→remount cycle in development.
+		mountedRef.current = true;
+		return () => {
 			mountedRef.current = false;
 			abortRef.current?.abort();
 			abortRef.current = null;
-		},
-		[],
-	);
+		};
+	}, []);
 
 	return { ...state, start, reset, logout };
 }

--- a/frontend/src/hooks/useDeviceAuth.ts
+++ b/frontend/src/hooks/useDeviceAuth.ts
@@ -1,0 +1,170 @@
+/**
+ * React hook driving the interactive Better Auth device flow.
+ *
+ * Owns the state machine and an in-memory access token (never persisted). Polling is
+ * cancellable: reset(), logout(), unmount, or a fresh start() abort the in-flight loop
+ * via an AbortController so a stale tick cannot deliver a token after the user leaves.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+	type DeviceCodeResponse,
+	type ProtectedUser,
+	fetchProtectedUser,
+	pollForToken,
+	requestDeviceCode,
+	signOut as signOutRequest,
+} from '@/api/deviceAuth';
+
+export type DeviceAuthStatus =
+	| 'idle'
+	| 'pending' // requesting the device code
+	| 'polling' // waiting for the user to approve in the browser
+	| 'success'
+	| 'error';
+
+export interface DeviceAuthState {
+	status: DeviceAuthStatus;
+	userCode?: string;
+	verificationUri?: string;
+	/** Present only on status==='success'. Held in memory only. */
+	token?: string;
+	user?: ProtectedUser;
+	error?: string;
+}
+
+export interface UseDeviceAuth extends DeviceAuthState {
+	/** Begin (or restart) the device flow. Aborts any in-flight attempt first. */
+	start: () => Promise<void>;
+	/** Cancel any in-flight flow and return to idle, clearing the token. */
+	reset: () => void;
+	/** Best-effort server sign-out, then clear local state. */
+	logout: () => Promise<void>;
+}
+
+const INITIAL: DeviceAuthState = { status: 'idle' };
+
+export function useDeviceAuth(): UseDeviceAuth {
+	const [state, setState] = useState<DeviceAuthState>(INITIAL);
+	const abortRef = useRef<AbortController | null>(null);
+	// Mirror the token in a ref so logout() can read it without a stale closure.
+	const tokenRef = useRef<string | undefined>(undefined);
+	const mountedRef = useRef(true);
+
+	const abortInFlight = useCallback(() => {
+		abortRef.current?.abort();
+		abortRef.current = null;
+	}, []);
+
+	// Only commit state if still mounted and this controller is the active one.
+	const safeSet = useCallback(
+		(controller: AbortController, next: Partial<DeviceAuthState>) => {
+			if (!mountedRef.current || abortRef.current !== controller) return;
+			setState((prev) => ({ ...prev, ...next }));
+		},
+		[],
+	);
+
+	const reset = useCallback(() => {
+		abortInFlight();
+		tokenRef.current = undefined;
+		if (mountedRef.current) setState(INITIAL);
+	}, [abortInFlight]);
+
+	const start = useCallback(async () => {
+		// Abort any prior attempt and open a fresh controller.
+		abortInFlight();
+		const controller = new AbortController();
+		abortRef.current = controller;
+		tokenRef.current = undefined;
+
+		setState({ status: 'pending' });
+
+		let code: DeviceCodeResponse;
+		try {
+			code = await requestDeviceCode(controller.signal);
+		} catch (e) {
+			if (controller.signal.aborted) return;
+			safeSet(controller, {
+				status: 'error',
+				error: (e as Error).message,
+			});
+			return;
+		}
+
+		safeSet(controller, {
+			status: 'polling',
+			userCode: code.user_code,
+			verificationUri: code.verification_uri_complete,
+		});
+
+		const result = await pollForToken(
+			code.device_code,
+			code.interval,
+			controller.signal,
+		);
+
+		switch (result.type) {
+			case 'aborted':
+				return;
+			case 'denied':
+				safeSet(controller, {
+					status: 'error',
+					error: 'Access denied. The request was not approved.',
+				});
+				return;
+			case 'expired':
+				safeSet(controller, {
+					status: 'error',
+					error: 'The code expired. Start sign-in again.',
+				});
+				return;
+			case 'error':
+				safeSet(controller, { status: 'error', error: result.message });
+				return;
+			case 'token':
+				break;
+		}
+
+		// Token acquired — verify it and load the user identity.
+		try {
+			const user = await fetchProtectedUser(
+				result.accessToken,
+				controller.signal,
+			);
+			tokenRef.current = result.accessToken;
+			safeSet(controller, {
+				status: 'success',
+				token: result.accessToken,
+				user,
+			});
+		} catch (e) {
+			if (controller.signal.aborted) return;
+			safeSet(controller, {
+				status: 'error',
+				error: `Token verification failed: ${(e as Error).message}`,
+			});
+		}
+	}, [abortInFlight, safeSet]);
+
+	const logout = useCallback(async () => {
+		const token = tokenRef.current;
+		abortInFlight();
+		if (token) {
+			// Best-effort; server-side invalidation is verified separately.
+			await signOutRequest(token);
+		}
+		tokenRef.current = undefined;
+		if (mountedRef.current) setState(INITIAL);
+	}, [abortInFlight]);
+
+	useEffect(
+		() => () => {
+			mountedRef.current = false;
+			abortRef.current?.abort();
+			abortRef.current = null;
+		},
+		[],
+	);
+
+	return { ...state, start, reset, logout };
+}

--- a/frontend/src/hooks/useDeviceAuth.ts
+++ b/frontend/src/hooks/useDeviceAuth.ts
@@ -48,18 +48,16 @@ export function useDeviceAuth(): UseDeviceAuth {
 	const abortRef = useRef<AbortController | null>(null);
 	// Mirror the token in a ref so logout() can read it without a stale closure.
 	const tokenRef = useRef<string | undefined>(undefined);
-	const mountedRef = useRef(true);
-
 	const abortInFlight = useCallback(() => {
 		abortRef.current?.abort();
 		abortRef.current = null;
 	}, []);
 
-	// Only commit state if still mounted and this controller is the active one.
+	// Only commit state if this async attempt has not been aborted.
 	const safeSet = useCallback(
-		(controller: AbortController, next: Partial<DeviceAuthState>) => {
-			if (!mountedRef.current || abortRef.current !== controller) return;
-			setState((prev) => ({ ...prev, ...next }));
+		(controller: AbortController, next: DeviceAuthState) => {
+			if (controller.signal.aborted) return;
+			setState(next);
 		},
 		[],
 	);
@@ -67,7 +65,7 @@ export function useDeviceAuth(): UseDeviceAuth {
 	const reset = useCallback(() => {
 		abortInFlight();
 		tokenRef.current = undefined;
-		if (mountedRef.current) setState(INITIAL);
+		setState(INITIAL);
 	}, [abortInFlight]);
 
 	const start = useCallback(async () => {
@@ -149,20 +147,24 @@ export function useDeviceAuth(): UseDeviceAuth {
 	const logout = useCallback(async () => {
 		const token = tokenRef.current;
 		abortInFlight();
-		if (token) {
-			// Best-effort; server-side invalidation is verified separately.
-			await signOutRequest(token);
+		// Best-effort; server-side invalidation is verified separately.
+		try {
+			if (token) {
+				await signOutRequest(token);
+			}
+		} catch { 
+			// Best-effort, ignore server sign-out failure. Clear local state regardless.
+		} finally {
+			// Clear local state regardless of sign-out success, since the token is the only proof of auth.
+			tokenRef.current = undefined;
+			setState(INITIAL);
 		}
-		tokenRef.current = undefined;
-		if (mountedRef.current) setState(INITIAL);
 	}, [abortInFlight]);
 
 	useEffect(() => {
-		// Set on mount (and reset on StrictMode remount) so safeSet isn't permanently
-		// disabled after StrictMode's mount→unmount→remount cycle in development.
-		mountedRef.current = true;
+		// Abort any in-flight device flow when the component unmounts. 
+		// The signal is the source of truth so no mounted flag is needed.
 		return () => {
-			mountedRef.current = false;
 			abortRef.current?.abort();
 			abortRef.current = null;
 		};

--- a/frontend/src/hooks/useDeviceAuth.ts
+++ b/frontend/src/hooks/useDeviceAuth.ts
@@ -92,7 +92,9 @@ export function useDeviceAuth(): UseDeviceAuth {
 		safeSet(controller, {
 			status: 'polling',
 			userCode: code.user_code,
-			verificationUri: code.verification_uri_complete,
+			// Generic page with NO code in the URL — the user reads the code from here
+			// and types it on the approval page (intent/anti-phishing hardening).
+			verificationUri: code.verification_uri,
 		});
 
 		const result = await pollForToken(

--- a/frontend/src/hooks/useDeviceAuth.ts
+++ b/frontend/src/hooks/useDeviceAuth.ts
@@ -8,8 +8,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
 	type DeviceCodeResponse,
-	type ProtectedUser,
-	fetchProtectedUser,
+	type UserInfo,
+	fetchUserInfo,
 	pollForToken,
 	requestDeviceCode,
 	signOut as signOutRequest,
@@ -28,7 +28,7 @@ export interface DeviceAuthState {
 	verificationUri?: string;
 	/** Present only on status==='success'. Held in memory only. */
 	token?: string;
-	user?: ProtectedUser;
+	user?: UserInfo;
 	error?: string;
 }
 
@@ -127,7 +127,7 @@ export function useDeviceAuth(): UseDeviceAuth {
 
 		// Token acquired — verify it and load the user identity.
 		try {
-			const user = await fetchProtectedUser(
+			const user = await fetchUserInfo(
 				result.accessToken,
 				controller.signal,
 			);

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -64,22 +64,48 @@ function DeviceAuthStatus({
 
 	// polling
 	return (
-		<div className={classes.loginInfoContainer}>
-			<p>
-				Your code: <strong>{authorization.userCode}</strong>
+		<div
+			className={classes.loginInfoContainer}
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				alignItems: 'center',
+				textAlign: 'center',
+			}}
+		>
+			<p style={{ margin: 0 }}>Your code:</p>
+			<p
+				style={{
+					fontFamily: 'monospace',
+					fontSize: '1.35rem',
+					fontWeight: 700,
+					letterSpacing: '0.12em',
+					margin: '0.25rem 0 0.75rem',
+				}}
+			>
+				{authorization.userCode}
 			</p>
 			{authorization.verificationUri ? (
-				<p>
+				<p style={{ margin: '0.25rem 0 0.75rem' }}>
 					<a
 						href={authorization.verificationUri}
 						target="_blank"
 						rel="noopener noreferrer"
+						style={{
+							display: 'inline-block',
+							padding: '0.5rem 1.1rem',
+							borderRadius: '6px',
+							background: '#2563eb',
+							color: '#fff',
+							fontWeight: 600,
+							textDecoration: 'none',
+						}}
 					>
 						Open approval page →
 					</a>
 				</p>
 			) : null}
-			<p>Waiting for approval…</p>
+			<p>Open the approval page and enter the code above to continue.</p>
 		</div>
 	);
 }

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -1,15 +1,16 @@
-import { Auth0Provider, useAuth0 } from '@auth0/auth0-react';
+import { Auth0Provider } from '@auth0/auth0-react';
 import { PostHogProvider, PostHogErrorBoundary } from '@posthog/react';
 import { useWindowSize } from '@react-hook/window-size/throttled';
 import { useAtomValue } from 'jotai';
-import { useContext, useState } from 'react';
+import { useState } from 'react';
 import { CgFacebook, CgGoogle, CgMicrosoft } from 'react-icons/cg';
 import {
-	AccessTokenProvider,
-	useAccessToken,
-} from '@/contexts/authTokenContext';
+	AppAuthProvider,
+	AppAuthTokenBridge,
+	useAppAuth,
+} from '@/contexts/appAuthContext';
+import { useAccessToken } from '@/contexts/authTokenContext';
 import ChatContextWrapper from '@/contexts/chatContext';
-import { EditorContext } from '@/contexts/editorContext';
 import {
 	OverallMode,
 	overallModeAtom,
@@ -30,14 +31,67 @@ const POSTHOG_KEY = 'phc_p3Br0zRnw7PdTVpdNI92vvBTWcBBY0jvkHO8dNvkCTl';
 const POSTHOG_HOST = 'https://e.thoughtful-ai.com/';
 const POSTHOG_ENABLED = true;
 
+// Device-flow status surfaced during Better Auth sign-in. Shows the user code and a
+// user-clicked link that opens the approval page in a new tab (no focus-stealing).
+// Rendered inside the not-logged-in screen, NOT gated by the isLoading "Waiting" screen.
+function DeviceAuthStatus({
+	authorization,
+}: {
+	authorization?: {
+		status: 'pending' | 'polling' | 'error';
+		userCode?: string;
+		verificationUri?: string;
+		error?: string;
+	};
+}) {
+	if (!authorization) return null;
+
+	if (authorization.status === 'error') {
+		return (
+			<div className={classes.loginInfoContainer}>
+				<p>Sign-in failed: {authorization.error}</p>
+			</div>
+		);
+	}
+
+	if (authorization.status === 'pending') {
+		return (
+			<div className={classes.loginInfoContainer}>
+				<p>Requesting device code…</p>
+			</div>
+		);
+	}
+
+	// polling
+	return (
+		<div className={classes.loginInfoContainer}>
+			<p>
+				Your code: <strong>{authorization.userCode}</strong>
+			</p>
+			{authorization.verificationUri ? (
+				<p>
+					<a
+						href={authorization.verificationUri}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Open approval page →
+					</a>
+				</p>
+			) : null}
+			<p>Waiting for approval…</p>
+		</div>
+	);
+}
+
 function AppInner() {
 	const mode = useAtomValue(overallModeAtom);
 	const noAuthMode = mode !== OverallMode.full;
-	const auth0Client = useAuth0();
-	const { isLoading, error, isAuthenticated, user } = auth0Client;
+	const session = useAppAuth();
+	const { isLoading, isAuthorizing, error, isAuthenticated, user, authorization } =
+		session;
 	const [width, _height] = useWindowSize();
 	const page = useAtomValue(pageNameAtom);
-	const editorAPI = useContext(EditorContext);
 	const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState(() => {
 		return localStorage.getItem('hasCompletedOnboarding') === 'true';
 	});
@@ -121,12 +175,15 @@ function AppInner() {
 							color="primary"
 							variant="solid"
 							size="large"
+							loading={isAuthorizing}
 							onClick={() => {
-								void editorAPI.doLogin(auth0Client);
+								void session.login();
 							}}
 						>
 							Login
 						</Button>
+
+						<DeviceAuthStatus authorization={authorization} />
 
 						<div className={classes.loginInfoContainer}>
 							<p>
@@ -217,7 +274,7 @@ function AppInner() {
 					variant="outline"
 					onClick={() => {
 						console.log('origin', window.location.origin);
-						editorAPI.doLogout(auth0Client);
+						void session.logout();
 					}}
 				>
 					Sign Out
@@ -257,7 +314,7 @@ function AppInner() {
 							variant="solid"
 							onClick={() => {
 								// do login again
-								void editorAPI.doLogin(auth0Client);
+								void session.login();
 							}}
 						>
 							Reauthorize
@@ -268,7 +325,7 @@ function AppInner() {
 						variant="outline"
 						onClick={() => {
 							console.log('origin', window.location.origin);
-							editorAPI.doLogout(auth0Client);
+							void session.logout();
 						}}
 					>
 						Sign Out
@@ -322,14 +379,9 @@ function AppWithProviders({
 }
 
 export default function App() {
-	// If demo mode is enabled, we use a mock access token provider
-	const mode = useAtomValue(overallModeAtom);
-	const needAuth = mode === OverallMode.full;
-
-	const AccessTokenProvider = needAuth
-		? Auth0AccessTokenProviderWrapper
-		: DemoAccessTokenProviderWrapper;
-
+	// Auth0Provider stays mounted always (harmless when unused). AppAuthProvider selects
+	// the active session adapter (Auth0 / Better Auth / Demo); AppAuthTokenBridge feeds
+	// the chosen session's getAccessToken into the existing token context.
 	return (
 		<AppWithProviders>
 			<ChatContextWrapper>
@@ -347,41 +399,14 @@ export default function App() {
 							leeway: 10,
 						}}
 					>
-						<AccessTokenProvider>
-							<AppInner />
-						</AccessTokenProvider>
+						<AppAuthProvider>
+							<AppAuthTokenBridge>
+								<AppInner />
+							</AppAuthTokenBridge>
+						</AppAuthProvider>
 					</Auth0Provider>
 				</Reshaped>
 			</ChatContextWrapper>
 		</AppWithProviders>
-	);
-}
-
-function DemoAccessTokenProviderWrapper({
-	children,
-}: {
-	children: React.ReactNode;
-}) {
-	const getAccessTokenSilently = () => {
-		// Simulate a token retrieval for demo purposes
-		return Promise.resolve('demo-access-token');
-	};
-	return (
-		<AccessTokenProvider getAccessTokenSilently={getAccessTokenSilently}>
-			{children}
-		</AccessTokenProvider>
-	);
-}
-
-function Auth0AccessTokenProviderWrapper({
-	children,
-}: {
-	children: React.ReactNode;
-}) {
-	const { getAccessTokenSilently } = useAuth0();
-	return (
-		<AccessTokenProvider getAccessTokenSilently={getAccessTokenSilently}>
-			{children}
-		</AccessTokenProvider>
 	);
 }

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -160,6 +160,11 @@ module.exports = async (env = {}, options = {}) => {
 			new webpack.DefinePlugin({
 				'process.env.AUTH0_DOMAIN': JSON.stringify('dev-rbroo1fvav24wamu.us.auth0.com'),
 				'process.env.AUTH0_CLIENT_ID': JSON.stringify('YZhokQZRgE2YUqU5Is9LcaMiCzujoaVr'),
+				// Device-flow client ID; must match a value in the backend's
+				// BETTER_AUTH_DEVICE_CLIENT_IDS allowlist. Override via env for other envs.
+				'process.env.BETTER_AUTH_DEVICE_CLIENT_ID': JSON.stringify(
+					process.env.BETTER_AUTH_DEVICE_CLIENT_ID || 'writing-tools-editor-dev'
+				),
 			})
 		],
 		devServer: {


### PR DESCRIPTION
## Summary

This PR adds a Better Auth device-flow path to the standalone editor frontend while keeping Auth0 as the default authentication path, and hardens the device approval flow to require manual user-code entry.

The goal is to prove that the real editor can authenticate through the new Better Auth backend/device authorization flow before removing Auth0.

## What changed

- Added frontend device authorization helpers for:
  - requesting a device code
  - polling for the Better Auth token
  - calling `/api/protected` with the returned Bearer token
- Added a React hook for managing the device auth state.
- Added an app-level auth context that can select between:
  - existing Auth0 behavior
  - existing demo behavior
  - Better Auth device flow when explicitly enabled
- Added a Better Auth path for the standalone editor behind:

  `?auth=betterauth`

- Preserved Auth0 as the default behavior.

## Manual user-code entry hardening

Later commits harden the device approval flow against pre-filled-link phishing — the user must read the code from the taskpane and type it into the browser, so the code is never carried in the approval URL.

- **Backend `auth.ts`**: device code `expiresIn` tightened `10m` → `4m` (smaller brute-force window; code keeps the default 8-char length). Google provider set to `prompt: 'select_account'` so the account chooser always appears.
- **Backend `device-approval.ts`**: sign-in first, then a code-entry input (normalized, claims/approves the typed code, retry on a bad code). The page no longer reads `user_code` from the URL. Shows **"Signed in as <email>"** plus a **"Use a different account"** link (sign out + re-auth) so the user can switch accounts before approving.
- **Backend `device-taskpane.ts`** (debug): opens `verification_uri` (no code) to match.
- **Frontend**: `useDeviceAuth` surfaces `verification_uri` (no code) instead of `verification_uri_complete`; the taskpane shows the code prominently with a clearer "Open approval page" button.

No schema change. No per-code attempt lockout yet — low practical risk at 8 chars + 4-minute expiry; tracked as the next hardening step before any broader rollout.

## Manual verification

Tested end to end in the standalone editor:

1. Started the backend with Better Auth/device authorization enabled.
2. Started the frontend dev server.
3. Opened `https://localhost:3000/editor.html?page=editor&auth=betterauth`.
4. Clicked login.
5. Completed Google sign-in through the device approval flow, entering the code shown in the taskpane on the approval page.
6. Confirmed the editor authenticated successfully and showed the signed-in user as `Nhyira Mante`.

## Non-goals

This PR does not remove Auth0 yet.

It also does not:
- protect the OpenAI routes
- change Google Docs auth behavior
- change Word taskpane auth behavior
- persist Better Auth tokens across refreshes
- make Better Auth the default for every surface
- add a per-code brute-force lockout (deferred)

## Housekeeping

- Renamed `ProtectedUser` -> `UserInfo` and `fetchProtectedUser` -> `fetchUserInfo` in the device-flow client for clearer, reusable names (the `/api/protected` route and error messages are unchanged).

## Follow-up

A follow-up branch removes Auth0 from the frontend and makes Better Auth the default authentication path now that the Better Auth flow has been proven in the standalone editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
