### PR TITLE
feat(consent): standalone account & privacy page + shared consent chooser (#503 PR 1)

### DIFF
--- a/backend/src/__tests__/app.test.ts
+++ b/backend/src/__tests__/app.test.ts
@@ -19,12 +19,20 @@ function makeAuthApp(user: { id: string; loggingConsent?: string } | null) {
 	};
 	const auth = {
 		handler: async () => new Response(null),
+		// The consent route writes server-controlled fields through the internal
+		// adapter (the public updateUser endpoint rejects input:false fields at
+		// runtime with FIELD_NOT_ALLOWED — a live-server behaviour this mock
+		// deliberately mirrors by not exposing api.updateUser at all).
+		$context: Promise.resolve({
+			internalAdapter: {
+				updateUser: async (userId: string, data: unknown) => {
+					calls.updateUser.push({ userId, data });
+					return {};
+				},
+			},
+		}),
 		api: {
 			getSession: async () => (user ? { user } : null),
-			updateUser: async (args: unknown) => {
-				calls.updateUser.push(args);
-				return { status: true };
-			},
 			deleteUser: async (args: unknown) => {
 				calls.deleteUser.push(args);
 				return { success: true, message: 'ok' };
@@ -195,7 +203,12 @@ describe('POST /api/me/consent', () => {
 		});
 		expect(good.status).toBe(200);
 		expect(await good.json()).toEqual({ loggingConsent: 'ai_output' });
-		expect(calls.updateUser).toHaveLength(1);
+		expect(calls.updateUser).toEqual([
+			{
+				userId: 'usr-1',
+				data: expect.objectContaining({ loggingConsent: 'ai_output' }),
+			},
+		]);
 	});
 
 	it('401s without a session', async () => {

--- a/backend/src/__tests__/app.test.ts
+++ b/backend/src/__tests__/app.test.ts
@@ -19,10 +19,11 @@ function makeAuthApp(user: { id: string; loggingConsent?: string } | null) {
 	};
 	const auth = {
 		handler: async () => new Response(null),
-		// The consent route writes server-controlled fields through the internal
-		// adapter (the public updateUser endpoint rejects input:false fields at
-		// runtime with FIELD_NOT_ALLOWED — a live-server behaviour this mock
-		// deliberately mirrors by not exposing api.updateUser at all).
+		// The consent route writes through internalAdapter, not api.updateUser
+		// (see app.ts for why: the public updateUser rejects input:false fields at
+		// runtime). This mock therefore exposes internalAdapter.updateUser and
+		// deliberately omits api.updateUser, matching what the live route can and
+		// cannot call.
 		$context: Promise.resolve({
 			internalAdapter: {
 				updateUser: async (userId: string, data: unknown) => {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -185,15 +185,14 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 			);
 		}
 
-		await auth.api.updateUser({
-			// loggingConsent/consentUpdatedAt are `input: false`, so Better Auth
-			// strips them from the client-input type even though updateUser writes
-			// them server-side. Cast past that purely-type restriction.
-			body: {
-				loggingConsent: level,
-				consentUpdatedAt: new Date(),
-			} as unknown as never,
-			headers: c.req.raw.headers,
+		// loggingConsent/consentUpdatedAt are `input: false`, which the public
+		// updateUser endpoint enforces at runtime (FIELD_NOT_ALLOWED) — not just
+		// in the types. Server-controlled fields are written through the internal
+		// adapter instead: that's the server-side path the declaration intends.
+		const ctx = await auth.$context;
+		await ctx.internalAdapter.updateUser(user.id, {
+			loggingConsent: level,
+			consentUpdatedAt: new Date(),
 		});
 		return c.json({ loggingConsent: level });
 	});

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -186,9 +186,15 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 		}
 
 		// loggingConsent/consentUpdatedAt are `input: false`, which the public
-		// updateUser endpoint enforces at runtime (FIELD_NOT_ALLOWED) — not just
-		// in the types. Server-controlled fields are written through the internal
-		// adapter instead: that's the server-side path the declaration intends.
+		// updateUser endpoint enforces at RUNTIME (FIELD_NOT_ALLOWED), not just in
+		// the types — so a server-controlled field can't be written through it.
+		// We use the same write path Better Auth uses internally for its OWN
+		// /update-user route (ctx.context.internalAdapter.updateUser — see
+		// better-auth/dist/api/routes/update-user.mjs); the public endpoint is that
+		// call plus the client-input guard we intentionally skip here. Not part of
+		// Better Auth's documented public API, but its own mechanism. A raw SQL
+		// UPDATE via our db() connection was rejected as more fragile — it would
+		// bypass Better Auth's date serialization and any user hooks.
 		const ctx = await auth.$context;
 		await ctx.internalAdapter.updateUser(user.id, {
 			loggingConsent: level,

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -60,8 +60,9 @@ export const auth = betterAuth({
 	secret: betterAuthSecret(),
 	trustedOrigins: betterAuthTrustedOrigins(),
 	// Logging-consent level lives on the user record so it's available on every
-	// session. Server-controlled (`input: false`): set only via auth.api.updateUser
-	// from our /api/me/consent route, never accepted from sign-up input. The enum and
+	// session. Server-controlled (`input: false`): set only via the internal adapter
+	// from our /api/me/consent route (the public updateUser endpoint rejects
+	// input:false fields at runtime), never accepted from sign-up input. The enum and
 	// default come straight from consent.ts (the single source of truth). New users
 	// default to 'usage' (content-free); content logging requires opting up.
 	user: {

--- a/frontend/account.html
+++ b/frontend/account.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Account &amp; Privacy</title>
+	</head>
+
+	<body>
+		<div id="container"></div>
+		<script type="module" src="./src/account/index.tsx"></script>
+	</body>
+</html>

--- a/frontend/src/account/AccountPage.tsx
+++ b/frontend/src/account/AccountPage.tsx
@@ -1,0 +1,263 @@
+/**
+ * Standalone account & privacy page (authenticated).
+ *
+ * Lets a signed-in user exercise the "Your Rights and Choices" actions from the
+ * privacy policy, which are deliberately three *different* things:
+ *   - change their logging-consent level        → POST /api/me/consent
+ *   - erase their logged activity (withdrawal)   → DELETE /api/me/activity
+ *   - delete their account (departure)           → POST /api/auth/delete-user
+ *
+ * Delete requires a *fresh* session (Better Auth freshAge). Our Google-only
+ * accounts have no password and no email-verification flow, so a stale session is
+ * rejected and we drive a re-authentication before retrying — the re-auth doubles
+ * as the strong confirmation an irreversible action deserves.
+ */
+import { useState } from 'react';
+import { Button } from 'reshaped';
+import { changeConsent, deleteAccount, eraseActivity } from '@/api/account';
+import { clearToken, loadToken } from '@/api/authTokenStore';
+import { ConsentLevelChooser } from '@/components/ConsentLevelChooser';
+import type { ConsentLevel } from '@/consent';
+import { useAppAuth } from '@/contexts/appAuthContext';
+import { DeviceCodePanel } from './DeviceCodePanel';
+import classes from './styles.module.css';
+
+type ConsentStatus = 'idle' | 'saving' | 'saved' | 'error';
+type EraseStatus = 'idle' | 'confirm' | 'working' | 'done' | 'error';
+type DeleteStatus =
+	| 'idle'
+	| 'confirm'
+	| 'working'
+	| 'needs-reauth'
+	| 'done'
+	| 'error';
+
+export function AccountPage() {
+	const session = useAppAuth();
+
+	const [level, setLevel] = useState<ConsentLevel>(session.loggingConsent);
+	const [consentStatus, setConsentStatus] = useState<ConsentStatus>('idle');
+
+	const [eraseStatus, setEraseStatus] = useState<EraseStatus>('idle');
+	const [eraseError, setEraseError] = useState<string | null>(null);
+
+	const [deleteStatus, setDeleteStatus] = useState<DeleteStatus>('idle');
+	const [deleteError, setDeleteError] = useState<string | null>(null);
+
+	// --- change logging level -------------------------------------------------
+	const onChangeLevel = async (next: ConsentLevel) => {
+		const previous = level;
+		setLevel(next); // optimistic
+		setConsentStatus('saving');
+		try {
+			const token = await session.getAccessToken();
+			await changeConsent(token, next);
+			setConsentStatus('saved');
+		} catch {
+			setLevel(previous); // roll back on failure
+			setConsentStatus('error');
+		}
+	};
+
+	// --- erase activity (withdrawal) ------------------------------------------
+	const onErase = async () => {
+		setEraseStatus('working');
+		setEraseError(null);
+		try {
+			const token = await session.getAccessToken();
+			await eraseActivity(token);
+			setEraseStatus('done');
+		} catch {
+			setEraseStatus('error');
+			setEraseError('Could not erase your activity. Please try again.');
+		}
+	};
+
+	// --- delete account (departure) -------------------------------------------
+	const runDelete = async () => {
+		setDeleteStatus('working');
+		setDeleteError(null);
+		let token: string | null;
+		try {
+			token = await session.getAccessToken();
+		} catch {
+			token = loadToken();
+		}
+		if (!token) {
+			setDeleteStatus('needs-reauth');
+			return;
+		}
+		let result: Awaited<ReturnType<typeof deleteAccount>>;
+		try {
+			result = await deleteAccount(token);
+		} catch {
+			setDeleteStatus('error');
+			setDeleteError('Could not delete your account. Please try again.');
+			return;
+		}
+		if (result.ok) {
+			clearToken();
+			setDeleteStatus('done');
+			return;
+		}
+		if (result.staleSession) {
+			// Session too old to delete — require a fresh sign-in, then retry.
+			setDeleteStatus('needs-reauth');
+			return;
+		}
+		setDeleteStatus('error');
+		setDeleteError(
+			`Could not delete your account (error ${result.status}).`,
+		);
+	};
+
+	return (
+		<main className={classes.page}>
+			<h1 className={classes.h1}>Account &amp; privacy</h1>
+			{session.user?.email ? (
+				<p className={classes.muted}>
+					Signed in as {session.user.email}
+				</p>
+			) : null}
+
+			{/* Logging level */}
+			<section className={classes.section}>
+				<h2 className={classes.h2}>What we log about you</h2>
+				<p className={classes.sectionIntro}>
+					Choose how much this app records about your usage. You can
+					change this at any time; lowering it stops new logging
+					immediately.
+				</p>
+				<ConsentLevelChooser
+					value={level}
+					onChange={(next) => void onChangeLevel(next)}
+					disabled={consentStatus === 'saving'}
+				/>
+				<p className={classes.statusLine}>
+					{consentStatus === 'saving' && 'Saving…'}
+					{consentStatus === 'saved' && 'Saved.'}
+					{consentStatus === 'error' &&
+						'Could not save your choice. Please try again.'}
+				</p>
+			</section>
+
+			{/* Erase activity — withdrawal */}
+			<section className={classes.section}>
+				<h2 className={classes.h2}>Erase my logged activity</h2>
+				<p className={classes.sectionIntro}>
+					Deletes the logged events and analytics profile we hold
+					about how you use the app.{' '}
+					<strong>Your account stays</strong> and you can keep using
+					the app. This does not delete the content-free AI usage
+					records we keep for billing.
+				</p>
+				{eraseStatus === 'done' ? (
+					<p className={classes.ok}>
+						Your logged activity has been erased.
+					</p>
+				) : eraseStatus === 'confirm' ? (
+					<div className={classes.actionRow}>
+						<span>
+							Erase all logged activity? This can’t be undone.
+						</span>
+						<Button onClick={() => void onErase()}>
+							Yes, erase it
+						</Button>
+						<Button onClick={() => setEraseStatus('idle')}>
+							Cancel
+						</Button>
+					</div>
+				) : (
+					<Button
+						disabled={eraseStatus === 'working'}
+						onClick={() => setEraseStatus('confirm')}
+					>
+						{eraseStatus === 'working'
+							? 'Erasing…'
+							: 'Erase my activity'}
+					</Button>
+				)}
+				{eraseError ? (
+					<p className={classes.error}>{eraseError}</p>
+				) : null}
+			</section>
+
+			{/* Delete account — departure */}
+			<section className={classes.section}>
+				<h2 className={classes.h2}>Delete my account</h2>
+				<p className={classes.sectionIntro}>
+					Permanently deletes your account and everything erasing
+					does, plus the account itself. Content-free AI usage records
+					are anonymized, not deleted.{' '}
+					<strong>This cannot be undone.</strong>
+				</p>
+
+				{deleteStatus === 'done' ? (
+					<p className={classes.ok}>
+						Your account has been deleted. You can close this page.
+					</p>
+				) : deleteStatus === 'needs-reauth' ? (
+					<div>
+						<p>
+							For your security, sign in again. After signing in,
+							start the deletion confirmation again.
+						</p>
+						{session.isAuthorizing ? (
+							<DeviceCodePanel
+								authorization={session.authorization}
+							/>
+						) : (
+							<>
+								{/* Failed/denied re-auth surfaces via authorization.status
+								    ('error'); show it alongside the buttons so the user can
+								    retry instead of silently returning to the button row. */}
+								{session.authorization?.status === 'error' ? (
+									<DeviceCodePanel
+										authorization={session.authorization}
+									/>
+								) : null}
+								<div className={classes.actionRow}>
+									<Button
+										onClick={() => void session.login()}
+									>
+										Sign in again
+									</Button>
+									<Button onClick={() => void runDelete()}>
+										Delete permanently
+									</Button>
+									<Button
+										onClick={() => setDeleteStatus('idle')}
+									>
+										Cancel
+									</Button>
+								</div>
+							</>
+						)}
+					</div>
+				) : deleteStatus === 'confirm' ? (
+					<div className={classes.actionRow}>
+						<span>Delete your account permanently?</span>
+						<Button onClick={() => void runDelete()}>
+							Delete permanently
+						</Button>
+						<Button onClick={() => setDeleteStatus('idle')}>
+							Cancel
+						</Button>
+					</div>
+				) : (
+					<Button
+						disabled={deleteStatus === 'working'}
+						onClick={() => setDeleteStatus('confirm')}
+					>
+						{deleteStatus === 'working'
+							? 'Deleting…'
+							: 'Delete my account'}
+					</Button>
+				)}
+				{deleteError ? (
+					<p className={classes.error}>{deleteError}</p>
+				) : null}
+			</section>
+		</main>
+	);
+}

--- a/frontend/src/account/DeviceCodePanel.tsx
+++ b/frontend/src/account/DeviceCodePanel.tsx
@@ -1,0 +1,47 @@
+/**
+ * Renders the in-flight device-authorization state (user code + approval link)
+ * for the account page — reused by the sign-in gate and the delete re-auth step.
+ * Presentation only; the flow itself is driven by useDeviceAuth via useAppAuth.
+ */
+import type { AppAuthSession } from '@/contexts/appAuthContext';
+import classes from './styles.module.css';
+
+export function DeviceCodePanel({
+	authorization,
+}: {
+	authorization: AppAuthSession['authorization'];
+}) {
+	if (!authorization) return null;
+
+	if (authorization.status === 'error') {
+		return (
+			<p className={classes.error}>
+				Sign-in failed: {authorization.error ?? 'unknown error'}
+			</p>
+		);
+	}
+
+	return (
+		<div className={classes.deviceCode}>
+			{authorization.userCode ? (
+				<>
+					<p>Enter this code on the sign-in page:</p>
+					<p className={classes.code}>{authorization.userCode}</p>
+				</>
+			) : (
+				<p>Starting sign-in…</p>
+			)}
+			{authorization.verificationUri ? (
+				<a
+					className={classes.link}
+					href={authorization.verificationUri}
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					Open sign-in page →
+				</a>
+			) : null}
+			<p className={classes.muted}>Waiting for approval…</p>
+		</div>
+	);
+}

--- a/frontend/src/account/index.tsx
+++ b/frontend/src/account/index.tsx
@@ -1,0 +1,94 @@
+/**
+ * Standalone account/consent entry — reachable without the Word task pane or
+ * editor loaded (its own Vite input: account.html). Gated on a Better Auth
+ * session; unauthenticated or demo/anonymous visitors are steered to real sign-in
+ * before they can manage consent or exercise deletion rights.
+ *
+ * overallModeAtom defaults to OverallMode.full, so AppAuthProvider selects the
+ * real Better Auth adapter (not the demo adapter) here.
+ */
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Button, Reshaped } from 'reshaped';
+import 'reshaped/themes/slate/theme.css';
+import { AppAuthProvider, useAppAuth } from '@/contexts/appAuthContext';
+import { AccountPage } from './AccountPage';
+import { DeviceCodePanel } from './DeviceCodePanel';
+import classes from './styles.module.css';
+
+function SignInGate() {
+	const session = useAppAuth();
+
+	if (session.isLoading) {
+		return <p className={classes.centered}>Loading…</p>;
+	}
+
+	if (!session.isAuthenticated || !session.user) {
+		return (
+			<main className={classes.page}>
+				<h1 className={classes.h1}>Account &amp; privacy</h1>
+				<p className={classes.sectionIntro}>
+					Sign in to view and manage your privacy settings.
+				</p>
+				{session.isAuthorizing ? (
+					<DeviceCodePanel authorization={session.authorization} />
+				) : (
+					<>
+						{/* A failed/denied device flow surfaces via authorization.status
+						    ('error'), not session.error — render it so a sign-in failure
+						    isn't silent, and keep the button so the user can retry. */}
+						{session.authorization?.status === 'error' ? (
+							<DeviceCodePanel
+								authorization={session.authorization}
+							/>
+						) : null}
+						<Button onClick={() => void session.login()}>
+							Sign in
+						</Button>
+					</>
+				)}
+			</main>
+		);
+	}
+
+	if (session.user.isAnonymous) {
+		return (
+			<main className={classes.page}>
+				<h1 className={classes.h1}>Account &amp; privacy</h1>
+				<p className={classes.sectionIntro}>
+					You’re using a temporary demo account. Sign in with a real
+					account to manage your privacy settings.
+				</p>
+				{session.isAuthorizing ? (
+					<DeviceCodePanel authorization={session.authorization} />
+				) : (
+					<>
+						{session.authorization?.status === 'error' ? (
+							<DeviceCodePanel
+								authorization={session.authorization}
+							/>
+						) : null}
+						<Button onClick={() => void session.login()}>
+							Sign in with Google
+						</Button>
+					</>
+				)}
+			</main>
+		);
+	}
+
+	return <AccountPage />;
+}
+
+const container = document.getElementById('container');
+if (container) {
+	createRoot(container).render(
+		<StrictMode>
+			<Reshaped theme="slate">
+				<AppAuthProvider>
+					<SignInGate />
+				</AppAuthProvider>
+			</Reshaped>
+		</StrictMode>,
+	);
+}

--- a/frontend/src/account/styles.module.css
+++ b/frontend/src/account/styles.module.css
@@ -1,0 +1,85 @@
+.page {
+	max-width: 640px;
+	margin: 2.5rem auto;
+	padding: 0 1.5rem 4rem;
+	line-height: 1.5;
+}
+
+.centered {
+	max-width: 640px;
+	margin: 4rem auto;
+	padding: 0 1.5rem;
+	text-align: center;
+	color: #52525b;
+}
+
+.h1 {
+	font-size: 1.5rem;
+	margin: 0 0 0.25rem;
+}
+
+.h2 {
+	font-size: 1.15rem;
+	margin: 0 0 0.5rem;
+}
+
+.muted {
+	color: #52525b;
+	font-size: 0.9rem;
+}
+
+.section {
+	margin-top: 2.25rem;
+	padding-top: 1.5rem;
+	border-top: 1px solid #e4e4e7;
+}
+
+.sectionIntro {
+	margin: 0 0 1rem;
+	color: #3f3f46;
+}
+
+.statusLine {
+	min-height: 1.25rem;
+	margin: 0.5rem 0 0;
+	font-size: 0.85rem;
+	color: #52525b;
+}
+
+.actionRow {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.75rem;
+}
+
+.ok {
+	color: #15803d;
+	font-weight: 600;
+}
+
+.error {
+	color: #b91c1c;
+	font-weight: 600;
+}
+
+/* Device-code re-auth / sign-in panel */
+.deviceCode {
+	margin-top: 0.75rem;
+	padding: 1rem;
+	border: 1px solid #d4d4d8;
+	border-radius: 8px;
+	background: #fafafa;
+}
+
+.code {
+	font-family: monospace;
+	font-size: 1.6rem;
+	letter-spacing: 0.18em;
+	margin: 0.25rem 0 0.75rem;
+}
+
+.link {
+	color: #2563eb;
+	font-weight: 600;
+}

--- a/frontend/src/api/__tests__/account.test.ts
+++ b/frontend/src/api/__tests__/account.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../index', () => ({ SERVER_URL: '/api' }));
+
+import { changeConsent, deleteAccount, eraseActivity } from '../account';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+	fetchMock = vi.fn();
+	vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe('account API', () => {
+	it('uses the bearer-only path for consent changes', async () => {
+		fetchMock.mockResolvedValueOnce({ ok: true } as Response);
+
+		await changeConsent('tok', 'ai_output');
+
+		expect(fetchMock).toHaveBeenCalledWith('/api/me/consent', {
+			method: 'POST',
+			credentials: 'omit',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: 'Bearer tok',
+			},
+			body: JSON.stringify({ level: 'ai_output' }),
+		});
+	});
+
+	it('uses the bearer-only path for activity erasure', async () => {
+		fetchMock.mockResolvedValueOnce({ ok: true } as Response);
+
+		await eraseActivity('tok');
+
+		expect(fetchMock).toHaveBeenCalledWith('/api/me/activity', {
+			method: 'DELETE',
+			credentials: 'omit',
+			headers: { Authorization: 'Bearer tok' },
+		});
+	});
+
+	it('recognizes only Better Auth SESSION_EXPIRED as stale', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			status: 400,
+			json: () => Promise.resolve({ code: 'SESSION_EXPIRED' }),
+		} as Response);
+
+		await expect(deleteAccount('tok')).resolves.toEqual({
+			ok: false,
+			staleSession: true,
+			status: 400,
+		});
+	});
+
+	it('does not treat unrelated 400 responses as stale', async () => {
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			status: 400,
+			json: () => Promise.resolve({ code: 'INVALID_PASSWORD' }),
+		} as Response);
+
+		await expect(deleteAccount('tok')).resolves.toEqual({
+			ok: false,
+			staleSession: false,
+			status: 400,
+		});
+	});
+});

--- a/frontend/src/api/__tests__/deviceAuth.test.ts
+++ b/frontend/src/api/__tests__/deviceAuth.test.ts
@@ -5,11 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('../index', () => ({ SERVER_URL: '/api' }));
 
 import { DEFAULT_CONSENT_LEVEL } from '@/consent';
-import {
-	pollForToken,
-	requestDeviceCode,
-	fetchUserInfo,
-} from '../deviceAuth';
+import { pollForToken, requestDeviceCode, fetchUserInfo } from '../deviceAuth';
 
 type Json = Record<string, unknown>;
 const resp = (data: Json, ok = false) =>
@@ -35,7 +31,8 @@ describe('requestDeviceCode', () => {
 					device_code: 'dev',
 					user_code: 'ABCD-1234',
 					verification_uri: '/api/device',
-					verification_uri_complete: '/api/device?user_code=ABCD-1234',
+					verification_uri_complete:
+						'/api/device?user_code=ABCD-1234',
 					expires_in: 600,
 					interval: 5,
 				},
@@ -49,7 +46,9 @@ describe('requestDeviceCode', () => {
 
 	it('throws on a non-ok response', async () => {
 		fetchMock.mockResolvedValueOnce(resp({ error: 'invalid_client' }));
-		await expect(requestDeviceCode()).rejects.toThrow(/device\/code failed/);
+		await expect(requestDeviceCode()).rejects.toThrow(
+			/device\/code failed/,
+		);
 	});
 });
 
@@ -129,6 +128,7 @@ describe('fetchUserInfo', () => {
 						name: 'A',
 						loggingConsent: 'document',
 						isAllowed: true,
+						isAnonymous: true,
 					},
 				},
 				true,
@@ -140,6 +140,7 @@ describe('fetchUserInfo', () => {
 			name: 'A',
 			loggingConsent: 'document',
 			isAllowed: true,
+			isAnonymous: true,
 		});
 		// hits the framework endpoint on the token-only path, no cookies
 		expect(fetchMock).toHaveBeenCalledWith(
@@ -172,6 +173,8 @@ describe('fetchUserInfo', () => {
 			loggingConsent: DEFAULT_CONSENT_LEVEL, // 'usage'
 			// server omitted isAllowed → client coerces to false, never derives it
 			isAllowed: false,
+			// Same fail-closed mapping for the anonymous marker.
+			isAnonymous: false,
 		});
 	});
 
@@ -189,6 +192,8 @@ describe('fetchUserInfo', () => {
 			status: 500,
 			json: () => Promise.resolve({}),
 		} as Response);
-		await expect(fetchUserInfo('tok')).rejects.toThrow(/get-session failed/);
+		await expect(fetchUserInfo('tok')).rejects.toThrow(
+			/get-session failed/,
+		);
 	});
 });

