### PR TITLE
Per-user LLM cost metering, on an authenticated proxy

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -9,9 +9,33 @@ thin: it proxies OpenAI requests with the server-held API key and writes study l
 
 ## Aspects
 
-- **OpenAI proxy** (`src/app.ts`): `POST /api/openai/chat/completions` injects
-  `OPENAI_API_KEY` and streams the upstream SSE response through unchanged. The
-  frontend's ai-sdk client builds the prompts and points at this route.
+- **Database** (`src/db.ts`): one SQLite file — `<DATA_DIR>/app.db` — on one shared
+  connection, holding Better Auth's tables *and* ours. Better Auth manages its own
+  schema (it introspects); our tables are versioned with `PRAGMA user_version` steps in
+  `MIGRATIONS`. **To change our schema, append a step — never edit an existing one**
+  (deployed DBs have already run it and will skip it forever). `src/migrate.ts` applies
+  both schemas and is the deploy-time entrypoint (k8s initContainer). A pre-existing
+  `auth.db` (the old name, when Better Auth was the only tenant) is renamed to `app.db`
+  on first open, siblings included.
+- **OpenAI proxy** (`src/openaiProxy.ts`): `POST /api/openai/chat/completions` injects a
+  server-held API key and streams the upstream SSE response through unchanged. The
+  frontend's ai-sdk client builds the prompts and points at this route, sending the
+  session token as its bearer. `attributeRequest` decides **which key pays**, and the
+  usage bucket always names the key that was charged so the summary reconciles against
+  the right invoice: a session → `OPENAI_API_KEY`, metered to that user; no session →
+  `OPENAI_DEMO_API_KEY` (the capped Thoughtful-demo project), metered to `demo` — this
+  is how demo mode and the pre-sign-in editor work; no session and no demo key → 401 if
+  auth is on (fail closed), else the main key metered to `anonymous` (local dev).
+- **Usage metering** (`src/usage.ts`, `src/pricing.ts`): every proxied model request
+  writes a content-free row (user, model, token counts, status) to the `llm_usage`
+  table. Streaming responses are `tee()`d so usage can be read from the
+  terminal SSE event — which is also why the proxy forces `stream_options.include_usage`
+  on Chat Completions requests. Metering sits *outside* the consent levels in
+  `consent.ts`: it's billing data, kept even at level `none`. `GET /api/usage_summary`
+  (gated by `LOG_SECRET`) breaks spend down by user; dollars are computed at read time
+  from the hand-maintained rate table in `pricing.ts`, so **an unlisted model reports
+  `cost: null` until you add its rates**. Account deletion anonymizes these rows rather
+  than dropping them (see `anonymizeUserUsage`).
 - **Logging** (`src/logging.ts`): structured JSONL to `backend/logs/<username>.jsonl`,
   same shape/location the Python backend used. `validateUsername` is the
   path-traversal guard. Log-viewer endpoints (`/api/logs_poll`, `/api/download_logs`)
@@ -24,9 +48,10 @@ thin: it proxies OpenAI requests with the server-held API key and writes study l
   (they reference content-hashed bundles by name), `immutable` for hashed assets.
 - **Telemetry** (`src/posthog.ts`): optional PostHog error capture; a no-op when
   `POSTHOG_PROJECT_TOKEN` is unset.
-- **Auth**: none in the backend (unchanged from before). Auth0 still lives in the
-  frontend. Replacing it (Better-Auth device-code) is deferred — see
-  `docs/js-backend-plan.md`.
+- **Auth** (`src/auth.ts`): Better Auth (Google sign-in + device-code flow for the
+  add-in), on the shared `app.db`, enabled by `BETTER_AUTH_ENABLED=true`. Carries the
+  user's `loggingConsent` level as a user field; `beforeDelete` purges study logs and
+  anonymizes usage rows.
 
 ## Commands
 
@@ -37,9 +62,14 @@ thin: it proxies OpenAI requests with the server-held API key and writes study l
 
 ## Env vars
 
-`OPENAI_API_KEY` (required to proxy), `LOG_SECRET` (required for log-viewer routes),
-`PORT`, `DEBUG`, `POSTHOG_PROJECT_TOKEN`, `POSTHOG_HOST`, `LOG_DIR` (defaults to
-`./logs`). For local dev, run `python scripts/get_env.py` to generate `backend/.env`.
+`OPENAI_API_KEY` (required to proxy), `OPENAI_DEMO_API_KEY` (Thoughtful-demo project;
+pays for sessionless requests — without it they're refused wherever auth is on),
+`LOG_SECRET` (required for log-viewer + `/api/usage_summary`), `DATA_DIR` (root for
+`app.db` + `logs/`), `PORT`, `DEBUG`, `POSTHOG_PROJECT_TOKEN`, `POSTHOG_HOST`, `LOG_DIR`
+(overrides just the logs subdir). Auth: `BETTER_AUTH_ENABLED`, `BETTER_AUTH_SECRET`,
+`BETTER_AUTH_URL`, `BETTER_AUTH_TRUSTED_ORIGINS`, `GOOGLE_CLIENT_ID`,
+`GOOGLE_CLIENT_SECRET`. For local dev, run `python scripts/get_env.py` to generate
+`backend/.env`.
 
 ## Analysis tooling
 

--- a/backend/src/__tests__/app.test.ts
+++ b/backend/src/__tests__/app.test.ts
@@ -1,14 +1,7 @@
 import { mkdtemp, readFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import {
-	afterEach,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	vi,
-} from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createApp } from '../app.js';
 import type { Auth } from '../auth.js';
 
@@ -175,13 +168,13 @@ describe('POST /api/me/consent', () => {
 	});
 });
 
