### PR TITLE
switch to gpt-5.6-terra on low reasoning

### DIFF
--- a/backend/src/pricing.ts
+++ b/backend/src/pricing.ts
@@ -25,6 +25,7 @@ interface Rate {
 const RATES: Record<string, Rate> = {
 	'gpt-4o': { input: 2.5, cachedInput: 1.25, output: 10.0 },
 	'gpt-4o-mini': { input: 0.15, cachedInput: 0.075, output: 0.6 },
+	'gpt-5.6-terra': { input: 2.5, cachedInput: 0.25, output: 15.0 },
 };
 
 function rateFor(model: string): Rate | null {

--- a/frontend/src/api/openai.ts
+++ b/frontend/src/api/openai.ts
@@ -1,4 +1,7 @@
-import { createOpenAI } from '@ai-sdk/openai';
+import {
+	createOpenAI,
+	type OpenAIResponsesProviderOptions,
+} from '@ai-sdk/openai';
 import { SERVER_URL } from './index';
 
 /**
@@ -42,4 +45,19 @@ export const openai = createOpenAI({
 	fetch: authorizedFetch,
 });
 
-export const OPENAI_MODEL = 'gpt-4o';
+export const OPENAI_MODEL = 'gpt-5.6-terra';
+
+/**
+ * The shared language model for all generation. `openai.responses()` selects the
+ * Responses API (rather than `openai.chat()` / Chat Completions), which is what
+ * the reasoning models expect.
+ */
+export const languageModel = openai.responses(OPENAI_MODEL);
+
+/**
+ * Passed as `providerOptions` on every `streamText` call. Low reasoning effort
+ * keeps latency down for the interactive writing-help flows.
+ */
+export const openaiProviderOptions = {
+	openai: { reasoningEffort: 'low' } satisfies OpenAIResponsesProviderOptions,
+};

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -3,7 +3,7 @@ import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { AiOutlineArrowDown, AiOutlineSend } from 'react-icons/ai';
 import { Remark } from 'react-remark';
 
-import { OPENAI_MODEL, openai } from '@/api/openai';
+import { languageModel, openaiProviderOptions } from '@/api/openai';
 import { ChatContext } from '@/contexts/chatContext';
 import { EditorContext } from '@/contexts/editorContext';
 import { useDocContext } from '@/utilities';
@@ -134,7 +134,8 @@ export default function Chat() {
 
 		try {
 			const result = streamText({
-				model: openai.chat(OPENAI_MODEL),
+				model: languageModel,
+				providerOptions: openaiProviderOptions,
 				messages: newMessages.slice(0, -1) as ModelMessage[],
 				maxOutputTokens: 1024,
 				abortSignal: requestController.signal,

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -11,7 +11,7 @@ import {
 	useState,
 } from 'react';
 import { Remark } from 'react-remark';
-import { OPENAI_MODEL, openai } from '@/api/openai';
+import { languageModel, openaiProviderOptions } from '@/api/openai';
 import { buildMessages } from '@/api/prompts';
 import { EditorContext } from '@/contexts/editorContext';
 import { useLog } from '@/hooks/useLog';
@@ -71,7 +71,8 @@ class Fetcher {
 			) as ModelMessage[];
 
 			const stream = streamText({
-				model: openai.chat(OPENAI_MODEL),
+				model: languageModel,
+				providerOptions: openaiProviderOptions,
 				messages,
 				abortSignal: AbortSignal.timeout(20000),
 			});

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -21,7 +21,7 @@ import {
 	AiOutlineQuestionCircle
 } from 'react-icons/ai';
 import { isRunningInGoogleDocs } from '@/api';
-import { OPENAI_MODEL, openai } from '@/api/openai';
+import { languageModel, openaiProviderOptions } from '@/api/openai';
 import { EditorContext } from '@/contexts/editorContext';
 import { useDocContext } from '@/utilities';
 import TagLinker from '../tag-linker';
@@ -292,7 +292,8 @@ ${request}
 
 			try {
 				const result = streamText({
-					model: openai.chat(OPENAI_MODEL),
+					model: languageModel,
+					providerOptions: openaiProviderOptions,
 					system: systemPrompt,
 					messages,
 					maxOutputTokens: 1024,

--- a/frontend/tests/draft-flows.spec.ts
+++ b/frontend/tests/draft-flows.spec.ts
@@ -111,7 +111,7 @@ const adviceLocator = 'button[title="Get suggestions for next words"]';
   const adviceButton = frame.locator(adviceLocator);
 
   // Mock backend with delay and realistic streamed response
-  await page.route('**/openai/chat/completions', async (route) => {
+  await page.route('**/openai/responses', async (route) => {
     await page.waitForTimeout(1000); // simulate network delay
     await fulfillOpenAI(
       route,

--- a/frontend/tests/mockBackend.ts
+++ b/frontend/tests/mockBackend.ts
@@ -4,9 +4,10 @@ import { Page, Route } from '@playwright/test';
  * Mock the OpenAI-compatible endpoint the frontend now talks to.
  *
  * The frontend uses the AI SDK's OpenAI provider (src/api/openai.ts) pointed at
- * `${SERVER_URL}/openai`, and calls streamText(). So the real wire request is a
- * POST to `/api/openai/chat/completions` with an OpenAI chat-completions body,
- * and the response must be an OpenAI-format SSE stream.
+ * `${SERVER_URL}/openai`, via `openai.responses()`, and calls streamText(). So the
+ * real wire request is a POST to `/api/openai/responses` with a Responses-API body
+ * (`instructions` for the system prompt, `input` for the message turns), and the
+ * response must be a Responses-API SSE stream (`response.output_text.delta` events).
  */
 
 const RESULTS = {
@@ -25,11 +26,28 @@ const RESULTS = {
   chat: 'This is a mock assistant reply about your document.',
 };
 
+// The Responses request body carries the prompt in two places: the system prompt as
+// `instructions`, and the message turns as `input`, each turn's content an array of
+// parts ({ type: 'input_text' | 'output_text', text }). Flatten all of it to text.
+type ResponsesBody = {
+  instructions?: string;
+  input?: Array<{ content?: string | Array<{ text?: string }> }>;
+};
+
+function textFromRequest(body: ResponsesBody): string {
+  const parts: string[] = [];
+  if (body.instructions) parts.push(body.instructions);
+  for (const turn of body.input ?? []) {
+    if (typeof turn.content === 'string') parts.push(turn.content);
+    else for (const p of turn.content ?? []) if (p.text) parts.push(p.text);
+  }
+  return parts.join('\n');
+}
+
 // gtype is no longer sent in the request; infer it from distinctive prompt text.
 // Draft prompts live in src/api/prompts.ts; Chat and Revise build their own
 // system/user messages in their page components.
-function resultForMessages(messages: { content: string }[]): string {
-  const text = messages.map((m) => m.content).join('\n');
+function resultForText(text: string): string {
   if (text.includes('inspiring and fresh possible next sentences'))
     return RESULTS.example_sentences;
   if (text.includes('questions the person might have'))
@@ -46,24 +64,35 @@ function resultForMessages(messages: { content: string }[]): string {
   return '';
 }
 
-// Frame text as an OpenAI chat-completions SSE stream so the AI SDK can parse it.
+// Frame text as a Responses-API SSE stream so the AI SDK's responses provider can
+// parse it: open a message item, stream one text delta, then complete with usage.
 function sseFromText(text: string): string {
-  const base = {
-    id: 'chatcmpl-mock',
-    object: 'chat.completion.chunk',
-    created: 0,
-    model: 'gpt-4o',
-  };
-  const chunk = (delta: object, finish: string | null = null) =>
-    `data: ${JSON.stringify({
-      ...base,
-      choices: [{ index: 0, delta, finish_reason: finish }],
-    })}\n\n`;
-  return chunk({ role: 'assistant', content: text }) + chunk({}, 'stop') + 'data: [DONE]\n\n';
+  const event = (payload: object) => `data: ${JSON.stringify(payload)}\n\n`;
+  return (
+    event({
+      type: 'response.created',
+      response: { id: 'resp-mock', created_at: 0, model: 'gpt-5.6-terra' },
+    }) +
+    event({
+      type: 'response.output_item.added',
+      output_index: 0,
+      item: { type: 'message', id: 'msg-mock' },
+    }) +
+    event({
+      type: 'response.output_text.delta',
+      item_id: 'msg-mock',
+      delta: text,
+    }) +
+    event({
+      type: 'response.completed',
+      response: { usage: { input_tokens: 0, output_tokens: 0 } },
+    }) +
+    'data: [DONE]\n\n'
+  );
 }
 
 /**
- * Fulfill an intercepted /openai/chat/completions route with an SSE stream.
+ * Fulfill an intercepted /openai/responses route with an SSE stream.
  * Exported so tests that need custom behavior (e.g. an added delay) can reuse it.
  */
 export async function fulfillOpenAI(route: Route, result: string) {
@@ -104,10 +133,8 @@ export async function setupMockBackend(page: Page) {
     });
   });
 
-  await page.route('**/openai/chat/completions', async (route) => {
-    const messages = (route.request().postDataJSON()?.messages ?? []) as {
-      content: string;
-    }[];
-    await fulfillOpenAI(route, resultForMessages(messages));
+  await page.route('**/openai/responses', async (route) => {
+    const body = (route.request().postDataJSON() ?? {}) as ResponsesBody;
+    await fulfillOpenAI(route, resultForText(textFromRequest(body)));
   });
 }


### PR DESCRIPTION
Input-token price is identical to (or lower than) gpt-4o.

Output cost is a bit higher, but writing feedback is input-heavy.

There might be a bit more latency, but we can watch telemetry.