--- a/frontend/src/api/account.ts
+++ b/frontend/src/api/account.ts
@@ -1,0 +1,96 @@
+/**
+ * Authenticated account/consent actions for the standalone account page.
+ *
+ * Raw fetch + Bearer, `credentials: 'omit'` throughout — the same token-only path
+ * the rest of the device-auth client uses (see deviceAuth.ts). No better-auth
+ * client dependency.
+ */
+import { SERVER_URL } from '@/api';
+import type { ConsentLevel } from '@/consent';
+
+function authedFetch(
+	path: string,
+	token: string,
+	init: Omit<RequestInit, 'headers'> & {
+		headers?: Record<string, string>;
+	} = {},
+): Promise<Response> {
+	return fetch(`${SERVER_URL}${path}`, {
+		...init,
+		credentials: 'omit',
+		headers: {
+			...(init.headers ?? {}),
+			Authorization: `Bearer ${token}`,
+		},
+	});
+}
+
+/**
+ * Change the signed-in user's logging-consent level.
+ * `POST /api/me/consent { level }` → `{ loggingConsent }`. Throws on non-2xx.
+ */
+export async function changeConsent(
+	token: string,
+	level: ConsentLevel,
+): Promise<void> {
+	const res = await authedFetch('/me/consent', token, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ level }),
+	});
+	if (!res.ok) {
+		throw new Error(`consent update failed (${res.status})`);
+	}
+}
+
+/**
+ * Withdrawal: erase the user's logged activity + analytics profile, keeping
+ * the account (usage/billing records deliberately survive — see erasure.ts).
+ * `DELETE /api/me/activity`. Throws on non-2xx.
+ */
+export async function eraseActivity(token: string): Promise<void> {
+	const res = await authedFetch('/me/activity', token, { method: 'DELETE' });
+	if (!res.ok) {
+		throw new Error(`erase activity failed (${res.status})`);
+	}
+}
+
+export type DeleteAccountResult =
+	| { ok: true }
+	/**
+	 * `staleSession` is true when Better Auth's delete-user rejected because the
+	 * session isn't fresh (freshAge, default 1 day). Our Google-only accounts have
+	 * no password and no email-verification flow, so this requires a fresh sign-in.
+	 */
+	| { ok: false; staleSession: boolean; status: number };
+
+/**
+ * Departure: delete the account. `beforeDelete` (auth.ts) runs the same erasure as
+ * withdrawal plus usage anonymization, then Better Auth drops the account/sessions.
+ * `POST /api/auth/delete-user` — no password/token, so it succeeds only on a fresh
+ * session (see DeleteAccountResult.staleSession).
+ */
+export async function deleteAccount(
+	token: string,
+): Promise<DeleteAccountResult> {
+	const res = await authedFetch('/auth/delete-user', token, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: '{}',
+	});
+	if (res.ok) return { ok: true };
+	// Better Auth error bodies are { code, message }; the freshness gate rejects
+	// with 400 + code SESSION_EXPIRED specifically. Match on the code so an
+	// unrelated 400 doesn't send the user around a pointless re-auth loop.
+	let code: unknown;
+	try {
+		code = ((await res.json()) as { code?: unknown } | null)?.code;
+	} catch {
+		code = undefined;
+	}
+	return {
+		ok: false,
+		staleSession: res.status === 400 && code === 'SESSION_EXPIRED',
+		status: res.status,
+	};
+}