-describe('DELETE /api/me/data', () => {
-	it("deletes the authenticated user's log file", async () => {
+describe('DELETE /api/me/activity', () => {
+	it("erases the authenticated user's logged activity", async () => {
 		const { app: authApp } = makeAuthApp({
 			id: 'usr-del',
 			loggingConsent: 'document',
 		});
-		// Write a log entry, confirm it exists, then delete.
+		// Write a log entry, confirm it exists, then erase.
 		await authApp.request('/api/log', {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
@@ -189,9 +182,15 @@ describe('DELETE /api/me/data', () => {
 		});
 		await readUserLog('usr-del'); // throws if missing
 
-		const res = await authApp.request('/api/me/data', { method: 'DELETE' });
+		const res = await authApp.request('/api/me/activity', { method: 'DELETE' });
 		expect(res.status).toBe(200);
 		await expect(readUserLog('usr-del')).rejects.toThrow();
+	});
+
+	it('401s without a session', async () => {
+		const { app: authApp } = makeAuthApp(null);
+		const res = await authApp.request('/api/me/activity', { method: 'DELETE' });
+		expect(res.status).toBe(401);
 	});
 });
 

--- a/backend/src/__tests__/db.test.ts
+++ b/backend/src/__tests__/db.test.ts
@@ -1,0 +1,95 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, db } from '../db.js';
+
+const env = { ...process.env };
+let dataDir: string;
+
+beforeEach(async () => {
+	dataDir = await mkdtemp(path.join(tmpdir(), 'wt-db-'));
+	process.env.DATA_DIR = dataDir;
+});
+
+afterEach(() => {
+	closeDb();
+	process.env = { ...env };
+});
+
+describe('migrations', () => {
+	it('creates our schema and records the version', () => {
+		const conn = db();
+		expect(conn.pragma('user_version', { simple: true })).toBe(1);
+
+		// The table is usable, not merely declared.
+		const table = conn
+			.prepare(
+				`SELECT name FROM sqlite_master WHERE type='table' AND name='llm_usage'`,
+			)
+			.get();
+		expect(table).toBeDefined();
+	});
+
+	it('is idempotent across reopens — a second open re-runs nothing', () => {
+		db()
+			.prepare(
+				`INSERT INTO llm_usage (ts, user_id, provider, endpoint, model, status, streamed, duration_ms)
+			 VALUES (1, 'usr-1', 'openai', 'chat/completions', 'gpt-4o', 200, 1, 5)`,
+			)
+			.run();
+		closeDb();
+
+		// Reopening must not drop or recreate the table (CREATE TABLE would throw).
+		const conn = db();
+		expect(conn.pragma('user_version', { simple: true })).toBe(1);
+		const rows = conn.prepare(`SELECT COUNT(*) AS n FROM llm_usage`).get() as {
+			n: number;
+		};
+		expect(rows.n).toBe(1);
+	});
+});
+
+describe('legacy auth.db rename', () => {
+	it('adopts an existing auth.db, keeping its rows', () => {
+		// Simulate a deployment created before the rename: an auth.db holding users.
+		const legacy = new Database(path.join(dataDir, 'auth.db'));
+		legacy.exec(`CREATE TABLE user (id TEXT PRIMARY KEY, email TEXT)`);
+		legacy
+			.prepare(`INSERT INTO user (id, email) VALUES ('usr-1', 'a@b.c')`)
+			.run();
+		legacy.close();
+
+		const conn = db();
+
+		// The old file is gone, the new one has the old contents...
+		expect(existsSync(path.join(dataDir, 'auth.db'))).toBe(false);
+		expect(existsSync(path.join(dataDir, 'app.db'))).toBe(true);
+		const user = conn
+			.prepare(`SELECT email FROM user WHERE id = 'usr-1'`)
+			.get();
+		expect(user).toEqual({ email: 'a@b.c' });
+
+		// ...and our migrations then run on top of the adopted database.
+		expect(conn.pragma('user_version', { simple: true })).toBe(1);
+	});
+
+	it('leaves an existing app.db alone when a stray auth.db is also present', async () => {
+		// app.db already exists (the rename happened on a previous boot); a stale
+		// auth.db must not clobber it.
+		db()
+			.prepare(
+				`INSERT INTO llm_usage (ts, user_id, provider, endpoint, model, status, streamed, duration_ms)
+			 VALUES (1, 'usr-real', 'openai', 'chat/completions', 'gpt-4o', 200, 1, 5)`,
+			)
+			.run();
+		closeDb();
+		await writeFile(path.join(dataDir, 'auth.db'), 'stale');
+
+		const rows = db().prepare(`SELECT user_id FROM llm_usage`).all();
+		expect(rows).toEqual([{ user_id: 'usr-real' }]);
+		expect(existsSync(path.join(dataDir, 'auth.db'))).toBe(true);
+	});
+});

--- a/backend/src/__tests__/erasure.test.ts
+++ b/backend/src/__tests__/erasure.test.ts
@@ -1,0 +1,114 @@
+import { existsSync } from 'node:fs';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { closeDb } from '../db.js';
+import { eraseLoggedData } from '../erasure.js';
+import { appendLog } from '../logging.js';
+import { deletePosthogPerson } from '../posthog.js';
+import {
+	DELETED_USER_ID,
+	recordUsage,
+	summarizeUsage,
+	type UsageRecord,
+} from '../usage.js';
+
+// PostHog deletion is a network call to their management API; we only care that
+// the erasure paths ask for it.
+vi.mock('../posthog.js', () => ({
+	deletePosthogPerson: vi.fn(async () => {}),
+	captureException: vi.fn(async () => {}),
+}));
+
+const env = { ...process.env };
+
+beforeEach(async () => {
+	const dir = await mkdtemp(path.join(tmpdir(), 'wt-erase-'));
+	process.env.DATA_DIR = dir;
+	process.env.LOG_DIR = path.join(dir, 'logs');
+	vi.mocked(deletePosthogPerson).mockClear();
+});
+
+afterEach(() => {
+	closeDb();
+	process.env = { ...env };
+});
+
+async function logSomething(userId: string) {
+	await appendLog({
+		timestamp: 1,
+		ok: true,
+		username: userId,
+		event: 'saved',
+		extra_data: {},
+	});
+}
+
+function meterSomething(userId: string) {
+	recordUsage({
+		userId,
+		provider: 'openai',
+		endpoint: 'chat/completions',
+		model: 'gpt-4o',
+		inputTokens: 100,
+		cachedInputTokens: 0,
+		outputTokens: 10,
+		reasoningTokens: 0,
+		status: 200,
+		streamed: true,
+		durationMs: 300,
+		ttftMs: 90,
+	} satisfies UsageRecord);
+}
+
+function logExists(userId: string): boolean {
+	return existsSync(
+		path.join(process.env.LOG_DIR as string, `${userId}.jsonl`),
+	);
+}
+
+describe('eraseLoggedData', () => {
+	it('removes the study log and the analytics profile together', async () => {
+		await logSomething('usr-1');
+		expect(logExists('usr-1')).toBe(true);
+
+		await eraseLoggedData('usr-1');
+
+		expect(logExists('usr-1')).toBe(false);
+		expect(deletePosthogPerson).toHaveBeenCalledWith('usr-1');
+	});
+});
+
+describe('account deletion (Better Auth beforeDelete)', () => {
+	it('does everything withdrawal does, and anonymizes the usage rows on top', async () => {
+		// Imported here, not at module load: auth.ts opens the DB as a side effect of
+		// evaluation, so it has to see this test's temp DATA_DIR.
+		process.env.BETTER_AUTH_SECRET = 'x'.repeat(32);
+		process.env.BETTER_AUTH_URL = 'http://localhost:8000';
+		process.env.GOOGLE_CLIENT_ID = 'test';
+		process.env.GOOGLE_CLIENT_SECRET = 'test';
+		const { auth } = await import('../auth.js');
+
+		await logSomething('usr-gone');
+		meterSomething('usr-gone');
+
+		const beforeDelete = auth.options.user?.deleteUser?.beforeDelete;
+		expect(beforeDelete).toBeDefined();
+		// Better Auth hands the hook the full user record; only the id is read.
+		await beforeDelete?.({ id: 'usr-gone' } as never);
+
+		// The withdrawal erasure — this is the half account deletion used to skip.
+		expect(logExists('usr-gone')).toBe(false);
+		expect(deletePosthogPerson).toHaveBeenCalledWith('usr-gone');
+
+		// ...plus the tombstone: the spend survives, detached from the person.
+		const rows = summarizeUsage(0, Date.now() + 1000);
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			userId: DELETED_USER_ID,
+			inputTokens: 100,
+			outputTokens: 10,
+		});
+	});
+});

--- a/backend/src/__tests__/openaiProxy.test.ts
+++ b/backend/src/__tests__/openaiProxy.test.ts
@@ -1,0 +1,499 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from '../app.js';
+import type { Auth } from '../auth.js';
+import { closeDb, db } from '../db.js';
+import {
+	attributeRequest,
+	createSseUsageScanner,
+	parseUsage,
+} from '../openaiProxy.js';
+import {
+	ANONYMOUS_USER_ID,
+	DEMO_USER_ID,
+	summarizeUsage,
+	type UsageSummaryRow,
+} from '../usage.js';
+
+const env = { ...process.env };
+
+/** Better Auth stub: a session for `user`, or none when null. */
+function appWithUser(user: { id: string } | null) {
+	const auth = {
+		handler: async () => new Response(null),
+		api: { getSession: async () => (user ? { user } : null) },
+	} as unknown as Auth;
+	return createApp({ auth });
+}
+
+/** A chat/completions SSE stream ending in the usage event include_usage asks for. */
+const CHAT_SSE = [
+	`data: {"id":"1","model":"gpt-4o-2024-08-06","choices":[{"delta":{"content":"Hi"}}],"usage":null}\n\n`,
+	`data: {"id":"1","model":"gpt-4o-2024-08-06","choices":[],"usage":{"prompt_tokens":120,"completion_tokens":30,"prompt_tokens_details":{"cached_tokens":100},"completion_tokens_details":{"reasoning_tokens":8}}}\n\n`,
+	`data: [DONE]\n\n`,
+];
+
+/** Upstream SSE response, delivered in several chunks so the scanner has to reassemble. */
+function sseResponse(chunks: string[] = CHAT_SSE): Response {
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream({
+		start(controller) {
+			for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+			controller.close();
+		},
+	});
+	return new Response(stream, {
+		status: 200,
+		headers: { 'Content-Type': 'text/event-stream' },
+	});
+}
+
+/**
+ * An SSE response whose first chunk arrives promptly but whose last one lags —
+ * the case where time-to-first-token and total duration diverge.
+ */
+function slowFinishingSseResponse(tailDelayMs: number): Response {
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream({
+		async start(controller) {
+			controller.enqueue(encoder.encode(CHAT_SSE[0] as string));
+			await new Promise((r) => setTimeout(r, tailDelayMs));
+			controller.enqueue(encoder.encode(CHAT_SSE[1] as string));
+			controller.enqueue(encoder.encode(CHAT_SSE[2] as string));
+			controller.close();
+		},
+	});
+	return new Response(stream, {
+		status: 200,
+		headers: { 'Content-Type': 'text/event-stream' },
+	});
+}
+
+/** Streaming usage is metered on a background branch; give it a moment to land. */
+async function waitForUsage(): Promise<UsageSummaryRow[]> {
+	for (let i = 0; i < 50; i++) {
+		const rows = summarizeUsage(0, Date.now() + 1000);
+		if (rows.length > 0) return rows;
+		await new Promise((r) => setTimeout(r, 10));
+	}
+	return [];
+}
+
+/** The raw timing columns, which the (cost-focused) summary doesn't expose. */
+function timingRow(): { duration_ms: number; ttft_ms: number | null } {
+	return db().prepare(`SELECT duration_ms, ttft_ms FROM llm_usage`).get() as {
+		duration_ms: number;
+		ttft_ms: number | null;
+	};
+}
+
+beforeEach(async () => {
+	process.env.DATA_DIR = await mkdtemp(path.join(tmpdir(), 'wt-proxy-'));
+	process.env.OPENAI_API_KEY = 'test-key';
+	process.env.LOG_SECRET = 'test-secret';
+});
+
+afterEach(() => {
+	closeDb();
+	vi.unstubAllGlobals();
+	process.env = { ...env };
+});
+
+describe('parseUsage', () => {
+	it('reads the Chat Completions shape', () => {
+		expect(
+			parseUsage({
+				usage: {
+					prompt_tokens: 120,
+					completion_tokens: 30,
+					prompt_tokens_details: { cached_tokens: 100 },
+					completion_tokens_details: { reasoning_tokens: 8 },
+				},
+			}),
+		).toEqual({
+			inputTokens: 120,
+			cachedInputTokens: 100,
+			outputTokens: 30,
+			reasoningTokens: 8,
+		});
+	});
+
+	it('reads the Responses shape, where usage is nested under `response`', () => {
+		expect(
+			parseUsage({
+				type: 'response.completed',
+				response: {
+					usage: {
+						input_tokens: 7,
+						output_tokens: 2,
+						input_tokens_details: { cached_tokens: 3 },
+						output_tokens_details: { reasoning_tokens: 1 },
+					},
+				},
+			}),
+		).toEqual({
+			inputTokens: 7,
+			cachedInputTokens: 3,
+			outputTokens: 2,
+			reasoningTokens: 1,
+		});
+	});
+
+	it('returns null for the intermediate chunks that carry `usage: null`', () => {
+		expect(parseUsage({ choices: [{ delta: {} }], usage: null })).toBeNull();
+	});
+});
+
+describe('createSseUsageScanner', () => {
+	it('finds the terminal usage event across chunk boundaries', () => {
+		const scanner = createSseUsageScanner();
+		// Split mid-JSON to prove the line buffer reassembles it.
+		const whole = CHAT_SSE.join('');
+		scanner.push(whole.slice(0, 200));
+		scanner.push(whole.slice(200));
+
+		const { usage, model } = scanner.result();
+		expect(usage).toEqual({
+			inputTokens: 120,
+			cachedInputTokens: 100,
+			outputTokens: 30,
+			reasoningTokens: 8,
+		});
+		// The served snapshot, not the alias the client asked for.
+		expect(model).toBe('gpt-4o-2024-08-06');
+	});
+
+	it('ignores [DONE] and non-JSON keepalives', () => {
+		const scanner = createSseUsageScanner();
+		scanner.push(': keepalive\n\ndata: [DONE]\n\n');
+		expect(scanner.result().usage).toBeNull();
+	});
+});
+
+describe('attributeRequest', () => {
+	it('bills a signed-in user to the main key', () => {
+		expect(attributeRequest('usr-1', true)).toEqual({
+			apiKey: 'test-key',
+			userId: 'usr-1',
+		});
+	});
+
+	it('sends sessionless traffic to the capped demo key', () => {
+		process.env.OPENAI_DEMO_API_KEY = 'demo-key';
+		expect(attributeRequest(null, true)).toEqual({
+			apiKey: 'demo-key',
+			userId: DEMO_USER_ID,
+		});
+	});
+
+	it('fails closed when auth is on and no demo key is configured', () => {
+		// Never quietly bill the main key for traffic we can't attribute.
+		expect(attributeRequest(null, true)).toBeNull();
+	});
+
+	it('falls back to the main key in local dev, bucketed apart from demo', () => {
+		expect(attributeRequest(null, false)).toEqual({
+			apiKey: 'test-key',
+			userId: ANONYMOUS_USER_ID,
+		});
+	});
+});
+
+describe('POST /api/openai/chat/completions', () => {
+	it('rejects a sessionless request, with no demo key, without calling OpenAI', async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+
+		const res = await appWithUser(null).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o', stream: true }),
+			},
+		);
+
+		expect(res.status).toBe(401);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('serves a sessionless request on the demo key and meters it to `demo`', async () => {
+		// Demo mode sends a token that isn't a session, so it lands here — the path
+		// that would otherwise 401 once the proxy started requiring auth.
+		process.env.OPENAI_DEMO_API_KEY = 'demo-key';
+		const fetchMock = vi.fn(async (_url: string, _init: RequestInit) =>
+			sseResponse(),
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const res = await appWithUser(null).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: 'Bearer demo-access-token',
+				},
+				body: JSON.stringify({ model: 'gpt-4o', stream: true }),
+			},
+		);
+
+		expect(res.status).toBe(200);
+		await res.text();
+
+		// The demo project's key paid, not the main one.
+		const sentHeaders = fetchMock.mock.calls[0]?.[1]?.headers as
+			| Record<string, string>
+			| undefined;
+		expect(sentHeaders?.Authorization).toBe('Bearer demo-key');
+
+		const rows = await waitForUsage();
+		expect(rows[0]).toMatchObject({ userId: DEMO_USER_ID, requests: 1 });
+	});
+
+	it('streams the response through untouched and meters usage to the session user', async () => {
+		const fetchMock = vi.fn(async () => sseResponse());
+		vi.stubGlobal('fetch', fetchMock);
+
+		const res = await appWithUser({ id: 'usr-123' }).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o', stream: true }),
+			},
+		);
+
+		expect(res.status).toBe(200);
+		// The client's bytes are the upstream's bytes.
+		expect(await res.text()).toBe(CHAT_SSE.join(''));
+
+		const rows = await waitForUsage();
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			userId: 'usr-123',
+			provider: 'openai',
+			model: 'gpt-4o-2024-08-06',
+			requests: 1,
+			inputTokens: 120,
+			cachedInputTokens: 100,
+			outputTokens: 30,
+			reasoningTokens: 8,
+		});
+	});
+
+	it('asks OpenAI to report usage on streamed requests', async () => {
+		const fetchMock = vi.fn(async (_url: string, _init: RequestInit) =>
+			sseResponse(),
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const res = await appWithUser({ id: 'usr-123' }).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o', stream: true }),
+			},
+		);
+		await res.text();
+
+		const sent = JSON.parse(String(fetchMock.mock.calls[0]?.[1]?.body));
+		expect(sent.stream_options).toEqual({ include_usage: true });
+		// Everything else about the request is passed through as the client sent it.
+		expect(sent.model).toBe('gpt-4o');
+		expect(sent.stream).toBe(true);
+	});
+
+	it('times the first token separately from the whole generation', async () => {
+		// First chunk lands immediately, the rest 150ms later: ttft should track the
+		// former and duration the latter, which is the entire point of having both.
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => slowFinishingSseResponse(150)),
+		);
+
+		const res = await appWithUser({ id: 'usr-1' }).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o', stream: true }),
+			},
+		);
+		await res.text();
+		await waitForUsage();
+
+		const { duration_ms, ttft_ms } = timingRow();
+		expect(ttft_ms).not.toBeNull();
+		expect(duration_ms).toBeGreaterThanOrEqual(150);
+		// The user saw text long before the generation finished.
+		expect(ttft_ms as number).toBeLessThan(duration_ms - 100);
+	});
+
+	it('leaves ttft null when the response is not streamed', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							model: 'gpt-4o',
+							usage: { prompt_tokens: 5, completion_tokens: 1 },
+						}),
+						{ status: 200, headers: { 'Content-Type': 'application/json' } },
+					),
+			),
+		);
+
+		const res = await appWithUser({ id: 'usr-1' }).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o' }),
+			},
+		);
+		await res.json();
+		await waitForUsage();
+
+		expect(timingRow().ttft_ms).toBeNull();
+	});
+
+	it('meters a non-streaming response from its JSON usage block', async () => {
+		const body = {
+			model: 'gpt-4o-2024-08-06',
+			choices: [{ message: { content: 'Hi' } }],
+			usage: { prompt_tokens: 40, completion_tokens: 9 },
+		};
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(JSON.stringify(body), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					}),
+			),
+		);
+
+		const res = await appWithUser({ id: 'usr-9' }).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o' }),
+			},
+		);
+
+		expect(await res.json()).toEqual(body);
+		const rows = await waitForUsage();
+		expect(rows[0]).toMatchObject({
+			userId: 'usr-9',
+			inputTokens: 40,
+			outputTokens: 9,
+		});
+	});
+
+	it('meters as anonymous when auth is disabled, rather than rejecting', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => sseResponse()),
+		);
+
+		// createApp() with no auth — local dev.
+		const res = await createApp().request('/api/openai/chat/completions', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ model: 'gpt-4o', stream: true }),
+		});
+
+		expect(res.status).toBe(200);
+		await res.text();
+		const rows = await waitForUsage();
+		expect(rows[0]).toMatchObject({ userId: ANONYMOUS_USER_ID });
+	});
+});
+
+describe('GET /api/usage_summary', () => {
+	it('rejects a bad secret', async () => {
+		const res = await createApp().request('/api/usage_summary?secret=wrong');
+		expect(res.status).toBe(403);
+	});
+
+	it('breaks spend down by user, costed from the stored token counts', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => sseResponse()),
+		);
+		const proxied = await appWithUser({ id: 'usr-spender' }).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o', stream: true }),
+			},
+		);
+		await proxied.text();
+		await waitForUsage();
+
+		const res = await createApp().request(
+			'/api/usage_summary?secret=test-secret',
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			totals: Array<{ userId: string; costUsd: number; requests: number }>;
+			unpricedModels: string[];
+		};
+
+		expect(body.totals).toHaveLength(1);
+		expect(body.totals[0]).toMatchObject({
+			userId: 'usr-spender',
+			requests: 1,
+		});
+		// The SSE fixture reports 120 input (100 of them cached) and 30 output on
+		// gpt-4o: 20 uncached @ $2.50/1M + 100 cached @ $1.25/1M + 30 out @ $10/1M.
+		expect(body.totals[0]?.costUsd).toBeCloseTo(
+			(20 * 2.5 + 100 * 1.25 + 30 * 10) / 1_000_000,
+			10,
+		);
+		expect(body.unpricedModels).toEqual([]);
+	});
+
+	it('flags a model with no rate instead of costing it at zero', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(
+						JSON.stringify({
+							model: 'gpt-6-turbo',
+							usage: { prompt_tokens: 10, completion_tokens: 5 },
+						}),
+						{ status: 200, headers: { 'Content-Type': 'application/json' } },
+					),
+			),
+		);
+		const proxied = await appWithUser({ id: 'usr-1' }).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-6-turbo' }),
+			},
+		);
+		await proxied.json();
+		await waitForUsage();
+
+		const summary = (await (
+			await createApp().request('/api/usage_summary?secret=test-secret')
+		).json()) as {
+			rows: Array<{ costUsd: number | null }>;
+			unpricedModels: string[];
+		};
+		expect(summary.rows[0]?.costUsd).toBeNull();
+		expect(summary.unpricedModels).toEqual(['gpt-6-turbo']);
+	});
+});

