### PR TITLE
Add draft Terms of Service for Google add-on

### DIFF
--- a/frontend/public/termsofservice.html
+++ b/frontend/public/termsofservice.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Albert+Sans:ital,wght@0,100..900;1,100..900&family=Fredoka:wght@300..700&family=Montserrat:ital,wght@0,100..900;1,100..900&family=Nunito+Sans:ital,opsz,wght@0,6..12,200..1000;1,6..12,200..1000&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&family=Urbanist:ital,wght@0,100..900;1,100..900&display=swap"
+    rel="stylesheet">
+  <title>terms-of-service</title>
+  <style>
+    html {
+      color: #1a1a1a;
+      background-color: #fdfdfd;
+    }
+    body {
+      margin: 0 auto;
+      max-width: 36em;
+      padding-left: 50px;
+      padding-right: 50px;
+      padding-top: 50px;
+      padding-bottom: 50px;
+      hyphens: auto;
+      overflow-wrap: break-word;
+      text-rendering: optimizeLegibility;
+      font-kerning: normal;
+      font-family: "Plus Jakarta Sans", sans-serif;
+    }
+    @media (max-width: 600px) {
+      body {
+        font-size: 0.9em;
+        padding: 12px;
+      }
+      h1 {
+        font-size: 1.8em;
+      }
+    }
+    @media print {
+      html {
+        background-color: white;
+      }
+      body {
+        background-color: transparent;
+        color: black;
+        font-size: 12pt;
+      }
+      p, h2, h3 {
+        orphans: 3;
+        widows: 3;
+      }
+      h2, h3, h4 {
+        page-break-after: avoid;
+      }
+    }
+    p {
+      margin: 1em 0;
+    }
+    a {
+      color: #1a1a1a;
+    }
+    a:visited {
+      color: #1a1a1a;
+    }
+    h1, h2, h3, h4, h5, h6 {
+      margin-top: 1.4em;
+    }
+    ol, ul {
+      padding-left: 1.7em;
+      margin-top: 1em;
+    }
+    li > ol, li > ul {
+      margin-top: 0;
+    }
+    blockquote {
+      margin: 1em 0 1em 1.7em;
+      padding-left: 1em;
+      border-left: 2px solid #e6e6e6;
+      color: #606060;
+    }
+    hr {
+      background-color: #1a1a1a;
+      border: none;
+      height: 1px;
+      margin: 1em 0;
+    }
+    /* Draft-only marker for boilerplate to be pasted from a standard service.
+       Remove this rule and all .placeholder blocks before publishing. */
+    .placeholder {
+      margin: 1em 0;
+      padding: 0.75em 1em;
+      border: 1px dashed #b58900;
+      border-radius: 4px;
+      background-color: #fdf6e3;
+      color: #7a5c00;
+      font-size: 0.9em;
+    }
+    .placeholder strong {
+      display: block;
+      margin-bottom: 0.25em;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      font-size: 0.8em;
+    }
+  </style>
+</head>
+<body>
+  <h1 id="terms-of-service">Terms of Service for AI Writing Assistant Add-in</h1>
+  <p>Last Updated: [DATE]</p>
+
+  <div class="placeholder">
+    <strong>Draft notice — remove before publishing</strong>
+    This document contains only the clauses specific to this product. Sections marked
+    as placeholders below are standard boilerplate to be pasted in from a reviewed
+    standard Terms of Service and adapted (provider is an individual based in Michigan;
+    governing law Michigan). The whole document, and especially the eligibility /
+    minors provisions, should be reviewed by a lawyer and checked against the IRB
+    protocol before it goes live.
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Introduction &amp; acceptance of terms</strong>
+    Standard opening: who "we" are, that these Terms govern use of the Add-in, and
+    that by using the Add-in the user agrees to them. Include the relationship to the
+    <a href="privacypolicy.html">Privacy Policy</a> (incorporated by reference).
+  </div>
+
+  <h2 id="eligibility">Eligibility</h2>
+  <p>You may use the Add-in if you are 18 or older and can form a binding agreement.</p>
+  <p>If you are under 18, you may use the Add-in only where your school or educational
+  institution has entered into an agreement with us and has authorized your use. In
+  that case, your school is responsible for obtaining any parental or guardian consent
+  required by law before you use the Add-in, and your use is also subject to your
+  school's own policies.</p>
+  <p>We do not knowingly allow children under 13 to use the Add-in except through a
+  participating school that has provided the consent required under the Children's
+  Online Privacy Protection Act (COPPA) on behalf of a parent or guardian. If we learn
+  that a child under 13 has used the Add-in without such consent, we will delete their
+  information.</p>
+  <blockquote>
+    <p>Review note: this clause presumes a written school agreement exists before any
+    minor uses the product (the standard COPPA "school consent" path), and that the
+    Privacy Policy has a corresponding minors section. Until those exist, effective
+    eligibility is 18+. Confirm the IRB protocol covers minors before enabling K-12
+    use. Remove this note before publishing.</p>
+  </blockquote>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Accounts &amp; registration</strong>
+    Standard account terms: accurate information, responsibility for account security
+    and activity, one account per person, notify us of unauthorized use. Sign-in is via
+    Google (see the Privacy Policy for what account data we receive).
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Description of the service / license to use</strong>
+    Standard grant of a limited, revocable, non-exclusive, non-transferable license to
+    use the Add-in, and note that it runs inside Microsoft Word and Google Docs subject
+    to those platforms' own terms.
+  </div>
+
+  <h2 id="ai-generated-suggestions">AI-generated suggestions</h2>
+  <p>The Add-in uses artificial intelligence to generate writing suggestions. You are
+  interacting with an automated system, not a human.</p>
+  <p>Suggestions are generated automatically and may be inaccurate, incomplete,
+  misleading, or unsuitable for your purpose. We do not review suggestions before you
+  see them and we do not guarantee they are correct, original, or fit for any
+  particular use. You are responsible for reviewing, editing, and deciding whether to
+  use any suggestion before relying on it. Any decision you make based on a suggestion
+  is your own.</p>
+
+  <h2 id="your-content-and-ai-suggestions">Your content and AI suggestions</h2>
+  <p>You keep all rights to the text you write and provide ("Your Content"). We do not
+  claim ownership of Your Content.</p>
+  <p>As between you and us, you own the suggestions the Add-in generates for you, and to
+  the extent we hold any rights in those suggestions, we assign them to you. We make no
+  promise that AI-generated text qualifies for copyright or any other legal protection,
+  and whether it does is outside our control.</p>
+
+  <h2 id="how-we-use-your-content">How we use Your Content</h2>
+  <p>We send the relevant part of Your Content to our AI provider only to generate the
+  suggestion you request, as described in our <a href="privacypolicy.html">Privacy
+  Policy</a>. We do not otherwise use Your Content, except that if you choose a
+  study-logging level and agree to our separate research study consent, we may retain
+  and analyze the data described in that consent for the research study. What we store
+  is always governed by the logging level you choose. We do not use Your Content to
+  train general-purpose AI models.</p>
+
+  <h2 id="academic-integrity">Academic integrity</h2>
+  <p>If you use the Add-in for schoolwork, you are responsible for following your
+  school's or institution's academic-integrity rules. You are responsible for how you
+  use the suggestions the Add-in provides. The Add-in is a writing aid; it is your work
+  and your responsibility.</p>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Acceptable use</strong>
+    Standard restrictions: no unlawful use, no reverse engineering, no interference with
+    or overloading the service, no abuse or attempts to circumvent access controls, no
+    infringing or harmful content.
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Our intellectual property</strong>
+    Standard clause: we (and our licensors) own the Add-in, its software, name, and
+    branding; nothing in these Terms transfers those rights to the user.
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Third-party services</strong>
+    Standard clause noting reliance on third parties (AI provider, Google, Microsoft,
+    analytics) each governed by their own terms; cross-reference the Privacy Policy for
+    data handling.
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Disclaimer of warranties</strong>
+    Standard "as is / as available," no warranties of any kind, no guarantee of
+    availability or uptime. (The AI-specific accuracy disclaimer is already stated above
+    under "AI-generated suggestions.")
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Limitation of liability</strong>
+    Standard limitation/cap on liability, exclusion of indirect and consequential
+    damages, to the extent permitted by law.
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Indemnification</strong>
+    Standard user indemnification for misuse or violation of these Terms (consider
+    softening for a free / academic tool).
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Termination</strong>
+    Standard clause: we may suspend or terminate access for violations; what happens on
+    termination; data handling on termination defers to the Privacy Policy.
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Changes to these Terms</strong>
+    Standard clause: we may update these Terms and will notify users of material changes
+    through the Add-in or by email.
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Governing law &amp; disputes</strong>
+    Governing law: State of Michigan, USA. Standard venue / dispute-resolution language.
+  </div>
+
+  <div class="placeholder">
+    <strong>Boilerplate — Contact</strong>
+    Contact address for questions about these Terms.
+  </div>
+
+  <hr />
+  <p>Note: These Terms apply specifically to our AI Writing Assistant Add-in and not to
+  other products or services we may offer.</p>
+</body>
+</html>