--- a/frontend/src/api/deviceAuth.ts
+++ b/frontend/src/api/deviceAuth.ts
@@ -9,7 +9,11 @@
  * browser at `verification_uri_complete`, which Better Auth builds from the backend's
  * BETTER_AUTH_URL. This module only requests the code and polls for the token.
  */
-import { type ConsentLevel, DEFAULT_CONSENT_LEVEL, isConsentLevel } from '@/consent';
+import {
+	type ConsentLevel,
+	DEFAULT_CONSENT_LEVEL,
+	isConsentLevel,
+} from '@/consent';
 import { SERVER_URL } from './index';
 
 // Supplied at build time via webpack DefinePlugin; must match a value in the backend's
@@ -159,6 +163,12 @@ export interface UserInfo {
 	 * the allowlist policy.
 	 */
 	isAllowed?: boolean;
+	/**
+	 * Demo/anonymous session (see the anonymous plugin in backend/src/auth.ts).
+	 * Surfaces so account/consent surfaces can steer these users to real sign-in
+	 * rather than letting them manage consent on a throwaway identity.
+	 */
+	isAnonymous?: boolean;
 }
 
 /**
@@ -173,6 +183,7 @@ interface GetSessionResponse {
 		name?: string;
 		loggingConsent?: unknown;
 		isAllowed?: unknown;
+		isAnonymous?: unknown;
 	};
 }
 
@@ -204,7 +215,14 @@ export async function fetchUserInfo(
 	if (!data?.user) {
 		throw new Error('get-session: no active session');
 	}
-	const { id, email, name, loggingConsent: raw, isAllowed } = data.user;
+	const {
+		id,
+		email,
+		name,
+		loggingConsent: raw,
+		isAllowed,
+		isAnonymous,
+	} = data.user;
 	return {
 		id,
 		email,
@@ -213,6 +231,7 @@ export async function fetchUserInfo(
 		// normalize server-side, so we replicate that guard client-side.
 		loggingConsent: isConsentLevel(raw) ? raw : DEFAULT_CONSENT_LEVEL,
 		isAllowed: isAllowed === true,
+		isAnonymous: isAnonymous === true,
 	};
 }
 

--- a/frontend/src/components/ConsentLevelChooser.module.css
+++ b/frontend/src/components/ConsentLevelChooser.module.css
@@ -1,0 +1,64 @@
+/*
+ * Equal visual weight across all options — no option is highlighted, bordered
+ * more strongly, or coloured to nudge the choice. The only emphasis is the
+ * currently-selected row, and only via a neutral background.
+ */
+.group {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+	border: none;
+	margin: 0;
+	padding: 0;
+}
+
+.option {
+	display: flex;
+	align-items: flex-start;
+	gap: 0.75rem;
+	padding: 0.75rem;
+	border: 1px solid #d4d4d8;
+	border-radius: 8px;
+	cursor: pointer;
+	background: #fff;
+}
+
+.option:hover {
+	background: #fafafa;
+}
+
+/* Selected state: neutral, no persuasive colour. */
+.option:has(.radio:checked) {
+	background: #f4f4f5;
+	border-color: #a1a1aa;
+}
+
+.radio {
+	margin-top: 0.2rem;
+	flex: 0 0 auto;
+	width: 1rem;
+	height: 1rem;
+	cursor: pointer;
+}
+
+.text {
+	display: flex;
+	flex-direction: column;
+	gap: 0.15rem;
+}
+
+.title {
+	font-weight: 600;
+	font-size: 0.95rem;
+}
+
+.description {
+	font-size: 0.85rem;
+	color: #52525b;
+	line-height: 1.4;
+}
+
+.group:disabled .option {
+	cursor: default;
+	opacity: 0.7;
+}