--- a/backend/src/__tests__/usage.test.ts
+++ b/backend/src/__tests__/usage.test.ts
@@ -1,0 +1,179 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDb, db } from '../db.js';
+import { costUsd } from '../pricing.js';
+import {
+	anonymizeUserUsage,
+	DELETED_USER_ID,
+	recordUsage,
+	summarizeUsage,
+	type UsageRecord,
+} from '../usage.js';
+
+const env = { ...process.env };
+
+beforeEach(async () => {
+	// Point the shared DB at a fresh temp dir; db.ts derives it from DATA_DIR.
+	process.env.DATA_DIR = await mkdtemp(path.join(tmpdir(), 'wt-usage-'));
+});
+
+afterEach(() => {
+	closeDb();
+	process.env = { ...env };
+});
+
+function record(overrides: Partial<UsageRecord> = {}): void {
+	recordUsage({
+		userId: 'usr-1',
+		provider: 'openai',
+		endpoint: 'chat/completions',
+		model: 'gpt-4o',
+		inputTokens: 1000,
+		cachedInputTokens: 0,
+		outputTokens: 100,
+		reasoningTokens: 0,
+		status: 200,
+		streamed: true,
+		durationMs: 500,
+		ttftMs: 120,
+		...overrides,
+	});
+}
+
+const ALL_TIME = (): [number, number] => [0, Date.now() + 1000];
+
+describe('recordUsage / summarizeUsage', () => {
+	it('groups token totals by user and model', () => {
+		record({ userId: 'usr-1' });
+		record({ userId: 'usr-1' });
+		record({ userId: 'usr-2', model: 'gpt-4o-mini', outputTokens: 50 });
+
+		const rows = summarizeUsage(...ALL_TIME());
+		expect(rows).toHaveLength(2);
+
+		const first = rows.find((r) => r.userId === 'usr-1');
+		expect(first?.requests).toBe(2);
+		expect(first?.inputTokens).toBe(2000);
+		expect(first?.outputTokens).toBe(200);
+
+		const second = rows.find((r) => r.userId === 'usr-2');
+		expect(second?.model).toBe('gpt-4o-mini');
+		expect(second?.requests).toBe(1);
+	});
+
+	it('excludes rows outside the window', () => {
+		record();
+		expect(summarizeUsage(0, Date.now() - 60_000)).toEqual([]);
+	});
+
+	it('leaves email null when Better Auth has never created the user table', () => {
+		record();
+		expect(summarizeUsage(...ALL_TIME())[0]).toMatchObject({ email: null });
+	});
+
+	it("labels rows with the account's email — the point of sharing one DB", () => {
+		// Stand in for Better Auth's `user` table, which lives in the same database.
+		db().exec(`CREATE TABLE user (id TEXT PRIMARY KEY, email TEXT)`);
+		db()
+			.prepare(
+				`INSERT INTO user (id, email) VALUES ('usr-1', 'ken@example.edu')`,
+			)
+			.run();
+		record({ userId: 'usr-1' });
+
+		expect(summarizeUsage(...ALL_TIME())[0]).toMatchObject({
+			userId: 'usr-1',
+			email: 'ken@example.edu',
+		});
+	});
+
+	it('shows the deleted bucket as unlabelled, since no account matches it', () => {
+		db().exec(`CREATE TABLE user (id TEXT PRIMARY KEY, email TEXT)`);
+		record({ userId: 'usr-gone' });
+		anonymizeUserUsage('usr-gone');
+
+		expect(summarizeUsage(...ALL_TIME())[0]).toMatchObject({
+			userId: DELETED_USER_ID,
+			email: null,
+		});
+	});
+});
+
+describe('anonymizeUserUsage', () => {
+	it("moves a deleted account's rows to the shared bucket, keeping the tokens", () => {
+		record({ userId: 'usr-gone', inputTokens: 500, outputTokens: 25 });
+		record({ userId: 'usr-stays' });
+
+		anonymizeUserUsage('usr-gone');
+
+		const rows = summarizeUsage(...ALL_TIME());
+		expect(rows.map((r) => r.userId).sort()).toEqual([
+			DELETED_USER_ID,
+			'usr-stays',
+		]);
+
+		// The spend survives the deletion — that's the whole point of the tombstone.
+		const tombstoned = rows.find((r) => r.userId === DELETED_USER_ID);
+		expect(tombstoned?.inputTokens).toBe(500);
+		expect(tombstoned?.outputTokens).toBe(25);
+	});
+
+	it('merges every deleted user into one bucket rather than a per-user pseudonym', () => {
+		record({ userId: 'usr-a' });
+		record({ userId: 'usr-b' });
+		anonymizeUserUsage('usr-a');
+		anonymizeUserUsage('usr-b');
+
+		const rows = summarizeUsage(...ALL_TIME());
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({ userId: DELETED_USER_ID, requests: 2 });
+	});
+});
+
+describe('costUsd', () => {
+	it('prices input and output at the model rate', () => {
+		// gpt-4o: $2.50/1M input, $10.00/1M output.
+		const cost = costUsd({
+			model: 'gpt-4o',
+			inputTokens: 1_000_000,
+			cachedInputTokens: 0,
+			outputTokens: 1_000_000,
+		});
+		expect(cost).toBeCloseTo(12.5, 6);
+	});
+
+	it('discounts the cached portion of the input rather than adding to it', () => {
+		// 1M input of which 1M is cached => all of it bills at the $1.25 cached rate.
+		const cost = costUsd({
+			model: 'gpt-4o',
+			inputTokens: 1_000_000,
+			cachedInputTokens: 1_000_000,
+			outputTokens: 0,
+		});
+		expect(cost).toBeCloseTo(1.25, 6);
+	});
+
+	it('resolves dated snapshots to the base model, preferring the longest match', () => {
+		const mini = costUsd({
+			model: 'gpt-4o-mini-2024-07-18',
+			inputTokens: 1_000_000,
+			cachedInputTokens: 0,
+			outputTokens: 0,
+		});
+		// $0.15/1M for gpt-4o-mini, not $2.50 for gpt-4o.
+		expect(mini).toBeCloseTo(0.15, 6);
+	});
+
+	it('returns null for an unpriced model instead of silently costing zero', () => {
+		expect(
+			costUsd({
+				model: 'some-future-model',
+				inputTokens: 1_000_000,
+				cachedInputTokens: 0,
+				outputTokens: 1_000_000,
+			}),
+		).toBeNull();
+	});
+});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -10,13 +10,10 @@ import {
 	isConsentLevel,
 } from './consent.js';
 import { gitCommit, logSecret } from './config.js';
-import { appendLog, deleteUserLogs, pollLogs, zipLogs } from './logging.js';
+import { eraseLoggedData } from './erasure.js';
+import { appendLog, pollLogs, zipLogs } from './logging.js';
 import { openaiProxy } from './openaiProxy.js';
