### PR TITLE
backend: add /api/openai/responses passthrough route

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -17,15 +17,19 @@ thin: it proxies OpenAI requests with the server-held API key and writes study l
   both schemas and is the deploy-time entrypoint (k8s initContainer). A pre-existing
   `auth.db` (the old name, when Better Auth was the only tenant) is renamed to `app.db`
   on first open, siblings included.
-- **OpenAI proxy** (`src/openaiProxy.ts`): `POST /api/openai/chat/completions` injects a
-  server-held API key and streams the upstream SSE response through unchanged. The
+- **OpenAI proxy** (`src/openaiProxy.ts`): `POST /api/openai/chat/completions` and
+  `/api/openai/responses` inject a server-held API key and relay the upstream response
+  through unchanged (`stream:true` piped as SSE, everything else buffered). The
   frontend's ai-sdk client builds the prompts and points at this route, sending the
   session token as its bearer. `attributeRequest` decides **which key pays**, and the
   usage bucket always names the key that was charged so the summary reconciles against
   the right invoice: a session → `OPENAI_API_KEY`, metered to that user; no session →
   `OPENAI_DEMO_API_KEY` (the capped Thoughtful-demo project), metered to `demo` — this
   is how demo mode and the pre-sign-in editor work; no session and no demo key → 401 if
-  auth is on (fail closed), else the main key metered to `anonymous` (local dev).
+  auth is on (fail closed), else the main key metered to `anonymous` (local dev). An
+  empty-bodied upstream 200 is rejected as a 502 (undici h2 transport failures on Node
+  26 otherwise surface as silent empty 200s — see the comment in `openaiProxy.ts`; run
+  Node 24 LTS).
 - **Usage metering** (`src/usage.ts`, `src/pricing.ts`): every proxied model request
   writes a content-free row (user, model, token counts, status) to the `llm_usage`
   table. Streaming responses are `tee()`d so usage can be read from the

--- a/backend/src/__tests__/openaiProxy.test.ts
+++ b/backend/src/__tests__/openaiProxy.test.ts
@@ -510,6 +510,74 @@ describe('POST /api/openai/chat/completions', () => {
 		const rows = await waitForUsage();
 		expect(rows[0]).toMatchObject({ userId: ANONYMOUS_USER_ID });
 	});
+
+	it('rejects an empty-bodied upstream 200 as a 502 instead of relaying it', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(null, {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					}),
+			),
+		);
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+		const res = await appWithUser(real('usr-e')).request(
+			'/api/openai/chat/completions',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o' }),
+			},
+		);
+
+		expect(res.status).toBe(502);
+		expect(await res.json()).toEqual({
+			detail: 'Upstream returned an empty response',
+		});
+		expect(errSpy).toHaveBeenCalledOnce();
+	});
+});
+
+describe('POST /api/openai/responses', () => {
+	it('proxies to the responses endpoint and meters usage to the session user', async () => {
+		const body = {
+			model: 'gpt-4o-2024-08-06',
+			output: [{ content: [{ text: 'Hi' }] }],
+			usage: { input_tokens: 40, output_tokens: 9 },
+		};
+		const fetchMock = vi.fn(
+			async (_url: string, _init: RequestInit) =>
+				new Response(JSON.stringify(body), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				}),
+		);
+		vi.stubGlobal('fetch', fetchMock);
+
+		const res = await appWithUser(real('usr-r')).request(
+			'/api/openai/responses',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ model: 'gpt-4o', input: 'hi' }),
+			},
+		);
+
+		expect(res.status).toBe(200);
+		expect(fetchMock.mock.calls[0]?.[0]).toBe(
+			'https://api.openai.com/v1/responses',
+		);
+		expect(await res.json()).toEqual(body);
+		const rows = await waitForUsage();
+		expect(rows[0]).toMatchObject({
+			userId: 'usr-r',
+			inputTokens: 40,
+			outputTokens: 9,
+		});
+	});
 });
 
 describe('GET /api/usage_summary', () => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -61,6 +61,15 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 			authEnabled: !!auth,
 		}),
 	);
+	// Responses API — same attribution, metering, and key selection, just a
+	// different upstream endpoint.
+	app.post(
+		'/api/openai/responses',
+		openaiProxy('responses', {
+			resolveUser,
+			authEnabled: !!auth,
+		}),
+	);
 
 	// Resolve the authenticated user from the request's session, or null. Returns
 	// null when auth is disabled (dev/tests without BETTER_AUTH_ENABLED) so the

--- a/backend/src/openaiProxy.ts
+++ b/backend/src/openaiProxy.ts
@@ -288,6 +288,23 @@ export function openaiProxy(endpoint: OpenAIEndpoint, options: ProxyOptions) {
 
 		if (!streaming || !upstream.body) {
 			const text = await upstream.text();
+			// An empty-bodied upstream 200 is a transport failure, not a real
+			// response: Node 26's undici negotiates HTTP/2 to api.openai.com by
+			// default (undici 8 flipped `allowH2` on) and its h2 client can tear a
+			// stream down after headers arrive — e.g. GOAWAY on a pinned idle
+			// session, undici#5381 / undici#5468 — without erroring, delivering
+			// 200 + 0 bytes. Buffering (above) turns most such failures into a
+			// thrown read (→ onError → 500); a clean empty 200 is rejected as a 502
+			// here rather than forwarded for the client to choke on. Observed
+			// intermittently on Node 26.4 in 2026-07; Node 24 (HTTP/1.1) is
+			// unaffected.
+			if (upstream.ok && text.length === 0) {
+				console.error(
+					`[openai-proxy] ${endpoint}: upstream ${upstream.status} with empty body — returning 502`,
+				);
+				meter(null, null, null);
+				return c.json({ detail: 'Upstream returned an empty response' }, 502);
+			}
 			let parsed: unknown = null;
 			try {
 				parsed = JSON.parse(text);


### PR DESCRIPTION
Adds a sibling proxy route for the OpenAI Responses API alongside the existing chat/completions passthrough. Both share one helper that injects the server-held API key and streams the upstream response back unchanged; only the upstream endpoint differs. The chat/completions route is untouched, so existing frontend/prototype clients keep working.