### PR TITLE
Add debug tools to add-in runtime image + track image size in CI

### DIFF
--- a/.github/workflows/build-addin-image.yml
+++ b/.github/workflows/build-addin-image.yml
@@ -64,6 +64,22 @@ jobs:
       - name: Audit build context
         run: ./scripts/audit-build-context.sh .
 
+      # Fetched before the push below overwrites `latest`, so this is the
+      # pre-build baseline to diff the new image against. Guards for a
+      # non-flat manifest (e.g. an attestation index left over from before
+      # `provenance: false` below) by falling back to "no baseline" rather
+      # than erroring — .manifests[].size on an index is the tiny JSON
+      # document size, not the image size, so it's not a usable number here.
+      - name: Record baseline size (current latest)
+        id: baseline
+        run: |
+          image=ghcr.io/aitoolslab/writing-tools-addin:latest
+          size=""
+          if manifest=$(docker buildx imagetools inspect "$image" --raw 2>/dev/null); then
+            size=$(jq -r 'if has("layers") then ([.config.size] + [.layers[].size] | add) else empty end' <<<"$manifest")
+          fi
+          echo "size=$size" >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
@@ -80,3 +96,59 @@ jobs:
             GIT_COMMIT=${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Nothing downstream consumes SLSA provenance/SBOM attestations, and
+          # leaving them on turns the pushed ref into a multi-manifest index
+          # (image manifest + attestation manifest) instead of a flat
+          # single-arch image manifest, which would break the size check below.
+          provenance: false
+          sbom: false
+
+      # Reads the manifest just pushed above (a small registry API call, not a
+      # full image pull) to report and track compressed image size over time.
+      - name: Report image size
+        env:
+          BASELINE_SIZE: ${{ steps.baseline.outputs.size }}
+          # Warn (never fail) once growth vs. the current `latest` passes this
+          # fraction. Bump this if a change intentionally grows the image.
+          WARN_THRESHOLD: "0.15"
+        run: |
+          image=ghcr.io/aitoolslab/writing-tools-addin:${{ github.sha }}
+          manifest=$(docker buildx imagetools inspect "$image" --raw)
+          new_size=$(jq -r 'if has("layers") then ([.config.size] + [.layers[].size] | add) else empty end' <<<"$manifest")
+
+          if [ -z "$new_size" ]; then
+            echo "### Add-in image size" >> "$GITHUB_STEP_SUMMARY"
+            echo "Pushed manifest wasn't the expected flat single-arch shape; skipping size report." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          new_human=$(numfmt --to=iec-i --suffix=B "$new_size")
+
+          {
+            echo "### Add-in image size"
+            echo
+            echo "| tag | compressed size |"
+            echo "|---|---|"
+            echo "| \`${{ github.sha }}\` | ${new_human} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ -z "$BASELINE_SIZE" ]; then
+            echo "No previous \`latest\` image found; nothing to compare against." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          base_human=$(numfmt --to=iec-i --suffix=B "$BASELINE_SIZE")
+          delta=$((new_size - BASELINE_SIZE))
+          delta_human=$(numfmt --to=iec-i --suffix=B "${delta#-}")
+          [ "$delta" -lt 0 ] && delta_human="-${delta_human}"
+          pct=$(awk -v b="$BASELINE_SIZE" -v d="$delta" 'BEGIN { printf "%.1f", (d / b) * 100 }')
+
+          {
+            echo "| previous \`latest\` | ${base_human} |"
+            echo "| delta | ${delta_human} (${pct}%) |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          over=$(awk -v b="$BASELINE_SIZE" -v d="$delta" -v t="$WARN_THRESHOLD" 'BEGIN { print (d > b * t) ? "1" : "0" }')
+          if [ "$over" = "1" ]; then
+            echo "::warning title=Image size grew ${pct}%::New add-in image is ${new_human} vs ${base_human} previously (+${delta_human}, ${pct}%), over the ${WARN_THRESHOLD} threshold. Check for accidentally added layers/deps."
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,14 @@ RUN npm run build
 FROM node:24-slim AS run
 WORKDIR /app/backend
 ENV NODE_ENV=production
+# Debug tools for shelling into a running/deployed container.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sqlite3 \
+    less \
+    curl \
+    ca-certificates \
+    vim \
+    && rm -rf /var/lib/apt/lists/*
 # Surfaced by GET /api/ping (backend/src/config.ts) so a deployed container can
 # be traced back to the commit it was built from.
 ARG GIT_COMMIT=unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     vim \
+    jq \
+    htop \
+    procps \
+    netcat-openbsd \
     && rm -rf /var/lib/apt/lists/*
 # Surfaced by GET /api/ping (backend/src/config.ts) so a deployed container can
 # be traced back to the commit it was built from.


### PR DESCRIPTION
## Summary
- Install `sqlite3`, `less`, `curl`, `ca-certificates`, `vim`, `jq`, `htop`, `procps`, and `netcat-openbsd` in the runtime stage of the root `Dockerfile`, so the deployed add-in container has basic tools for poking around when debugging.
- Add an image-size check to `build-addin-image.yml`: after pushing, it reads the pushed manifest (`docker buildx imagetools inspect --raw`, a small registry API call — not a full image pull) to compute the compressed size, reports it in the job summary alongside the delta vs. the current `latest` tag, and emits a `::warning::` (never fails the build) if size grows more than 15%.
- Disable `provenance`/`sbom` attestations on the push, since nothing downstream consumes them and leaving them on turns the pushed ref into a multi-manifest index instead of a flat single-arch manifest, which the size check relies on.

## Test plan
- [ ] CI build (`Build add-in image` workflow) runs successfully and the job summary shows a size table
- [ ] `docker exec` into a deployed container and confirm `sqlite3`, `curl`, `less`, `jq`, `vim`, `htop`, `nc` are on `PATH`
- [ ] First post-merge run degrades gracefully (no crash) if the existing `latest` tag is still index-shaped from before this change


---
_Generated by [Claude Code](https://claude.ai/code/session_01AjvEktiqK2X5EANAEr3n5h)_