-import {
-	captureException,
-	deletePosthogPerson,
-	posthogMiddleware,
-} from './posthog.js';
+import { captureException, posthogMiddleware } from './posthog.js';
 import { costUsd } from './pricing.js';
 import { summarizeUsage } from './usage.js';
 
@@ -161,26 +158,26 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 		return c.json({ loggingConsent: level });
 	});
 
-	// Delete the authenticated user's logged study data (keeps their account).
-	// Removes the JSONL log file and best-effort purges their PostHog person.
-	// Full account deletion is Better Auth's /api/auth delete-user route, whose
-	// beforeDelete hook also calls deleteUserLogs.
+	// Erase the authenticated user's logged activity — study logs and analytics
+	// profile — while keeping their account. This is *withdrawal*: they carry on
+	// using the add-in, they just want what we've recorded about them gone.
 	//
-	// LLM usage rows are deliberately untouched here: the account still exists and
-	// still runs up a bill, so it still has to be metered. They're anonymized only
-	// when the account itself is deleted (see auth.ts).
-	app.delete('/api/me/data', async (c) => {
+	// Not "delete my data", which is what this used to be called: it doesn't touch
+	// the account, and it deliberately leaves the LLM usage rows, because the
+	// account is still open and still running up a bill. Departure is Better Auth's
+	// delete-user route, whose beforeDelete hook runs this same erasure and *then*
+	// anonymizes the usage rows (see erasure.ts, auth.ts).
+	app.delete('/api/me/activity', async (c) => {
 		const user = await resolveUser(c);
 		if (!user) return c.json({ detail: 'Unauthorized' }, 401);
 
 		try {
-			await deleteUserLogs(user.id);
+			await eraseLoggedData(user.id);
 		} catch (e) {
-			await captureException(e, { path: '/api/me/data' });
-			return c.json({ detail: 'Failed to delete log data' }, 500);
+			await captureException(e, { path: '/api/me/activity' });
+			return c.json({ detail: 'Failed to erase logged activity' }, 500);
 		}
-		await deletePosthogPerson(user.id);
-		return c.json({ message: 'Your logged data has been deleted.' });
+		return c.json({ message: 'Your logged activity has been erased.' });
 	});
 
 	app.get('/api/ping', (c) =>

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -9,15 +9,16 @@ import {
 	filterExtraDataForConsent,
 	isConsentLevel,
 } from './consent.js';
-import { gitCommit, logSecret, openaiApiKey } from './config.js';
+import { gitCommit, logSecret } from './config.js';
 import { appendLog, deleteUserLogs, pollLogs, zipLogs } from './logging.js';
+import { openaiProxy } from './openaiProxy.js';
 import {
 	captureException,
 	deletePosthogPerson,
 	posthogMiddleware,
 } from './posthog.js';
-
-const OPENAI_URL = 'https://api.openai.com/v1/chat/completions';
+import { costUsd } from './pricing.js';
+import { summarizeUsage } from './usage.js';
 
 export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 	const app = new Hono();
@@ -51,27 +52,17 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 		return c.json({ detail: 'Internal server error' }, 500);
 	});
 
-	// OpenAI-compatible passthrough. The frontend's ai-sdk client posts here; we
-	// only inject the server-held API key and stream the upstream response back.
-	app.post('/api/openai/chat/completions', async (c) => {
-		const body = await c.req.text();
-		const upstream = await fetch(OPENAI_URL, {
-			method: 'POST',
-			headers: {
-				Authorization: `Bearer ${openaiApiKey()}`,
-				'Content-Type': 'application/json',
-			},
-			body,
-		});
-
-		return new Response(upstream.body, {
-			status: upstream.status,
-			headers: {
-				'Content-Type':
-					upstream.headers.get('content-type') ?? 'text/event-stream',
-			},
-		});
-	});
+	// OpenAI-compatible passthrough: picks the API key that pays for the request,
+	// relays the upstream response unchanged, and meters token usage against the
+	// paying identity (see attributeRequest in openaiProxy.ts). A session spends the
+	// main key; sessionless traffic spends the capped demo key, or is refused.
+	app.post(
+		'/api/openai/chat/completions',
+		openaiProxy('chat/completions', {
+			resolveUserId: async (c) => (await resolveUser(c))?.id ?? null,
+			authEnabled: !!auth,
+		}),
+	);
 
 	// Resolve the authenticated user from the request's session, or null. Returns
 	// null when auth is disabled (dev/tests without BETTER_AUTH_ENABLED) so the
@@ -174,6 +165,10 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 	// Removes the JSONL log file and best-effort purges their PostHog person.
 	// Full account deletion is Better Auth's /api/auth delete-user route, whose
 	// beforeDelete hook also calls deleteUserLogs.
+	//
+	// LLM usage rows are deliberately untouched here: the account still exists and
+	// still runs up a bill, so it still has to be metered. They're anonymized only
+	// when the account itself is deleted (see auth.ts).
 	app.delete('/api/me/data', async (c) => {
 		const user = await resolveUser(c);
 		if (!user) return c.json({ detail: 'Unauthorized' }, 401);
@@ -196,7 +191,10 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 	app.post('/api/logs_poll', async (c) => {
 		const { log_positions = {}, secret = '' } = (await c.req
 			.json()
-			.catch(() => ({}))) as { log_positions?: Record<string, number>; secret?: string };
+			.catch(() => ({}))) as {
+			log_positions?: Record<string, number>;
+			secret?: string;
+		};
 
 		if (logSecret() === '') {
 			return c.json({ error: 'Logging secret not set.' }, 500);
@@ -223,6 +221,62 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 				'Content-Type': 'application/zip',
 				'Content-Disposition': 'attachment; filename=logs.zip',
 			},
+		});
+	});
+
+	// LLM spend broken down by user (and model). Operator tool, gated by the same
+	// LOG_SECRET as the other researcher routes. `since`/`until` are ISO dates and
+	// default to the last 30 days. Dollars are computed here from the stored token
+	// counts, so a model with no entry in pricing.ts reports costUsd: null and shows
+	// up in `unpricedModels` rather than silently costing nothing.
+	app.get('/api/usage_summary', (c) => {
+		const secret = c.req.query('secret') ?? '';
+		if (logSecret() === '') {
+			return c.json({ error: 'Logging secret not set.' }, 500);
+		}
+		if (secret !== logSecret()) {
+			return c.json({ error: 'Invalid secret.' }, 403);
+		}
+
+		const parseDate = (raw: string | undefined, fallback: number): number => {
+			const parsed = raw ? Date.parse(raw) : Number.NaN;
+			return Number.isNaN(parsed) ? fallback : parsed;
+		};
+		const until = parseDate(c.req.query('until'), Date.now());
+		const since = parseDate(
+			c.req.query('since'),
+			until - 30 * 24 * 60 * 60 * 1000,
+		);
+
+		const rows = summarizeUsage(since, until).map((row) => ({
+			...row,
+			costUsd: costUsd(row),
+		}));
+
+		// Per-user totals; unpriced rows contribute requests but no dollars.
+		const byUser = new Map<
+			string,
+			{ email: string | null; costUsd: number; requests: number }
+		>();
+		for (const row of rows) {
+			const entry = byUser.get(row.userId) ?? {
+				email: row.email,
+				costUsd: 0,
+				requests: 0,
+			};
+			entry.costUsd += row.costUsd ?? 0;
+			entry.requests += row.requests;
+			byUser.set(row.userId, entry);
+		}
+
+		return c.json({
+			since: new Date(since).toISOString(),
+			until: new Date(until).toISOString(),
+			totals: [...byUser].map(([userId, t]) => ({ userId, ...t })),
+			rows,
+			unpricedModels: [
+				...new Set(rows.filter((r) => r.costUsd === null).map((r) => r.model)),
+			],
 		});
 	});
 

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,28 +1,16 @@
-import { mkdirSync } from 'node:fs';
-import path from 'node:path';
 import { betterAuth } from 'better-auth';
 import { bearer, deviceAuthorization } from 'better-auth/plugins';
-import Database from 'better-sqlite3';
 import {
 	betterAuthSecret,
 	betterAuthTrustedOrigins,
 	betterAuthUrl,
-	dataDir,
 	deviceClientIds,
 	googleClientId,
 	googleClientSecret,
 } from './config.js';
+import { db } from './db.js';
 import { deleteUserLogs } from './logging.js';
-
-// The auth DB lives under the shared DATA_DIR (defaults to backend/data). In
-// Docker/k8s, DATA_DIR points at the mounted volume so auth.db persists.
-const dbPath = path.join(dataDir(), 'auth.db');
-
-// Ensure the data directory exists. This runs only when this module is actually
-// executed — i.e. at runtime when auth is enabled, or when the Better Auth CLI
-// imports this file for migration. mkdirSync creates the directory; new Database()
-// creates auth.db if absent; `@better-auth/cli migrate` creates the tables.
-mkdirSync(path.dirname(dbPath), { recursive: true });
+import { anonymizeUserUsage } from './usage.js';
 
 // A module-level `auth` singleton (not a factory) so the Better Auth CLI can
 // auto-discover it: `npx @better-auth/cli migrate` looks for an exported `auth`