--- a/frontend/src/components/ConsentLevelChooser.tsx
+++ b/frontend/src/components/ConsentLevelChooser.tsx
@@ -1,0 +1,80 @@
+/**
+ * Shared logging-consent chooser, used by the account page and (later) the
+ * onboarding consent step.
+ *
+ * Choice architecture — no dark patterns:
+ *   - every level is a plain radio of equal visual weight (styling in the CSS
+ *     module deliberately does not emphasise the higher-collection options);
+ *   - descriptions come verbatim from CONSENT_LEVEL_LABELS (plain language);
+ *   - nothing is pre-checked here — the caller supplies `value`, and is
+ *     responsible for defaulting to the privacy-protective option;
+ *   - `document` ("full study logging") is hidden unless `allowStudyLevel`, so a
+ *     user can't opt into study logging outside the explicit study flow. It remains
+ *     visible when it is the current value, so an existing participant can see and
+ *     lower their actual setting.
+ */
+import {
+	CONSENT_LEVELS,
+	CONSENT_LEVEL_LABELS,
+	type ConsentLevel,
+} from '@/consent';
+import classes from './ConsentLevelChooser.module.css';
+
+/** The study-only level, gated behind an explicit study opt-in. */
+const STUDY_LEVEL: ConsentLevel = 'document';
+
+export interface ConsentLevelChooserProps {
+	value: ConsentLevel;
+	onChange: (level: ConsentLevel) => void;
+	/** Offer the `document` (full study logging) level. Default: false. */
+	allowStudyLevel?: boolean;
+	/** Disable all inputs (e.g. while a change is saving). */
+	disabled?: boolean;
+	/** Radio group name — unique it if two choosers ever share a page. */
+	name?: string;
+}
+
+export function ConsentLevelChooser({
+	value,
+	onChange,
+	allowStudyLevel = false,
+	disabled = false,
+	name = 'loggingConsent',
+}: ConsentLevelChooserProps) {
+	const levels = CONSENT_LEVELS.filter(
+		(level) =>
+			allowStudyLevel || level !== STUDY_LEVEL || value === STUDY_LEVEL,
+	);
+
+	return (
+		<fieldset
+			className={classes.group}
+			disabled={disabled}
+			aria-label="Logging level"
+		>
+			{levels.map((level) => {
+				const { title, description } = CONSENT_LEVEL_LABELS[level];
+				const id = `${name}-${level}`;
+				return (
+					<label key={level} htmlFor={id} className={classes.option}>
+						<input
+							type="radio"
+							id={id}
+							name={name}
+							value={level}
+							checked={value === level}
+							onChange={() => onChange(level)}
+							className={classes.radio}
+						/>
+						<span className={classes.text}>
+							<span className={classes.title}>{title}</span>
+							<span className={classes.description}>
+								{description}
+							</span>
+						</span>
+					</label>
+				);
+			})}
+		</fieldset>
+	);
+}