### PR DESCRIPTION
## What this is

A **draft** Terms of Service at `frontend/public/termsofservice.html`, served the same way as `privacypolicy.html`. Google Workspace Marketplace (and OAuth verification, which we hit via Google sign-in) requires a Terms of Service URL on our own domain — this fills that gap for the Google add-on.

It contains **only the product-specific clauses**. Everything a standard/off-the-shelf ToS would supply is left as clearly labeled `[BOILERPLATE]` placeholders to paste in later from a reviewed standard document. The prose is written fresh (not copied from the AI-generated privacy policy's voice).

## Custom clauses included

- **Eligibility** — 18+, with a school-consent path for minors (COPPA "school as parent's agent" model) so we can grow into K-12 later. Effective floor stays 18+ until the school agreement + a minors section in the privacy policy exist.
- **AI-generated suggestions** — automated-system transparency (relevant to the EU AI Act transparency rules effective Aug 2, 2026) plus the accuracy disclaimer / user-must-review language.
- **Your content and AI suggestions** — user keeps their content; output ownership assigned "as between you and us," without falsely promising AI text is copyrightable.
- **How we use Your Content** — limited research license scoped to consented study-logging users, tied to the separate study consent; no general model-training use.
- **Academic integrity** — user's own responsibility to follow their institution's rules.

## Placeholders left for boilerplate

Introduction/acceptance, accounts, license to use, acceptable use, our IP, third-party services, warranty disclaimer, limitation of liability, indemnification, termination, changes to terms, governing law (**Michigan**), and contact.

## Before this ships

- Lawyer review of the whole document, especially eligibility/minors and liability.
- The K-12 path assumes a written school agreement and a minors section in the privacy policy; it also interacts with the IRB protocol (research on minors). Confirm those before enabling under-18 use.
- Fill in `[DATE]`, provider identity, and contact.

Draft PR — not for merge as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SZ7PJeS6R72iRmxKabYpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_017SZ7PJeS6R72iRmxKabYpZ)_