@@ -30,7 +18,10 @@ mkdirSync(path.dirname(dbPath), { recursive: true });
 // tests never executes this module and never opens SQLite. index.ts imports this
 // module dynamically, and only when BETTER_AUTH_ENABLED=true.
 export const auth = betterAuth({
-	database: new Database(dbPath),
+	// The shared application database (db.ts) — Better Auth's tables and ours live
+	// in one file, on one connection. Better Auth creates its own tables here via
+	// `@better-auth/cli migrate` (src/migrate.ts); ours are versioned in db.ts.
+	database: db(),
 	baseURL: betterAuthUrl(),
 	secret: betterAuthSecret(),
 	trustedOrigins: betterAuthTrustedOrigins(),
@@ -57,10 +48,15 @@ export const auth = betterAuth({
 		// beforeDelete purges the user's study logs so "delete my account" also
 		// removes their data. Google-only accounts have no password, so deletion
 		// proceeds from the session alone (no verification flow configured).
+		//
+		// LLM usage rows are anonymized rather than deleted: they're content-free
+		// billing records, and dropping them would make our per-user spend stop
+		// reconciling with the provider's invoice. See usage.ts.
 		deleteUser: {
 			enabled: true,
 			beforeDelete: async (user) => {
 				await deleteUserLogs(user.id);
+				anonymizeUserUsage(user.id);
 			},
 		},
 	},

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -9,7 +9,7 @@ import {
 	googleClientSecret,
 } from './config.js';
 import { db } from './db.js';
-import { deleteUserLogs } from './logging.js';
+import { eraseLoggedData } from './erasure.js';
 import { anonymizeUserUsage } from './usage.js';
 
 // A module-level `auth` singleton (not a factory) so the Better Auth CLI can
@@ -45,17 +45,19 @@ export const auth = betterAuth({
 			},
 		},
 		// Enables auth.api.deleteUser for the authenticated user (off by default).
-		// beforeDelete purges the user's study logs so "delete my account" also
-		// removes their data. Google-only accounts have no password, so deletion
-		// proceeds from the session alone (no verification flow configured).
+		// Google-only accounts have no password, so deletion proceeds from the
+		// session alone (no verification flow configured).
 		//
-		// LLM usage rows are anonymized rather than deleted: they're content-free
-		// billing records, and dropping them would make our per-user spend stop
-		// reconciling with the provider's invoice. See usage.ts.
+		// beforeDelete runs the same erasure as the withdrawal endpoint (study logs
+		// + analytics profile), so account deletion is by construction a superset of
+		// it — see erasure.ts. On top of that it anonymizes the LLM usage rows rather
+		// than deleting them: they're content-free billing records, and dropping them
+		// would make our per-user spend stop reconciling with the provider's invoice
+		// (see usage.ts). Better Auth then drops the account, sessions and OAuth links.
 		deleteUser: {
 			enabled: true,
 			beforeDelete: async (user) => {
-				await deleteUserLogs(user.id);
+				await eraseLoggedData(user.id);
 				anonymizeUserUsage(user.id);
 			},
 		},

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -30,6 +30,14 @@ export const gitCommit = () => (process.env.GIT_COMMIT ?? 'unknown').trim();
 
 // Read at request time via these helpers so tests can override the environment
 export const openaiApiKey = () => (process.env.OPENAI_API_KEY ?? '').trim();
+
+// Key for the Thoughtful-demo OpenAI project, used to serve requests that carry no
+// session (demo mode, and the standalone editor before sign-in). Separate from the
+// main key so its spend is capped on OpenAI's side rather than by us. When unset,
+// unauthenticated requests are refused wherever auth is enabled — see openaiProxy.ts.
+export const openaiDemoApiKey = () =>
+	(process.env.OPENAI_DEMO_API_KEY ?? '').trim();
+
 export const logSecret = () => (process.env.LOG_SECRET ?? '').trim();
 
 // Auth — opt-in via BETTER_AUTH_ENABLED=true

--- a/backend/src/consent.ts
+++ b/backend/src/consent.ts
@@ -7,6 +7,10 @@
  * more. This module is the single source of truth for that ordering and for
  * which payload fields are allowed at which level. The client pre-strips to the
  * same rules, but the server re-applies them so a tampered client can't escalate.
+ *
+ * These levels govern *study/analytics* logging only. LLM usage metering (usage.ts)
+ * sits outside them deliberately: it's the content-free billing record for requests
+ * we are charged for, so it is kept at every level, including `none`.
  */
 
 export const CONSENT_LEVELS = [

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,0 +1,115 @@
+/**
+ * The application database — one SQLite file, one connection, shared by Better
+ * Auth and by our own tables.
+ *
+ * Better Auth manages its own schema (it introspects and creates its tables via
+ * `@better-auth/cli migrate` / src/migrate.ts). Everything else — currently just
+ * `llm_usage`, and any user preferences we add later — is versioned here with
+ * `PRAGMA user_version`, which Better Auth doesn't touch. Migrations are plain
+ * SQL steps applied in order, each bumping the version inside a transaction, so a
+ * half-applied migration can't leave the schema mid-flight.
+ *
+ * Adding a schema change: append a step to MIGRATIONS. Never edit an existing
+ * step — deployed databases have already run it and will skip it forever.
+ */
+import { mkdirSync, renameSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { dataDir } from './config.js';
+
+function dbPath(): string {
+	return path.join(dataDir(), 'app.db');
+}
+
+/**
+ * The DB used to be called auth.db, back when Better Auth was its only tenant.
+ * Rename it in place on first startup so existing deployments keep their users.
+ * The -wal/-shm siblings are renamed with it: SQLite locates them by the main
+ * file's name, so they have to move together or a pending WAL would be orphaned.
+ */
+function renameLegacyAuthDb(target: string): void {
+	const legacy = path.join(dataDir(), 'auth.db');
+	if (existsSync(target) || !existsSync(legacy)) return;
+
+	for (const suffix of ['', '-wal', '-shm']) {
+		if (existsSync(legacy + suffix)) {
+			renameSync(legacy + suffix, target + suffix);
+		}
+	}
+	console.log(`Renamed legacy auth.db → ${path.basename(target)}.`);
+}
+
+/**
+ * Ordered schema steps for our (non-Better-Auth) tables. The array index is the
+ * version: after running MIGRATIONS[0], user_version is 1.
+ */
+const MIGRATIONS: Array<(conn: Database.Database) => void> = [
+	// v1 — LLM usage metering (see usage.ts). No foreign key to `user`: a cascade
+	// would delete the billing rows we deliberately keep when an account is
+	// deleted (they're anonymized instead).
+	(conn) => {
+		conn.exec(`
+			CREATE TABLE llm_usage (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				ts INTEGER NOT NULL,
+				user_id TEXT NOT NULL,
+				provider TEXT NOT NULL,
+				endpoint TEXT NOT NULL,
+				model TEXT NOT NULL,
+				input_tokens INTEGER NOT NULL DEFAULT 0,
+				cached_input_tokens INTEGER NOT NULL DEFAULT 0,
+				output_tokens INTEGER NOT NULL DEFAULT 0,
+				reasoning_tokens INTEGER NOT NULL DEFAULT 0,
+				status INTEGER NOT NULL,
+				streamed INTEGER NOT NULL,
+				-- request sent → last byte of the upstream response (the whole
+				-- generation, for a stream). ttft_ms is request sent → first byte,
+				-- i.e. what the user actually waits for; NULL when not streaming,
+				-- where there is no first token to distinguish from the last.
+				duration_ms INTEGER NOT NULL,
+				ttft_ms INTEGER
+			);
+			CREATE INDEX llm_usage_user_ts ON llm_usage (user_id, ts);
+		`);
+	},
+];
+
+function migrate(conn: Database.Database): void {
+	const current = conn.pragma('user_version', { simple: true }) as number;
+	for (let version = current; version < MIGRATIONS.length; version++) {
+		const step = MIGRATIONS[version];
+		if (!step) continue;
+		conn.transaction(() => {
+			step(conn);
+			conn.pragma(`user_version = ${version + 1}`);
+		})();
+	}
+}
+
+// Cached per resolved path so tests can repoint DATA_DIR at a temp dir and get a
+// fresh database rather than the previous test's connection.
+const connections = new Map<string, Database.Database>();
+
+/** The shared connection, opened and migrated on first use. */
+export function db(): Database.Database {
+	const file = dbPath();
+	const existing = connections.get(file);
+	if (existing) return existing;
+
+	mkdirSync(path.dirname(file), { recursive: true });
+	renameLegacyAuthDb(file);
+
+	const conn = new Database(file);
+	conn.pragma('journal_mode = WAL');
+	conn.pragma('foreign_keys = ON');
+	migrate(conn);
+
+	connections.set(file, conn);
+	return conn;
+}
+
+/** Close the cached connections. Tests call this between temp DATA_DIRs. */
+export function closeDb(): void {
+	for (const conn of connections.values()) conn.close();
+	connections.clear();
+}

--- a/backend/src/erasure.ts
+++ b/backend/src/erasure.ts
@@ -1,0 +1,30 @@
+/**
+ * Erasing a user's logged activity — the one definition of what "delete my data"
+ * means, shared by both paths that promise it.
+ *
+ * Two different requests reach this:
+ *   - "delete my logged activity" (DELETE /api/me/activity) — withdrawal. The user
+ *     keeps their account and keeps using the add-in; they just want what we've
+ *     recorded about them gone. Their LLM usage rows stay: the account is still
+ *     open and still running up a bill, so it still has to be metered.
+ *   - "delete my account" (Better Auth's deleteUser) — departure. The `beforeDelete`
+ *     hook calls this too, and *then* anonymizes the usage rows and drops the
+ *     account, so account deletion is by construction a superset of the above.
+ *
+ * Keeping this in one function is the point: when the two paths each maintained
+ * their own list, account deletion quietly forgot to purge the PostHog person —
+ * the thorough option was doing less than the lesser one.
+ */
+import { deleteUserLogs } from './logging.js';
+import { deletePosthogPerson } from './posthog.js';
+
+/**
+ * Delete everything we've logged about a user: their study-log file and their
+ * analytics profile. PostHog deletion is best-effort (it needs a management API
+ * key; see deletePosthogPerson), so a failure there is reported rather than
+ * thrown — the logs we control are still gone.
+ */
+export async function eraseLoggedData(userId: string): Promise<void> {
+	await deleteUserLogs(userId);
+	await deletePosthogPerson(userId);
+}

--- a/backend/src/migrate.ts
+++ b/backend/src/migrate.ts
@@ -1,13 +1,20 @@
-// Standalone Better Auth schema migration entrypoint.
+// Standalone schema migration entrypoint.
 //
-// Runs the SQLite migrations for the configured auth instance (core tables plus
-// any plugin tables, e.g. the device-authorization `deviceCode` table) and
-// exits. Deployments run this before starting the server — e.g. as a Kubernetes
-// initContainer sharing the DATA_DIR volume — so `auth.db` is migrated on a
-// fresh volume without needing @better-auth/cli or dev dependencies in the
-// runtime image. Idempotent: only missing migrations are applied.
+// Migrates the shared application database (`app.db` under DATA_DIR): Better
+// Auth's tables (core plus plugin tables, e.g. the device-authorization
+// `deviceCode` table) and our own (db.ts's `user_version` steps). Deployments run
+// this before starting the server — e.g. as a Kubernetes initContainer sharing the
+// DATA_DIR volume — so a fresh volume is migrated without needing @better-auth/cli
+// or dev dependencies in the runtime image. Idempotent: only missing migrations
+// are applied.
+//
+// Importing auth.js opens the shared connection, which applies our migrations (and
+// renames a legacy auth.db) as a side effect; getMigrations then applies Better
+// Auth's on the same connection. The explicit db() call below just makes that
+// ordering visible rather than incidental.
 import { getMigrations } from 'better-auth/db/migration';
 import { auth } from './auth.js';
+import { db } from './db.js';
 
 // Let the process exit naturally rather than calling process.exit(): in a
 // container stdout is a pipe (async on Unix), so exiting immediately after a
@@ -15,10 +22,13 @@ import { auth } from './auth.js';
 // the event loop, so the process ends on its own once this resolves. On failure
 // we set a non-zero exit code so the initContainer fails and blocks the pod.
 try {
+	db();
+	console.log('Application schema migrations applied.');
+
 	const { runMigrations } = await getMigrations(auth.options);
 	await runMigrations();
 	console.log('Better Auth migrations applied.');
 } catch (err) {
-	console.error('Better Auth migration failed:', err);
+	console.error('Migration failed:', err);
 	process.exitCode = 1;
 }

--- a/backend/src/openaiProxy.ts
+++ b/backend/src/openaiProxy.ts
@@ -1,0 +1,308 @@
+/**
+ * OpenAI passthrough proxy, with per-user token metering.
+ *
+ * Still a passthrough — the client sends an OpenAI request body and gets the
+ * upstream response back unchanged — but it now (a) picks which API key pays for
+ * the request, so the main key can't be spent anonymously, and (b) records a
+ * content-free usage row so spend can be broken down by user. Nothing about the
+ * prompt or the completion is inspected or stored; only the `usage` block is read
+ * out of the response.
+ *
+ * Getting usage back out of a passthrough differs by transport:
+ *   - non-streaming: the response is buffered, so `usage` is just a JSON field.
+ *   - streaming: the SSE stream is tee'd — one branch goes to the client
+ *     untouched, the other is drained here and scanned for the terminal usage
+ *     event. Chat Completions only emits it when `stream_options.include_usage`
+ *     is set, so we set it on the way out; the Responses API emits it regardless.
+ *
+ * The usage shapes of both OpenAI APIs are handled (`prompt_tokens` vs
+ * `input_tokens`), so a `/responses` route can reuse this by passing a different
+ * endpoint.
+ */
+import type { Context } from 'hono';
+import { openaiApiKey, openaiDemoApiKey } from './config.js';
+import { captureException } from './posthog.js';
+import { ANONYMOUS_USER_ID, DEMO_USER_ID, recordUsage } from './usage.js';
+
+const OPENAI_BASE = 'https://api.openai.com/v1';
+
+export type OpenAIEndpoint = 'chat/completions' | 'responses';
+
+export interface ProxyOptions {
+	/** Authenticated user id for this request, or null if there's no session. */
+	resolveUserId: (c: Context) => Promise<string | null>;
+	/**
+	 * Whether auth is configured at all. When it isn't (local dev with
+	 * BETTER_AUTH_ENABLED unset), unauthenticated requests are served rather than
+	 * refused — otherwise turning auth off would break the whole app.
+	 */
+	authEnabled: boolean;
+}
+
+/** Which key pays for a request, and which bucket its tokens are metered to. */
+export interface Attribution {
+	apiKey: string;
+	userId: string;
+}
+
+/**
+ * Decide who pays. The bucket always names whoever's key was actually charged, so
+ * the usage summary reconciles against the right OpenAI invoice:
+ *
+ *   - a session          → the main key, metered to that user;
+ *   - no session, demo key set → the Thoughtful-demo key, metered to `demo`. This
+ *     is how demo mode and the pre-sign-in editor work: they carry no session, and
+ *     their spend is capped on OpenAI's side by that project's own limit;
+ *   - no session, no demo key, auth on → null, i.e. 401. Fail closed rather than
+ *     quietly billing the main key for unauthenticated traffic;
+ *   - no session, no demo key, auth off → the main key, metered to `anonymous`.
+ *     Local dev only; kept separate from `demo` because a different key paid.
+ */
+export function attributeRequest(
+	userId: string | null,
+	authEnabled: boolean,
+): Attribution | null {
+	if (userId) return { apiKey: openaiApiKey(), userId };
+
+	const demoKey = openaiDemoApiKey();
+	if (demoKey) return { apiKey: demoKey, userId: DEMO_USER_ID };
+
+	if (authEnabled) return null;
+	return { apiKey: openaiApiKey(), userId: ANONYMOUS_USER_ID };
+}
+
+interface RawUsage {
+	inputTokens: number;
+	cachedInputTokens: number;
+	outputTokens: number;
+	reasoningTokens: number;
+}
+
+function num(value: unknown): number {
+	return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Pull the usage block out of an OpenAI response object or a single SSE event.
+ * Returns null when the object carries no usage — which includes the intermediate
+ * streaming chunks, where Chat Completions sends `usage: null`.
+ */
+export function parseUsage(obj: unknown): RawUsage | null {
+	if (typeof obj !== 'object' || obj === null) return null;
+	const o = obj as Record<string, any>;
+	// Chat Completions puts usage at the top level; the Responses API nests the
+	// final object under `response`.
+	const u = o.usage ?? o.response?.usage;
+	if (typeof u !== 'object' || u === null) return null;
+
+	return {
+		inputTokens: num(u.input_tokens ?? u.prompt_tokens),
+		cachedInputTokens: num(
+			u.input_tokens_details?.cached_tokens ??
+				u.prompt_tokens_details?.cached_tokens,
+		),
+		outputTokens: num(u.output_tokens ?? u.completion_tokens),
+		reasoningTokens: num(
+			u.output_tokens_details?.reasoning_tokens ??
+				u.completion_tokens_details?.reasoning_tokens,
+		),
+	};
+}
+
+/** The model the provider actually served (resolves aliases/snapshots). */
+export function parseModel(obj: unknown): string | null {
+	if (typeof obj !== 'object' || obj === null) return null;
+	const o = obj as Record<string, any>;
+	const model = o.model ?? o.response?.model;
+	return typeof model === 'string' ? model : null;
+}
+
+/**
+ * Incremental scanner over an SSE byte stream. Keeps the last usage block and
+ * model it saw; usage arrives in the terminal event, so that's what survives.
+ */
+export function createSseUsageScanner() {
+	let pending = '';
+	let usage: RawUsage | null = null;
+	let model: string | null = null;
+
+	return {
+		push(text: string): void {
+			pending += text;
+			const lines = pending.split('\n');
+			// The trailing element is an incomplete line; hold it for the next chunk.
+			pending = lines.pop() ?? '';
+			for (const line of lines) {
+				const trimmed = line.trim();
+				if (!trimmed.startsWith('data:')) continue;
+				const data = trimmed.slice('data:'.length).trim();
+				if (!data || data === '[DONE]') continue;
+				try {
+					const obj = JSON.parse(data);
+					usage = parseUsage(obj) ?? usage;
+					model = parseModel(obj) ?? model;
+				} catch {
+					// Not JSON (comment/keepalive) — nothing to read.
+				}
+			}
+		},
+		result(): { usage: RawUsage | null; model: string | null } {
+			return { usage, model };
+		},
+	};
+}
+
+/**
+ * Force Chat Completions to emit a usage event on streamed responses. Without
+ * this the stream ends with no token counts at all and the request can't be
+ * costed. Returns the body unchanged for the Responses API (which always reports
+ * usage) and for anything we can't parse.
+ */
+function withUsageReporting(body: string, endpoint: OpenAIEndpoint): string {
+	if (endpoint !== 'chat/completions') return body;
+	try {
+		const parsed = JSON.parse(body);
+		if (parsed?.stream !== true) return body;
+		parsed.stream_options = { ...parsed.stream_options, include_usage: true };
+		return JSON.stringify(parsed);
+	} catch {
+		return body;
+	}
+}
+
+function wantsStream(body: string): boolean {
+	try {
+		return JSON.parse(body)?.stream === true;
+	} catch {
+		return false;
+	}
+}
+
+function requestedModel(body: string): string {
+	try {
+		const model = JSON.parse(body)?.model;
+		return typeof model === 'string' ? model : 'unknown';
+	} catch {
+		return 'unknown';
+	}
+}
+
+export function openaiProxy(endpoint: OpenAIEndpoint, options: ProxyOptions) {
+	return async (c: Context): Promise<Response> => {
+		const userId = await options.resolveUserId(c);
+		const attribution = attributeRequest(userId, options.authEnabled);
+		if (!attribution) return c.json({ detail: 'Unauthorized' }, 401);
+
+		const body = await c.req.text();
+		const streaming = wantsStream(body);
+		const startedAt = Date.now();
+
+		const upstream = await fetch(`${OPENAI_BASE}/${endpoint}`, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${attribution.apiKey}`,
+				'Content-Type': 'application/json',
+			},
+			body: withUsageReporting(body, endpoint),
+		});
+
+		const contentType =
+			upstream.headers.get('content-type') ??
+			(streaming ? 'text/event-stream' : 'application/json');
+
+		// Exactly one row per proxied request, including failures: a 4xx/5xx has no
+		// usage, but recording it with zero tokens keeps request counts honest and
+		// makes a user hammering a failing endpoint visible.
+		//
+		// `ttftMs` is only meaningful for a stream (see UsageRecord); non-streaming
+		// callers pass null rather than a time-to-first-byte that would just be the
+		// duration again.
+		const meter = (
+			usage: RawUsage | null,
+			model: string | null,
+			ttftMs: number | null,
+		) => {
+			if (upstream.ok && !usage) {
+				console.warn(
+					`[openai-proxy] ${endpoint}: no usage in a ${upstream.status} response — spend will be under-reported`,
+				);
+			}
+			try {
+				recordUsage({
+					userId: attribution.userId,
+					provider: 'openai',
+					endpoint,
+					model: model ?? requestedModel(body),
+					inputTokens: usage?.inputTokens ?? 0,
+					cachedInputTokens: usage?.cachedInputTokens ?? 0,
+					outputTokens: usage?.outputTokens ?? 0,
+					reasoningTokens: usage?.reasoningTokens ?? 0,
+					status: upstream.status,
+					streamed: streaming,
+					durationMs: Date.now() - startedAt,
+					ttftMs,
+				});
+			} catch (e) {
+				// Metering must never take down a request the user is paying for.
+				void captureException(e, { path: `/api/openai/${endpoint}` });
+			}
+		};
+
+		if (!streaming || !upstream.body) {
+			const text = await upstream.text();
+			let parsed: unknown = null;
+			try {
+				parsed = JSON.parse(text);
+			} catch {
+				// Non-JSON body (e.g. an upstream error page) — record it unmetered.
+			}
+			meter(parseUsage(parsed), parseModel(parsed), null);
+			return new Response(text, {
+				status: upstream.status,
+				headers: { 'Content-Type': contentType },
+			});
+		}
+
+		// One branch to the client byte-for-byte, one to the meter. Draining the
+		// meter branch to completion matters: if the user closes the sidebar
+		// mid-stream, OpenAI has still generated (and billed for) those tokens, and
+		// tee() keeps the source alive as long as this branch is still reading.
+		//
+		// Reading this branch also dates the first token. tee() pulls from the source
+		// as fast as it arrives regardless of how slowly the client reads its branch,
+		// so the timing reflects OpenAI, not a stalled sidebar.
+		const [toClient, toMeter] = upstream.body.tee();
+		void (async () => {
+			const scanner = createSseUsageScanner();
+			const decoder = new TextDecoder();
+			const reader = toMeter.getReader();
+			let firstByteAt: number | null = null;
+			try {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					firstByteAt ??= Date.now();
+					scanner.push(decoder.decode(value, { stream: true }));
+				}
+			} catch (e) {
+				await captureException(e, {
+					path: `/api/openai/${endpoint}`,
+					phase: 'meter',
+				});
+			} finally {
+				reader.releaseLock();
+			}
+			const { usage, model } = scanner.result();
+			meter(
+				usage,
+				model,
+				firstByteAt === null ? null : firstByteAt - startedAt,
+			);
+		})();
+
+		return new Response(toClient, {
+			status: upstream.status,
+			headers: { 'Content-Type': contentType },
+		});
+	};
+}

--- a/backend/src/pricing.ts
+++ b/backend/src/pricing.ts
@@ -1,0 +1,66 @@
+/**
+ * Token → dollars. Applied at read time by the usage summary, never stored: rates
+ * change and get corrected, and re-pricing history from stored token counts is
+ * cheap, whereas a wrong dollar figure baked into a row at request time is stuck
+ * there.
+ *
+ * RATES MUST BE VERIFIED AND EXTENDED BY HAND against the provider's price list
+ * (https://openai.com/api/pricing) — nothing here checks them. A model that isn't
+ * in the table is reported as `unpriced` rather than being silently costed at $0,
+ * so switching models makes the gap visible in the summary instead of quietly
+ * under-reporting spend.
+ *
+ * Last verified: 2026-07-13.
+ */
+
+/** USD per 1M tokens. `cachedInput` is the discounted rate for cache hits. */
+interface Rate {
+	input: number;
+	cachedInput: number;
+	output: number;
+}
+
+// Keyed by model prefix, so dated snapshots (gpt-4o-2024-08-06) inherit the base
+// model's rate. Longest matching prefix wins, so gpt-4o-mini beats gpt-4o.
+const RATES: Record<string, Rate> = {
+	'gpt-4o': { input: 2.5, cachedInput: 1.25, output: 10.0 },
+	'gpt-4o-mini': { input: 0.15, cachedInput: 0.075, output: 0.6 },
+};
+
+function rateFor(model: string): Rate | null {
+	let best: { prefix: string; rate: Rate } | null = null;
+	for (const [prefix, rate] of Object.entries(RATES)) {
+		if (!model.startsWith(prefix)) continue;
+		if (!best || prefix.length > best.prefix.length) best = { prefix, rate };
+	}
+	return best?.rate ?? null;
+}
+
+export interface TokenCounts {
+	model: string;
+	inputTokens: number;
+	cachedInputTokens: number;
+	outputTokens: number;
+}
+
+/**
+ * Cost in USD, or null if the model has no rate in the table.
+ *
+ * Cached input tokens are a subset of input tokens in OpenAI's accounting, so the
+ * uncached remainder is billed at the full rate and the cached portion at the
+ * discounted one. Reasoning tokens are likewise already counted inside output
+ * tokens, so they are not billed again here.
+ */
+export function costUsd(counts: TokenCounts): number | null {
+	const rate = rateFor(counts.model);
+	if (!rate) return null;
+
+	const cached = Math.min(counts.cachedInputTokens, counts.inputTokens);
+	const uncached = counts.inputTokens - cached;
+	return (
+		(uncached * rate.input +
+			cached * rate.cachedInput +
+			counts.outputTokens * rate.output) /
+		1_000_000
+	);
+}

--- a/backend/src/usage.ts
+++ b/backend/src/usage.ts
@@ -1,0 +1,168 @@
+/**
+ * LLM usage metering — a content-free, per-user record of every model request we
+ * pay for.
+ *
+ * This is operational/billing data, deliberately NOT part of the logging-consent
+ * tiers in consent.ts: we record it at every level, including `none`, because we
+ * are billed for the request regardless of whether the user opted into study
+ * logging. It carries no prompt, no completion, no document text — only who,
+ * when, which model, and how many tokens.
+ *
+ * The `llm_usage` table lives in the shared application database (db.ts), whose
+ * schema owns its definition. Its identity column is a bare `user_id` with no
+ * foreign key to `user`: a cascade would delete exactly the rows we want to keep
+ * when an account goes away (see anonymizeUserUsage).
+ */
+import { db } from './db.js';
+
+/** user_id value for rows whose account has been deleted (see anonymizeUserUsage). */
+export const DELETED_USER_ID = 'deleted';
+
+/**
+ * Buckets for requests that have no account behind them. They are distinct because
+ * a *different OpenAI key* pays for each, and the summary has to reconcile against
+ * the right invoice: `demo` is the capped Thoughtful-demo project (demo mode, the
+ * pre-sign-in editor), `anonymous` is the main key being spent by local dev with
+ * auth switched off. See attributeRequest in openaiProxy.ts.
+ */
+export const DEMO_USER_ID = 'demo';
+export const ANONYMOUS_USER_ID = 'anonymous';
+
+/**
+ * One metered request. Token counts follow OpenAI's accounting, where
+ * `cachedInputTokens` is a SUBSET of `inputTokens` (not an addition to it) and
+ * `reasoningTokens` is a subset of `outputTokens`. pricing.ts relies on that.
+ *
+ * The two timings measure different things and neither is "latency" on its own:
+ * `durationMs` is the whole round trip (request sent → last byte), which for a
+ * stream is the entire generation; `ttftMs` is time to the first byte of the
+ * response body — what the user actually waits for before text starts appearing.
+ * A fast-starting, slow-finishing generation and its opposite have the same
+ * duration, so only ttft says whether the assistant *feels* slow. It is null for
+ * non-streaming requests, where there's no first token distinct from the last.
+ */
+export interface UsageRecord {
+	userId: string;
+	provider: string;
+	endpoint: string;
+	model: string;
+	inputTokens: number;
+	cachedInputTokens: number;
+	outputTokens: number;
+	reasoningTokens: number;
+	status: number;
+	streamed: boolean;
+	durationMs: number;
+	ttftMs: number | null;
+}
+
+/** Insert one metered request. */
+export function recordUsage(record: UsageRecord): void {
+	db()
+		.prepare(
+			`INSERT INTO llm_usage (
+				ts, user_id, provider, endpoint, model,
+				input_tokens, cached_input_tokens, output_tokens, reasoning_tokens,
+				status, streamed, duration_ms, ttft_ms
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		)
+		.run(
+			Date.now(),
+			record.userId,
+			record.provider,
+			record.endpoint,
+			record.model,
+			record.inputTokens,
+			record.cachedInputTokens,
+			record.outputTokens,
+			record.reasoningTokens,
+			record.status,
+			record.streamed ? 1 : 0,
+			record.durationMs,
+			record.ttftMs,
+		);
+}
+
+/**
+ * Detach a deleted account's usage rows from its identity, keeping the tokens.
+ *
+ * Called from Better Auth's `beforeDelete` hook. Billing history has to survive
+ * account deletion or our per-user totals stop reconciling with the provider's
+ * invoice — but nothing identifying may survive, so every departed user's rows
+ * collapse into one shared `deleted` bucket. A random per-user tombstone would
+ * still be a pseudonym (it would let you re-single-out the person), which is the
+ * thing deletion is supposed to prevent.
+ */
+export function anonymizeUserUsage(userId: string): void {
+	db()
+		.prepare(`UPDATE llm_usage SET user_id = ? WHERE user_id = ?`)
+		.run(DELETED_USER_ID, userId);
+}
+
+export interface UsageSummaryRow {
+	userId: string;
+	email: string | null;
+	provider: string;
+	model: string;
+	requests: number;
+	inputTokens: number;
+	cachedInputTokens: number;
+	outputTokens: number;
+	reasoningTokens: number;
+}
+
+/**
+ * Per-user, per-model token totals over a time window (epoch ms, `until`
+ * exclusive). Returns tokens only — dollars are computed by pricing.ts at read
+ * time, so a rate change or a correction re-prices history instead of baking a
+ * possibly-wrong number into the row.
+ */
+export function summarizeUsage(
+	since: number,
+	until: number,
+): UsageSummaryRow[] {
+	const rows = db()
+		.prepare(
+			`SELECT user_id, provider, model,
+				COUNT(*) AS requests,
+				SUM(input_tokens) AS input_tokens,
+				SUM(cached_input_tokens) AS cached_input_tokens,
+				SUM(output_tokens) AS output_tokens,
+				SUM(reasoning_tokens) AS reasoning_tokens
+			FROM llm_usage
+			WHERE ts >= ? AND ts < ?
+			GROUP BY user_id, provider, model
+			ORDER BY user_id, provider, model`,
+		)
+		.all(since, until) as Array<Record<string, string | number>>;
+
+	const emails = userEmails();
+	return rows.map((r) => ({
+		userId: String(r.user_id),
+		email: emails.get(String(r.user_id)) ?? null,
+		provider: String(r.provider),
+		model: String(r.model),
+		requests: Number(r.requests),
+		inputTokens: Number(r.input_tokens),
+		cachedInputTokens: Number(r.cached_input_tokens),
+		outputTokens: Number(r.output_tokens),
+		reasoningTokens: Number(r.reasoning_tokens),
+	}));
+}
+
+/**
+ * user id → email, for labelling the summary. Better Auth owns the `user` table;
+ * when auth has never run (tests, a fresh dev DB) it doesn't exist yet, so a
+ * missing table just means unlabelled ids rather than a failed summary.
+ */
+function userEmails(): Map<string, string> {
+	try {
+		const rows = db().prepare(`SELECT id, email FROM user`).all() as Array<{
+			id: string;
+			email: string;
+		}>;
+		return new Map(rows.map((r) => [r.id, r.email]));
+	} catch {
+		return new Map();
+	}
+}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - LOG_SECRET=${LOG_SECRET:-}
     volumes:
-      # Single persistent volume: holds auth.db and logs/ (LOG_DIR points here).
+      # Single persistent volume: holds app.db and logs/ (LOG_DIR points here).
       - ./backend/data:/app/backend/data
 
   experiment:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -7,6 +7,9 @@ services:
       - PORT=5000
       - DEBUG=True
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # Thoughtful-demo project key: pays for sessionless (demo-mode) requests, capped
+      # on OpenAI's side. Unset => sessionless requests are refused. See openaiProxy.ts.
+      - OPENAI_DEMO_API_KEY=${OPENAI_DEMO_API_KEY:-}
       - LOG_SECRET=${LOG_SECRET:-}
     volumes:
       # Single persistent volume: holds app.db and logs/ (LOG_DIR points here).

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -7,6 +7,9 @@ services:
       - PORT=5000
       - DEBUG=False
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # Thoughtful-demo project key: pays for sessionless (demo-mode) requests, capped
+      # on OpenAI's side. Unset => sessionless requests are refused. See openaiProxy.ts.
+      - OPENAI_DEMO_API_KEY=${OPENAI_DEMO_API_KEY:-}
       - POSTHOG_PROJECT_TOKEN=${POSTHOG_PROJECT_TOKEN:-}
       - POSTHOG_HOST=${POSTHOG_HOST:-https://e.thoughtful-ai.com/}
     volumes:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -10,7 +10,7 @@ services:
       - POSTHOG_PROJECT_TOKEN=${POSTHOG_PROJECT_TOKEN:-}
       - POSTHOG_HOST=${POSTHOG_HOST:-https://e.thoughtful-ai.com/}
     volumes:
-      # Single persistent volume (auth.db + logs/). One-time host migration:
+      # Single persistent volume (app.db + logs/). One-time host migration:
       #   mkdir -p /opt/thoughtful/data/logs
       #   mv /opt/thoughtful/auth/auth.db /opt/thoughtful/data/
       #   mv /opt/thoughtful/logs/* /opt/thoughtful/data/logs/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
         GIT_COMMIT: ${GIT_COMMIT:-unknown}
     environment:
       - PORT=5000
-      # Persist study logs and the auth SQLite DB under one mounted volume.
-      # DATA_DIR is the single root for both (auth.db + logs/).
+      # Persist study logs and the application SQLite DB under one mounted volume.
+      # DATA_DIR is the single root for both (app.db + logs/).
       - DATA_DIR=/app/backend/data
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - LOG_SECRET=${LOG_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
       # DATA_DIR is the single root for both (app.db + logs/).
       - DATA_DIR=/app/backend/data
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      # Thoughtful-demo project key: pays for sessionless (demo-mode) requests, capped
+      # on OpenAI's side. Unset => sessionless requests are refused. See openaiProxy.ts.
+      - OPENAI_DEMO_API_KEY=${OPENAI_DEMO_API_KEY:-}
       - LOG_SECRET=${LOG_SECRET}
       - POSTHOG_PROJECT_TOKEN=${POSTHOG_PROJECT_TOKEN:-}
       - POSTHOG_HOST=${POSTHOG_HOST:-https://e.thoughtful-ai.com/}

--- a/frontend/public/privacypolicy.html
+++ b/frontend/public/privacypolicy.html
@@ -177,7 +177,7 @@
   <p>Last Updated: June 30, 2026</p>
   <h2 id="overview">Overview</h2>
   <p>This privacy policy describes how our AI Writing Assistant (“the Add-in”) collects, uses, and protects your information. The Add-in is a writing tool that uses AI to help you think and reflect as you write. You can also choose to take part in an optional research study. We are committed to data minimization and to being transparent about exactly what we collect and store.</p>
-  <p>A key principle: <strong>you control what we log</strong>. You choose a logging level (described under “Your Logging Choices” below), and we never store more than that level allows.</p>
+  <p>A key principle: <strong>you control what we log</strong>. You choose a logging level (described under “Your Logging Choices” below), and we never store more than that level allows. The one exception is a content-free record of the AI requests we are billed for, described under “AI Usage Records” — it contains none of your writing, and we keep it at every logging level.</p>
   <h2 id="information-we-collect">Information We Collect</h2>
   <h3 id="document-content">Document Content and AI Processing</h3>
   <ul>
@@ -191,6 +191,12 @@
   <li>For product analytics and error monitoring we use <strong>PostHog</strong>. Analytics are disabled until you choose a level that permits them, and are tied to your account so that you can later have them deleted. They are not anonymous.</li>
   <li>No data is collected in the background when the Add-in is not in use.</li>
   </ul>
+  <h3 id="ai-usage-records">AI Usage Records</h3>
+  <ul>
+  <li>Every time the Add-in asks an AI provider for a suggestion, we record that the request happened: the time, which model answered it, how many tokens it consumed, and your account. We are charged for these requests, so we keep this record to run the service, understand our costs, and detect misuse.</li>
+  <li><strong>These records contain no content</strong> — not your document text, not your request, and not the suggestion you received. Only the counts.</li>
+  <li>Because this is operational and billing information rather than research or analytics data, we keep it at <em>every</em> logging level, including “No logging”. Your logging level governs what we store about how you <em>use</em> the Add-in; it does not change the fact that we are billed for the AI requests you make.</li>
+  </ul>
   <h3 id="account-information">Account Information</h3>
   <ul>
   <li>You sign in with Google. We receive your name and email address from Google to create and identify your account.</li>
@@ -199,7 +205,7 @@
   <h2 id="your-logging-choices">Your Logging Choices</h2>
   <p>You choose one of four cumulative logging levels. We ask you to choose when you start, and you can change it at any time from the Add-in’s account settings. Each level includes everything in the levels below it.</p>
   <ul>
-  <li><strong>No logging</strong> — No usage analytics or event logging at all.</li>
+  <li><strong>No logging</strong> — No usage analytics or event logging at all. (The content-free AI usage records described above are still kept, because we are billed for those requests.)</li>
   <li><strong>Usage only</strong> — Which features you use (for example, which buttons and modes, and timing). No document text and no AI suggestions are stored. This is the starting point for new users.</li>
   <li><strong>Usage + AI suggestions</strong> — Also stores the suggestions the assistant shows you. Your document text itself is still not stored.</li>
   <li><strong>Full study logging</strong> — Also stores the document context sent to generate suggestions. This level is intended for participants who have agreed to join our research study.</li>
@@ -222,6 +228,7 @@
   <ul>
   <li>Logged events are stored on our servers, keyed to your account identifier.</li>
   <li>We retain logged events for as long as your account is active, and delete them when you request it (see “Your Rights and Choices”). Research data is retained according to the applicable study consent.</li>
+  <li>AI usage records are retained as billing history. They hold no content, and they are detached from your identity if you delete your account.</li>
   <li>Data is protected with encryption in transit, and access is restricted to our team.</li>
   </ul>
   <h2 id="data-sharing-and-third-parties">Data Sharing and Third Parties</h2>
@@ -236,8 +243,8 @@
   <h2 id="your-rights-and-choices">Your Rights and Choices</h2>
   <ul>
   <li><strong>Change what is logged</strong> at any time by changing your logging level in the Add-in’s account settings.</li>
-  <li><strong>Delete your logged data</strong> — you can request deletion of your logged events and analytics from the account settings; this removes your log records and requests deletion of your analytics profile.</li>
-  <li><strong>Delete your account</strong> — deleting your account also deletes your logged data.</li>
+  <li><strong>Erase your logged activity</strong> — from the account settings you can erase everything we have recorded about how you use the Add-in: your logged events and your analytics profile. You keep your account and can carry on using the Add-in; this is how you withdraw from the research study without leaving. Because your account is still open, the content-free AI usage records described above continue from that point on — we are still billed for the requests you make.</li>
+  <li><strong>Delete your account</strong> — this erases your logged activity (exactly as above) and then removes your account itself. Your AI usage records are stripped of your identity rather than erased: the token counts remain, so that our books still reconcile with what the AI provider billed us, but they are no longer linked to you or to each other — and they never contained any of your content.</li>
   <li><strong>Access</strong> information about what we hold and how it is used by contacting us.</li>
   </ul>
   <h2 id="changes-to-this-policy">Changes to This Policy</h2>

--- a/frontend/src/api/openai.ts
+++ b/frontend/src/api/openai.ts
@@ -1,9 +1,45 @@
-import { createOpenAI } from "@ai-sdk/openai";
-import { SERVER_URL } from "./index";
+import { createOpenAI } from '@ai-sdk/openai';
+import { SERVER_URL } from './index';
+
+/**
+ * The backend proxy authenticates every model request and meters its token usage
+ * against the signed-in user, so the client has to send the session token.
+ *
+ * This client is a module singleton reached from non-React code (the Fetcher class
+ * in the draft page), so it can't read the token from a hook. Instead the auth
+ * layer installs a token getter here at startup — AppAuthTokenBridge calls
+ * setOpenAITokenProvider — and the custom `fetch` below attaches a fresh token to
+ * each request. Before the provider is installed (or when signed out) requests go
+ * out unauthenticated and the proxy answers 401, which surfaces as a normal
+ * generation error.
+ */
+let tokenProvider: (() => Promise<string>) | null = null;
+
+export function setOpenAITokenProvider(provider: () => Promise<string>): void {
+	tokenProvider = provider;
+}
+
+async function authorizedFetch(
+	input: RequestInfo | URL,
+	init?: RequestInit,
+): Promise<Response> {
+	const headers = new Headers(init?.headers);
+	try {
+		const token = await tokenProvider?.();
+		// Overwrites the placeholder `apiKey` Bearer header the SDK sets.
+		if (token) headers.set('Authorization', `Bearer ${token}`);
+	} catch {
+		// Not signed in — send it unauthenticated and let the proxy reject it.
+	}
+	return fetch(input, { ...init, headers });
+}
 
 export const openai = createOpenAI({
 	baseURL: `${SERVER_URL}/openai`,
-	apiKey: "unused",
+	// The real credential is the session token attached by authorizedFetch; the
+	// SDK only requires this to be non-empty.
+	apiKey: 'unused',
+	fetch: authorizedFetch,
 });
 
-export const OPENAI_MODEL = "gpt-4o";
+export const OPENAI_MODEL = 'gpt-4o';

--- a/frontend/src/consent.ts
+++ b/frontend/src/consent.ts
@@ -38,7 +38,7 @@ export const CONSENT_LEVEL_LABELS: Record<
 	none: {
 		title: 'No logging',
 		description:
-			'No usage analytics or event logging at all — nothing about your activity is sent to our servers.',
+			'No usage analytics or event logging at all. We still keep a content-free record of the AI requests we are billed for (time, model, token counts) — never your writing.',
 	},
 	usage: {
 		title: 'Usage only',

--- a/frontend/src/contexts/appAuthContext.tsx
+++ b/frontend/src/contexts/appAuthContext.tsx
@@ -16,9 +16,11 @@ import { useAtomValue } from 'jotai';
 import {
 	createContext,
 	useContext,
+	useEffect,
 	useMemo,
 	type ReactNode,
 } from 'react';
+import { setOpenAITokenProvider } from '@/api/openai';
 import { type ConsentLevel, DEFAULT_CONSENT_LEVEL } from '@/consent';
 import { AccessTokenProvider } from '@/contexts/authTokenContext';
 import { OverallMode, overallModeAtom } from '@/contexts/pageContext';
@@ -159,9 +161,19 @@ export function AppAuthProvider({ children }: { children: ReactNode }) {
 	return <BetterAuthProvider>{children}</BetterAuthProvider>;
 }
 
-/** Feeds the selected session's getAccessToken into the existing token context. */
+/**
+ * Feeds the selected session's getAccessToken into the existing token context, and
+ * into the OpenAI client — the model proxy is authenticated and meters spend per
+ * user, but the client is a module singleton used outside React, so it takes the
+ * token getter by installation rather than through context.
+ */
 export function AppAuthTokenBridge({ children }: { children: ReactNode }) {
 	const session = useAppAuth();
+
+	useEffect(() => {
+		setOpenAITokenProvider(session.getAccessToken);
+	}, [session.getAccessToken]);
+
 	return (
 		<AccessTokenProvider getAccessTokenSilently={session.getAccessToken}>
 			{children}


### PR DESCRIPTION
## What & why

We could not break down OpenAI spend by user — because the proxy didn't know who
anyone was. `POST /api/openai/chat/completions` was an unauthenticated passthrough:
anyone with the URL could spend the key, and nothing recorded that a request had
happened. This branch closes that, and generalizes to future providers.

Stacked on `privacy` (#504), so the diff shows only this work.

> Note: OpenAI's usage/costs API groups by project and API key, not by the `user`
> field in a request body, so per-end-user attribution has to be metered in our
> proxy. That's also what makes it provider-agnostic.

## The proxy now knows who pays

`attributeRequest` (`backend/src/openaiProxy.ts`) decides which key is charged, and
the usage bucket always names the key that was actually charged, so the summary
reconciles against the right invoice:

| request | key charged | metered to |
| --- | --- | --- |
| has a session | `OPENAI_API_KEY` | that user |
| no session, demo key set | `OPENAI_DEMO_API_KEY` | `demo` |
| no session, no demo key, auth on | — | 401 (fail closed) |
| no session, no demo key, auth off | `OPENAI_API_KEY` | `anonymous` (local dev) |

Demo mode and the pre-sign-in editor need **no frontend special-casing**: they carry
no session, so they fall through to the capped Thoughtful-demo project on their own.

## Metering

Every proxied request writes one content-free row to `llm_usage` — user, provider,
model, token counts, status, duration, ttft. No prompt, no completion, no document
text; only the `usage` block is read out of the response.

- **Streaming** is `tee()`d: one branch to the client byte-for-byte, one drained here
  for the terminal usage event. The meter branch always drains fully, so a user
  closing the sidebar mid-stream doesn't lose tokens OpenAI already billed us for.
  Chat Completions only reports usage when asked, so the proxy injects
  `stream_options.include_usage` on the way out.
- **Two timings, not one.** `duration_ms` is the whole round trip; `ttft_ms` is time
  to first byte — the only one that says whether the assistant *feels* slow. Null for
  non-streaming.
- **Dollars are computed at read time** from `backend/src/pricing.ts`, never stored,
  so a rate change re-prices history. A model with no rate reports `costUsd: null` and
  lands in `unpricedModels` rather than silently costing $0.
- `GET /api/usage_summary?secret=...` (LOG_SECRET-gated) breaks spend down by user
  (labelled with email) and model.

## Storage

One SQLite file — `app.db` — on one shared connection for Better Auth's tables and
ours (`backend/src/db.ts`); previously two connections to the same file. Our schema is
versioned with `PRAGMA user_version` steps (Better Auth introspects, so we don't
collide). A pre-existing `auth.db` is renamed on first open, `-wal`/`-shm` included,
so deployed installs keep their users. `migrate.ts` applies both schemas.

## Consent, and the privacy policy

**Usage metering sits outside the consent tiers**, deliberately. It's operational
billing data — we're charged for the request whether or not the user opted into study
logging — so it's kept at every level, including `none`. That makes #504's `none` copy
false ("nothing about your activity is sent to our servers"), so the policy gains an
"AI Usage Records" section and the label is corrected.

## Deletion: withdrawal vs departure

These were confusingly named and asymmetric — account deletion did **less** than
"delete my data" (it never purged the PostHog person). Both now route through one
`eraseLoggedData()`, so departure is a superset by construction:

```
withdrawal (DELETE /api/me/activity)  ->  eraseLoggedData()
departure  (Better Auth delete-user)  ->  eraseLoggedData() + anonymizeUserUsage() + drop account
```

Usage rows survive account deletion **anonymized, not deleted** — token counts stay,
identity goes, everyone who leaves collapses into one `deleted` bucket. Deleting them
would make our per-user spend stop reconciling with OpenAI's invoice; a per-user
tombstone would be a pseudonym, which is the thing deletion is meant to prevent.

## Testing

63 backend tests, 23 frontend, typecheck clean. Each commit was verified to build and
pass on its own. Covered: the four attribution branches, SSE usage extraction across
chunk boundaries, ttft vs duration diverging, the tombstone, migration idempotency,
the legacy `auth.db` rename in both directions, and `beforeDelete` doing everything
withdrawal does (a test that fails against the old code).

## Follow-ups

- #517 — **post-deploy verification** (reconcile totals against the OpenAI dashboard;
  confirm `deletePosthogPerson` actually works against our PostHog — it's mocked in
  tests and load-bearing for both deletion paths)
- #516 — mirror usage to PostHog AI observability (analytics view; `llm_usage` stays
  the ledger, because it must survive consent opt-out and account deletion)
- #503 — consent UI, untouched by this branch; its endpoint spec is updated for the
  rename