--- a/frontend/src/components/__tests__/ConsentLevelChooser.test.tsx
+++ b/frontend/src/components/__tests__/ConsentLevelChooser.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { ConsentLevelChooser } from '../ConsentLevelChooser';
+
+describe('ConsentLevelChooser', () => {
+	it('does not offer study logging as a new opt-in by default', () => {
+		const html = renderToStaticMarkup(
+			<ConsentLevelChooser value="usage" onChange={vi.fn()} />,
+		);
+
+		expect(html).not.toContain('value="document"');
+	});
+
+	it('shows document when it is the current level', () => {
+		const html = renderToStaticMarkup(
+			<ConsentLevelChooser value="document" onChange={vi.fn()} />,
+		);
+
+		expect(html).toContain('value="document"');
+		expect(html).toContain('checked="" value="document"');
+	});
+
+	it('offers document during the explicit study flow', () => {
+		const html = renderToStaticMarkup(
+			<ConsentLevelChooser
+				value="usage"
+				onChange={vi.fn()}
+				allowStudyLevel
+			/>,
+		);
+
+		expect(html).toContain('value="document"');
+	});
+});

--- a/frontend/src/contexts/appAuthContext.tsx
+++ b/frontend/src/contexts/appAuthContext.tsx
@@ -40,6 +40,8 @@ export interface AppAuthSession {
 		loggingConsent?: ConsentLevel;
 		/** Beta access decision, computed server-side (see backend userAllowlist.ts). */
 		isAllowed?: boolean;
+		/** Demo/anonymous session — account surfaces steer these to real sign-in. */
+		isAnonymous?: boolean;
 	};
 	/** Resolved consent level (defaults applied) — gate analytics/logging on this. */
 	loggingConsent: ConsentLevel;

--- a/frontend/src/hooks/useLog.ts
+++ b/frontend/src/hooks/useLog.ts
@@ -44,15 +44,26 @@ export function useLog(): LogFn {
 			}
 
 			try {
-				await fetch(`${SERVER_URL}/log`, {
+				const res = await fetch(`${SERVER_URL}/log`, {
 					method: 'POST',
 					credentials: 'omit',
 					headers: {
 						'Content-Type': 'application/json',
 						Authorization: `Bearer ${token}`,
 					},
-					body: JSON.stringify({ ...filtered, timestamp: Date.now() / 1000 }),
+					body: JSON.stringify({
+						...filtered,
+						timestamp: Date.now() / 1000,
+					}),
 				});
+				// fetch only rejects on network failure, so a rejected auth (e.g. a 401
+				// after a session/consent regression) would otherwise be invisible.
+				// Surface non-2xx instead of silently dropping the event.
+				if (!res.ok) {
+					console.warn(
+						`event logging rejected: /api/log returned ${res.status}`,
+					);
+				}
 			} catch {
 				// Best-effort; never disrupt the UI on a logging failure.
 			}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -36,7 +36,7 @@ function manifestPlugin(): Plugin {
 					.replace(new RegExp(urlDev, 'g'), urlProd);
 			}
 			fs.writeFileSync(manifestPath, content);
-		}
+		},
 	};
 }
 
@@ -117,7 +117,7 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
 			httpsOptions = {
 				key: serverOptions.key,
 				cert: serverOptions.cert,
-				ca: serverOptions.ca
+				ca: serverOptions.ca,
 			};
 		} catch (error) {
 			console.warn('Failed to get HTTPS options, using HTTP:', error);
@@ -142,32 +142,33 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
 					taskpane: path.resolve(__dirname, 'taskpane.html'),
 					editor: path.resolve(__dirname, 'editor.html'),
 					logs: path.resolve(__dirname, 'logs.html'),
-					commands: path.resolve(__dirname, 'commands.html')
+					commands: path.resolve(__dirname, 'commands.html'),
+					account: path.resolve(__dirname, 'account.html'),
 				},
 				output: {
 					manualChunks: {
-						'react-vendor': ['react', 'react-dom']
-					}
-				}
-			}
+						'react-vendor': ['react', 'react-dom'],
+					},
+				},
+			},
 		},
 		server: {
 			port: 3000,
 			https: httpsOptions,
 			cors: true,
 			headers: {
-				'Access-Control-Allow-Origin': '*'
+				'Access-Control-Allow-Origin': '*',
 			},
 			proxy: {
 				'/api': {
 					target: backendDev,
 					changeOrigin: true,
-					secure: false
-				}
-			}
+					secure: false,
+				},
+			},
 		},
 		optimizeDeps: {
-			include: ['react', 'react-dom']
-		}
+			include: ['react', 'react-dom'],
+		},
 	};
 });


### PR DESCRIPTION
**Part of #503** — PR 1 of 2.

## What this adds

A standalone **account & privacy page** where a signed-in user can manage their data without opening Word. Visiting `/account.html`, you sign in via the device-code flow (no Office host needed) and can then:

- **Change your logging-consent level** — how much of your writing activity the study server is allowed to record
- **Erase your logged activity** — one click, `DELETE /api/me/activity`
- **Delete your account** — `POST /api/auth/delete-user`, with a re-auth safeguard (below)

## Where the code lives

- `frontend/account.html` + `frontend/src/account/` — the new page: `AccountPage.tsx` (the page itself), `DeviceCodePanel.tsx` (sign-in UI), `index.tsx` (entry/bootstrap)
- `frontend/src/components/ConsentLevelChooser.tsx` — the consent picker, built as a **shared component** because PR 2's onboarding step will reuse it
- `frontend/src/api/account.ts` — the erase/delete API calls
- `frontend/src/contexts/appAuthContext.tsx` — now surfaces `isAnonymous`, so demo users get steered to a real sign-in before managing consent
- `frontend/src/hooks/useLog.ts` — now warns on non-2xx from `/api/log` (auth regressions used to fail silently)
- Tests alongside each: `account.test.ts`, `deviceAuth.test.ts`, `ConsentLevelChooser.test.tsx`

## Verified live, not just in tests

The branch was exercised end-to-end against a real backend and browser: device-code sign-in, all three consent levels saving, erase (verified at the file level: exactly the requesting user's log file is deleted, other users' files untouched), hard-refresh session persistence, cross-tab session sharing with the editor, and account deletion (account row dropped, `llm_usage` rows anonymized to `"anonymous"`, sessions invalidated across tabs).

That pass caught a real bug the unit tests missed: Better Auth's public `updateUser` endpoint rejects `input: false` additional fields **at runtime** (`FIELD_NOT_ALLOWED`) — the mock had accepted them, so every consent save 500'd against the live server. Fixed in the second commit by writing server-controlled fields through the internal adapter, and the test mock now mirrors live behaviour.

## Things that may look odd (on purpose)

1. **Deleting your account never shows a password prompt.** Accounts are Google-only — there's no password to ask for. Instead we lean on Better Auth's session-freshness gate: if your session is stale, the delete is refused with `SESSION_EXPIRED`, the page sends you through a fresh device sign-in, and that re-auth *is* the confirmation step. We match the specific error code, not a blanket 400. (Note: Better Auth's default freshness window is generous, so most deletions won't re-prompt — whether deletion should *always* demand a fresh sign-in is flagged in the auth-flow follow-up issue.)
2. **The "document" consent level is usually hidden.** The chooser only shows it if it's already your current value or the page passes `allowStudyLevel` — full-document study logging should only ever be offered through the explicit study opt-in, never as a casual dropdown option.
3. **How does a user find this page?** Direct URL for now — the taskpane/editor don't link to it yet. Surface entry points come with PR 2's onboarding step.
4. **⚠️ Needs reviewer ratification:** beta-disallowed users (`isAllowed = false`) can still use this page. Rationale: privacy rights (view consent, erase data, delete account) shouldn't depend on beta access. Say so if you disagree — this is a deliberate, reversible decision.

## Deferred to PR 2: onboarding consent step

- **First-run consent prompt** inside the add-in — detected via `consentUpdatedAt == null` from get-session, so existing users are never re-prompted
- **Reuses `ConsentLevelChooser`** from this PR — that's why it shipped as a shared component
- **`refreshUser()` on `useDeviceAuth`** so a consent change propagates live without re-signing in
- **Study opt-in as its own explicit consent** — the only path that ever surfaces the `document` level

🤖 Generated with [Claude Code](https://claude.com/claude-code)
