### PR TITLE
Make Google Docs doc-context pull-based instead of always polling

### DIFF
--- a/frontend/src/api/__tests__/googleDocsEditorAPI.test.ts
+++ b/frontend/src/api/__tests__/googleDocsEditorAPI.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { googleDocsEditorAPI } from '../googleDocsEditorAPI';
+
+/**
+ * These tests pin down the Google Docs polling contract: we only re-fetch the
+ * document (an expensive Apps Script round-trip) while a handler is registered
+ * AND the sidebar is actually in front of the user. When the user is editing
+ * the document (sidebar blurred) or the tab is hidden, polling pauses.
+ *
+ * We stub minimal `window`/`document` globals rather than pulling in jsdom, to
+ * match the repo's node-based unit suite.
+ */
+
+const CONTEXT_A: DocContext = {
+	beforeCursor: 'a',
+	selectedText: '',
+	afterCursor: 'b',
+};
+const CONTEXT_B: DocContext = {
+	beforeCursor: 'a',
+	selectedText: 'selected',
+	afterCursor: 'b',
+};
+
+/** A tiny addEventListener/removeEventListener/emit target. */
+function makeEmitter() {
+	const listeners = new Map<string, Set<() => void>>();
+	return {
+		addEventListener(type: string, cb: () => void) {
+			if (!listeners.has(type)) listeners.set(type, new Set());
+			listeners.get(type)?.add(cb);
+		},
+		removeEventListener(type: string, cb: () => void) {
+			listeners.get(type)?.delete(cb);
+		},
+		emit(type: string) {
+			for (const cb of [...(listeners.get(type) ?? [])]) cb();
+		},
+	};
+}
+
+let getDocContextMock: ReturnType<typeof vi.fn>;
+let fakeWindow: ReturnType<typeof makeEmitter> & Record<string, unknown>;
+let fakeDocument: ReturnType<typeof makeEmitter> & Record<string, unknown>;
+let visible: boolean;
+let focused: boolean;
+// Track handlers so we can always tear down the module-level singleton state,
+// even if an assertion throws mid-test.
+const registered: Array<() => void> = [];
+
+function setSidebar(nextVisible: boolean, nextFocused: boolean) {
+	visible = nextVisible;
+	focused = nextFocused;
+}
+
+function register(handler: () => void) {
+	registered.push(handler);
+	googleDocsEditorAPI.addSelectionChangeHandler(handler);
+}
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	visible = true;
+	focused = true;
+	getDocContextMock = vi.fn().mockResolvedValue(CONTEXT_A);
+
+	fakeWindow = Object.assign(makeEmitter(), {
+		GoogleAppsScript: { getDocContext: getDocContextMock },
+	});
+	fakeDocument = Object.assign(makeEmitter(), {
+		hasFocus: () => focused,
+	});
+	Object.defineProperty(fakeDocument, 'visibilityState', {
+		configurable: true,
+		get: () => (visible ? 'visible' : 'hidden'),
+	});
+
+	vi.stubGlobal('window', fakeWindow);
+	vi.stubGlobal('document', fakeDocument);
+});
+
+afterEach(() => {
+	for (const handler of registered.splice(0)) {
+		googleDocsEditorAPI.removeSelectionChangeHandler(handler);
+	}
+	vi.useRealTimers();
+});
+
+describe('googleDocsEditorAPI selection polling', () => {
+	it('pulls immediately and notifies handlers when the selection changes', async () => {
+		getDocContextMock
+			.mockResolvedValueOnce(CONTEXT_A) // initial pull
+			.mockResolvedValue(CONTEXT_B); // subsequent polls: selection changed
+		const handler = vi.fn();
+
+		register(handler);
+
+		// Immediate pull on registration.
+		await vi.advanceTimersByTimeAsync(0);
+		expect(getDocContextMock).toHaveBeenCalledTimes(1);
+		expect(handler).toHaveBeenCalledTimes(1);
+
+		// Next tick sees a changed selection -> notifies again.
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(getDocContextMock).toHaveBeenCalledTimes(2);
+		expect(handler).toHaveBeenCalledTimes(2);
+
+		// Another tick with the same selection -> no extra notification.
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(getDocContextMock).toHaveBeenCalledTimes(3);
+		expect(handler).toHaveBeenCalledTimes(2);
+	});
+
+	it('does not touch Apps Script while the sidebar is inactive, and starts on focus', async () => {
+		setSidebar(false, false);
+		const handler = vi.fn();
+
+		register(handler);
+
+		// No pull at all while the sidebar is not in front of the user.
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(getDocContextMock).not.toHaveBeenCalled();
+		expect(handler).not.toHaveBeenCalled();
+
+		// User returns to the sidebar: pull immediately, then poll on an interval.
+		setSidebar(true, true);
+		fakeWindow.emit('focus');
+		await vi.advanceTimersByTimeAsync(0);
+		expect(getDocContextMock).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(getDocContextMock).toHaveBeenCalledTimes(2);
+	});
+
+	it('pauses polling when the sidebar is blurred and resumes on return', async () => {
+		const handler = vi.fn();
+		register(handler);
+
+		await vi.advanceTimersByTimeAsync(1000);
+		const callsWhileActive = getDocContextMock.mock.calls.length;
+		expect(callsWhileActive).toBeGreaterThan(0);
+
+		// Blur: interval stops, so advancing time makes no further calls.
+		setSidebar(true, false);
+		fakeWindow.emit('blur');
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(getDocContextMock).toHaveBeenCalledTimes(callsWhileActive);
+
+		// Refocus: polling resumes.
+		setSidebar(true, true);
+		fakeWindow.emit('focus');
+		await vi.advanceTimersByTimeAsync(1000);
+		expect(getDocContextMock.mock.calls.length).toBeGreaterThan(callsWhileActive);
+	});
+
+	it('stops polling entirely once the last handler is removed', async () => {
+		const handler = vi.fn();
+		register(handler);
+
+		await vi.advanceTimersByTimeAsync(1000);
+		const callsBeforeRemoval = getDocContextMock.mock.calls.length;
+		expect(callsBeforeRemoval).toBeGreaterThan(0);
+
+		googleDocsEditorAPI.removeSelectionChangeHandler(handler);
+		registered.length = 0;
+
+		await vi.advanceTimersByTimeAsync(5000);
+		expect(getDocContextMock).toHaveBeenCalledTimes(callsBeforeRemoval);
+	});
+});

--- a/frontend/src/api/googleDocsEditorAPI.ts
+++ b/frontend/src/api/googleDocsEditorAPI.ts
@@ -45,63 +45,149 @@ declare global {
 
 /**
  * Selection change handlers.
- * Note: Google Docs doesn't have real-time selection change events like Word.
- * We implement polling as a workaround.
+ *
+ * Google Docs has no real-time selection-change event like Word, and the only
+ * way to observe a change is to re-fetch the entire document through Apps
+ * Script (a slow, quota-metered round-trip). So most of the app is pull-based
+ * (it calls `getDocContext()` on demand) and does not register here at all.
+ *
+ * A handler is registered only by the rare feature that genuinely needs to
+ * react to the user's selection as they move it (e.g. the tag linker). For
+ * those, we poll — but only while the sidebar is actually in front of the user
+ * (visible and focused). When the user is editing the document (sidebar
+ * blurred) or the tab is hidden, polling pauses, so we never re-fetch the whole
+ * document in the background.
  */
 const selectionChangeHandlers: Set<() => void> = new Set();
 let pollingInterval: ReturnType<typeof setInterval> | null = null;
 let lastDocContext: DocContext | null = null;
+let lifecycleListenersAttached = false;
+
+const POLL_INTERVAL_MS = 1000;
 
 /**
- * Starts polling for selection changes.
- * This is a workaround since Google Docs doesn't provide selection change events.
+ * Whether the sidebar is currently in front of the user. We only poll while
+ * this is true — polling while the user is elsewhere just burns Apps Script
+ * quota re-fetching a document they're not looking at through the sidebar.
  */
-function startPolling() {
-	if (pollingInterval) return;
-
-	const pollForChanges = async () => {
-		if (selectionChangeHandlers.size === 0) {
-			stopPolling();
-			return;
-		}
-
-		try {
-			const newContext = await window.GoogleAppsScript.getDocContext();
-
-			// Check if selection changed
-			if (
-				!lastDocContext ||
-				lastDocContext.selectedText !== newContext.selectedText ||
-				lastDocContext.beforeCursor !== newContext.beforeCursor
-			) {
-				lastDocContext = newContext;
-				// Notify all handlers
-				for (const handler of selectionChangeHandlers) {
-					try {
-						handler();
-					} catch (e) {
-						console.error('Selection change handler error:', e);
-					}
-				}
-			}
-		} catch (e) {
-			console.error('Error polling for selection changes:', e);
-		}
-	};
-
-	pollingInterval = setInterval(() => {
-		void pollForChanges();
-	}, 1000); // Poll every second
+function sidebarIsActive(): boolean {
+	if (typeof document === 'undefined') return false;
+	if (document.visibilityState !== 'visible') return false;
+	// hasFocus() may be undefined in some embedded contexts; treat that as active.
+	return typeof document.hasFocus !== 'function' || document.hasFocus();
 }
 
 /**
- * Stops polling for selection changes.
+ * Fetches the current context and, if the selection/cursor changed since the
+ * last fetch, notifies every registered handler.
  */
-function stopPolling() {
+async function pollForChanges(): Promise<void> {
+	if (selectionChangeHandlers.size === 0) {
+		stopPolling();
+		return;
+	}
+
+	try {
+		const newContext = await window.GoogleAppsScript.getDocContext();
+
+		if (
+			!lastDocContext ||
+			lastDocContext.selectedText !== newContext.selectedText ||
+			lastDocContext.beforeCursor !== newContext.beforeCursor
+		) {
+			lastDocContext = newContext;
+			for (const handler of selectionChangeHandlers) {
+				try {
+					handler();
+				} catch (e) {
+					console.error('Selection change handler error:', e);
+				}
+			}
+		}
+	} catch (e) {
+		console.error('Error polling for selection changes:', e);
+	}
+}
+
+/**
+ * Starts the polling interval, if it isn't already running and the sidebar is
+ * active. Does nothing while the sidebar is in the background.
+ */
+function runInterval(): void {
+	if (pollingInterval || selectionChangeHandlers.size === 0) return;
+	if (!sidebarIsActive()) return;
+
+	pollingInterval = setInterval(() => {
+		void pollForChanges();
+	}, POLL_INTERVAL_MS);
+}
+
+/**
+ * Stops the polling interval without tearing down the handler registration or
+ * lifecycle listeners, so polling can resume when the sidebar becomes active.
+ */
+function pauseInterval(): void {
 	if (pollingInterval) {
 		clearInterval(pollingInterval);
 		pollingInterval = null;
 	}
+}
+
+/**
+ * Resumes or pauses polling in response to focus/visibility changes.
+ */
+function handleLifecycleChange(): void {
+	if (selectionChangeHandlers.size === 0) return;
+
+	if (sidebarIsActive()) {
+		// The user just came back to the sidebar — refresh immediately so a
+		// selection they made while away is picked up without waiting a tick.
+		void pollForChanges();
+		runInterval();
+	} else {
+		pauseInterval();
+	}
+}
+
+function attachLifecycleListeners(): void {
+	if (lifecycleListenersAttached || typeof window === 'undefined') return;
+	window.addEventListener('focus', handleLifecycleChange);
+	window.addEventListener('blur', handleLifecycleChange);
+	document.addEventListener('visibilitychange', handleLifecycleChange);
+	lifecycleListenersAttached = true;
+}
+
+function detachLifecycleListeners(): void {
+	if (!lifecycleListenersAttached || typeof window === 'undefined') return;
+	window.removeEventListener('focus', handleLifecycleChange);
+	window.removeEventListener('blur', handleLifecycleChange);
+	document.removeEventListener('visibilitychange', handleLifecycleChange);
+	lifecycleListenersAttached = false;
+}
+
+/**
+ * Begins reacting to selection changes for the newly-registered handler:
+ * pull once immediately, then poll only while the sidebar is active.
+ */
+function startPolling(): void {
+	attachLifecycleListeners();
+	// Pull once right away so a freshly-registered listener gets current state,
+	// but only if the sidebar is in front of the user — otherwise the first pull
+	// waits until they return (handled by the focus/visibility listener).
+	if (sidebarIsActive()) {
+		void pollForChanges();
+	}
+	runInterval();
+}
+
+/**
+ * Stops polling entirely and removes lifecycle listeners. Called once the last
+ * handler is removed.
+ */
+function stopPolling(): void {
+	pauseInterval();
+	detachLifecycleListeners();
+	lastDocContext = null;
 }
 
 /**

--- a/frontend/src/pages/chat/__tests__/docContextMessage.test.ts
+++ b/frontend/src/pages/chat/__tests__/docContextMessage.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { docContextMessageContent, withCurrentDocContext } from '../index';
+
+describe('chat document-context message', () => {
+	describe('docContextMessageContent', () => {
+		it('marks the cursor position when nothing is selected', () => {
+			const content = docContextMessageContent({
+				beforeCursor: 'Hello ',
+				selectedText: '',
+				afterCursor: 'world',
+			});
+
+			expect(content).toContain('<<CURSOR>>');
+			expect(content).not.toContain('<<SELECTION>>');
+			expect(content).toContain('Hello <<CURSOR>>world');
+		});
+
+		it('wraps the selection when text is selected', () => {
+			const content = docContextMessageContent({
+				beforeCursor: 'Hello ',
+				selectedText: 'big',
+				afterCursor: ' world',
+			});
+
+			expect(content).toContain('<<SELECTION>>big<</SELECTION>>');
+			expect(content).not.toContain('<<CURSOR>>');
+		});
+	});
+
+	describe('withCurrentDocContext', () => {
+		const docContext: DocContext = {
+			beforeCursor: 'a',
+			selectedText: '',
+			afterCursor: 'b',
+		};
+
+		it('seeds system + doc-context + greeting when the chat is empty', () => {
+			const result = withCurrentDocContext([], docContext);
+
+			expect(result).toHaveLength(3);
+			expect(result[0].role).toBe('system');
+			expect(result[1].role).toBe('user');
+			expect(result[1].content).toBe(docContextMessageContent(docContext));
+			expect(result[2].role).toBe('assistant');
+		});
+
+		it('replaces only the doc-context message (index 1) on an existing chat', () => {
+			const existing: ChatMessage[] = [
+				{ role: 'system', content: 'sys' },
+				{ role: 'user', content: 'STALE CONTEXT' },
+				{ role: 'assistant', content: 'greeting' },
+				{ role: 'user', content: 'a real question' },
+			];
+
+			const result = withCurrentDocContext(existing, docContext);
+
+			// Fresh context injected at index 1...
+			expect(result[1].content).toBe(docContextMessageContent(docContext));
+			// ...without disturbing the rest of the conversation.
+			expect(result[0]).toEqual(existing[0]);
+			expect(result[2]).toEqual(existing[2]);
+			expect(result[3]).toEqual(existing[3]);
+		});
+
+		it('does not mutate the input array', () => {
+			const existing: ChatMessage[] = [
+				{ role: 'system', content: 'sys' },
+				{ role: 'user', content: 'STALE CONTEXT' },
+				{ role: 'assistant', content: 'greeting' },
+			];
+			const snapshot = structuredClone(existing);
+
+			withCurrentDocContext(existing, docContext);
+
+			expect(existing).toEqual(snapshot);
+		});
+	});
+});

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -18,6 +18,46 @@ const suggestionPrompts = [
 	'What am I missing?',
 ];
 
+const CHAT_SYSTEM_MESSAGE: ChatMessage = {
+	role: 'system',
+	content:
+		'Help the user improve their writing. Encourage the user towards critical thinking and self-reflection. Be concise. If the user mentions "here" or "this", assume they are referring to the area near the cursor or selection.',
+};
+
+const CHAT_GREETING_MESSAGE: ChatMessage = {
+	role: 'assistant',
+	content: 'What do you think about your document so far?',
+};
+
+/** Renders the document context into the message the model reads. */
+export function docContextMessageContent(docContext: DocContext): string {
+	return docContext.selectedText === ''
+		? `Here is my document, with the current cursor position marked with <<CURSOR>>:\n\n${docContext.beforeCursor}${docContext.selectedText}<<CURSOR>>${docContext.afterCursor}`
+		: `Here is my document, with the current selection marked with <<SELECTION>> tags:\n\n${docContext.beforeCursor}<<SELECTION>>${docContext.selectedText}<</SELECTION>>${docContext.afterCursor}`;
+}
+
+/**
+ * Builds the base conversation with the freshest document context as its
+ * second message. When the chat is empty it seeds the system + doc-context +
+ * greeting messages; otherwise it replaces the existing doc-context message so
+ * the model always sees the current document state at send time.
+ */
+export function withCurrentDocContext(
+	chatMessages: ChatMessage[],
+	docContext: DocContext,
+): ChatMessage[] {
+	const docContextMessage: ChatMessage = {
+		role: 'user',
+		content: docContextMessageContent(docContext),
+	};
+	if (chatMessages.length === 0) {
+		return [CHAT_SYSTEM_MESSAGE, docContextMessage, CHAT_GREETING_MESSAGE];
+	}
+	const updated = chatMessages.slice();
+	updated[1] = docContextMessage;
+	return updated;
+}
+
 export default function Chat() {
 	const { chatMessages, updateChatMessages } = useContext(ChatContext);
 	const editorAPI = useContext(EditorContext);
@@ -54,50 +94,25 @@ export default function Chat() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [chatMessages]);
 
-	const docContext = useDocContext(editorAPI);
+	const { refresh: refreshDocContext } = useDocContext(editorAPI);
 
-	const docContextMessageContent =
-		docContext.selectedText === ''
-			? `Here is my document, with the current cursor position marked with <<CURSOR>>:\n\n${docContext.beforeCursor}${docContext.selectedText}<<CURSOR>>${docContext.afterCursor}`
-			: `Here is my document, with the current selection marked with <<SELECTION>> tags:\n\n${docContext.beforeCursor}<<SELECTION>>${docContext.selectedText}<</SELECTION>>${docContext.afterCursor}`;
-
-	let messagesWithCurDocContext = chatMessages;
-	if (chatMessages.length === 0) {
-		// Initialize the chat with the system message and the document-context message.
-		const systemMessage = {
-			role: 'system',
-			content:
-				'Help the user improve their writing. Encourage the user towards critical thinking and self-reflection. Be concise. If the user mentions "here" or "this", assume they are referring to the area near the cursor or selection.',
-		};
-
-		const docContextMessage = {
-			role: 'user',
-			content: docContextMessageContent,
-		};
-
-		const initialAssistantMessage = {
-			role: 'assistant',
-			content: 'What do you think about your document so far?',
-		};
-		messagesWithCurDocContext = [
-			systemMessage,
-			docContextMessage,
-			initialAssistantMessage,
-		];
-	} else {
-		// Update the document context message with the current selection.
-		messagesWithCurDocContext[1].content = docContextMessageContent;
-	}
+	// Seed the conversation once (system + doc-context + greeting) when empty.
+	// The document context is pulled here and refreshed again at send time, so
+	// there's no need to track selection changes continuously.
 	useEffect(() => {
-		updateChatMessages(messagesWithCurDocContext);
-	}, [messagesWithCurDocContext, updateChatMessages]);
+		if (chatMessages.length !== 0) return;
+		void (async () => {
+			const docContext = await refreshDocContext();
+			updateChatMessages(withCurrentDocContext([], docContext));
+		})();
+	}, [chatMessages.length, refreshDocContext, updateChatMessages]);
 
 	const [isSendingMessage, updateSendingMessage] = useState(false);
 
 	const [message, updateMessage] = useState('');
 
 	const visibleMessages =
-		messagesWithCurDocContext.length > 3 ? messagesWithCurDocContext.slice(3) : [];
+		chatMessages.length > 3 ? chatMessages.slice(3) : [];
 
 	const resizeTextarea = useCallback(() => {
 		const textarea = textareaRef.current;
@@ -126,8 +141,11 @@ export default function Chat() {
 		chatLog.messageSent(log, { message: text, source });
 		updateSendingMessage(true);
 
+		// Pull the current document context at send time so the model sees the
+		// document as it is now, then inject it as the doc-context message.
+		const docContext = await refreshDocContext();
 		let newMessages = [
-			...messagesWithCurDocContext,
+			...withCurrentDocContext(chatMessages, docContext),
 			{ role: 'user', content: text },
 			{ role: 'assistant', content: '' },
 		];

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -236,7 +236,7 @@ function useResettableInterval(callback: () => void, interval: number) {
 
 export default function Draft() {
 	const editorAPI = useContext(EditorContext);
-	const docContextSnapshot = useDocContext(editorAPI);
+	const { refresh: refreshDocContext } = useDocContext(editorAPI);
 	const log = useLog();
 	const [isLoading, setIsLoading] = useState(false);
 	const [savedItems, updateSavedItems] = useState<SavedItem[]>([]);
@@ -250,14 +250,6 @@ export default function Draft() {
 		}
 		return fetcherRef.current;
 	}, []);
-	const docContextRef = useRef<DocContext>(docContextSnapshot);
-	docContextRef.current = docContextSnapshot;
-
-	// console.log({
-	// 	before: docContextSnapshot.beforeCursor.slice(-50),
-	// 	selected: docContextSnapshot.selectedText,
-	// 	after: docContextSnapshot.afterCursor.slice(0, 50),
-	// });
 
 	const autoRefreshInterval = 0;
 	const modesToShow = modes;
@@ -370,24 +362,27 @@ export default function Draft() {
 		[getFetcher, save, log],
 	);
 
-	const autoRefreshCallback = useCallback(() => {
+	const autoRefreshCallback = useCallback(async () => {
 		if (!shouldAutoRefresh) {
 			return;
 		}
-		const request = {
-			docContext: docContextRef.current,
-			type: modesToShow[0],
-		};
 		if (getFetcher().requestInFlight) {
 			console.warn(
 				'Auto-refresh skipped because a request is already in flight.',
 			);
 			return;
 		}
+		// Pull the current document context at refresh time rather than tracking
+		// it continuously.
+		const docContext = await refreshDocContext();
+		const request = {
+			docContext,
+			type: modesToShow[0],
+		};
 		const prevRequest = getFetcher().previousRequest;
 		if (
 			prevRequest &&
-			JSON.stringify(prevRequest.docContext) === JSON.stringify(docContextRef.current) &&
+			JSON.stringify(prevRequest.docContext) === JSON.stringify(docContext) &&
 			prevRequest.type === modesToShow[0]
 		) {
 			console.warn(
@@ -397,10 +392,10 @@ export default function Draft() {
 		}
 		draftLog.autoRefresh(log, {
 			generationType: modesToShow[0],
-			docContext: docContextRef.current,
+			docContext,
 		});
 		getSuggestion(request, false);
-	}, [getFetcher, getSuggestion, shouldAutoRefresh, log]);
+	}, [getFetcher, getSuggestion, shouldAutoRefresh, log, refreshDocContext]);
 
 	const resetAutoRefresh = useResettableInterval(
 		autoRefreshCallback,
@@ -430,17 +425,17 @@ export default function Draft() {
 										key={mode}
 										className={`${classes.featureCard} ${isActive ? classes.active : ''}`}
 										onClick={() => {
-											setActiveMode(mode);
-											draftLog.suggestionRequested(log, {
-												generationType: mode,
-												docContext: docContextRef.current,
-											});
-											resetAutoRefresh();
-											const request = {
-												docContext: docContextRef.current,
-												type: mode,
-											};
-											getSuggestion(request, true);
+											void (async () => {
+												setActiveMode(mode);
+												// Pull the current document context at click time.
+												const docContext = await refreshDocContext();
+												draftLog.suggestionRequested(log, {
+													generationType: mode,
+													docContext,
+												});
+												resetAutoRefresh();
+												getSuggestion({ docContext, type: mode }, true);
+											})();
 										}}
 										disabled={isLoading}
 										type="button"

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -207,7 +207,7 @@ const makeAnchorWithCallback = (
 
 export default function Revise() {
 	const editorAPI = useContext(EditorContext);
-	const docContext = useDocContext(editorAPI);
+	const { docContext, refresh: refreshDocContext } = useDocContext(editorAPI);
 	const log = useLog();
 	const activeRequestControllerRef = useRef<AbortController | null>(null);
 	const [_loading, setLoading] = useState(false);
@@ -276,16 +276,20 @@ export default function Revise() {
 				? prompt.prompt
 				: `Go part-by-part through the document. For each part, please do the following: ${prompt.prompt}`;
 
-			const newViz = new Visualization(request, docContext);
+			// Pull the current document context at request time rather than
+			// tracking it continuously.
+			const currentContext = await refreshDocContext();
+
+			const newViz = new Visualization(request, currentContext);
 			setVisualizations((prev) => [...prev, newViz]);
 
 			reviseLog.visualizationRequested(log, {
 				feature: prompt.keyword,
 				isOverall: Boolean(prompt.isOverall),
-				docContext,
+				docContext: currentContext,
 			});
 
-			const docTextAsPrompt = getDocTextAsPrompt(docContext);
+			const docTextAsPrompt = getDocTextAsPrompt(currentContext);
 
 			const messages: ModelMessage[] = [
 				{
@@ -344,7 +348,7 @@ ${request}
 				}
 			}
 		},
-		[docContext, log],
+		[refreshDocContext, log],
 	);
 
 	const toggleFeature = useCallback(

--- a/frontend/src/utilities/index.tsx
+++ b/frontend/src/utilities/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 /**
  * Converts a Word paragraph object into a usable string by removing leading and trailing
@@ -23,14 +23,24 @@ export function handleAutoResize(textarea: HTMLTextAreaElement): void {
 }
 
 /**
- * Hook to manage the document context in the editor.
+ * Hook that exposes the current document context with a pull-based API.
+ *
+ * Rather than subscribing to pushed selection-change events, this pulls the
+ * context on mount and whenever the user returns to the sidebar (focus /
+ * visibility) — the moments a displayed context can go stale. This matters for
+ * the Google Docs surface, where there is no native selection event and the
+ * only way to observe changes is to re-fetch the whole document through Apps
+ * Script; an always-on poll there is expensive and slow. Callers that act on
+ * the document (send a message, run a feature, generate a suggestion) should
+ * call `refresh()` at that moment to get the freshest value instead of relying
+ * on the last displayed one.
+ *
+ * @returns `docContext` — the last pulled context (for display), and
+ *   `refresh` — pulls the latest context, updates `docContext`, and resolves
+ *   with the fresh value.
  */
 export function useDocContext(editorAPI: EditorAPI) {
-	const {
-		addSelectionChangeHandler,
-		removeSelectionChangeHandler,
-		getDocContext,
-	} = editorAPI;
+	const { getDocContext } = editorAPI;
 
 	const [docContext, updateDocContext] = useState<DocContext>({
 		beforeCursor: '',
@@ -38,29 +48,30 @@ export function useDocContext(editorAPI: EditorAPI) {
 		afterCursor: '',
 	});
 
-	 // Register event handlers for selection changes in the document.
+	const refresh = useCallback(async (): Promise<DocContext> => {
+		const latest = await getDocContext();
+		updateDocContext(latest);
+		return latest;
+	}, [getDocContext]);
+
+	// Pull on mount, and again whenever the sidebar regains focus / becomes
+	// visible (i.e. the user came back from editing the document).
 	useEffect(() => {
-		function handleSelectionChanged(): void {
-			// Get the document context (before cursor, selected text, after cursor)
-			getDocContext().then((docInfo: DocContext) => {
-				updateDocContext(docInfo);
-			});
+		void refresh();
+
+		function handleReturnToSidebar(): void {
+			if (document.visibilityState === 'visible') {
+				void refresh();
+			}
 		}
 
-		// Handle initial selection change
-		handleSelectionChanged();
-
-		// Handle subsequent selection changes
-		addSelectionChangeHandler(handleSelectionChanged);
-
-		// Cleanup
+		window.addEventListener('focus', handleReturnToSidebar);
+		document.addEventListener('visibilitychange', handleReturnToSidebar);
 		return () => {
-			removeSelectionChangeHandler(handleSelectionChanged);
+			window.removeEventListener('focus', handleReturnToSidebar);
+			document.removeEventListener('visibilitychange', handleReturnToSidebar);
 		};
-	}, [
-		addSelectionChangeHandler,
-		getDocContext,
-		removeSelectionChangeHandler,
-	]);
-	return docContext;
+	}, [refresh]);
+
+	return { docContext, refresh };
 }


### PR DESCRIPTION
## Problem

The Google Docs surface has no native selection-change event, so `googleDocsEditorAPI` faked one by re-fetching the **entire document** through Apps Script every second, for as long as any handler was registered (`getDocContext` in `Code.gs` walks the whole body via `extractTextOnly` on every call). That round-trip is slow and quota-metered, and it ran continuously in the background even while the user was editing the document rather than looking at the sidebar.

There's no cheaper thing to poll: `DocumentApp` exposes no live change-token, and the dominant signal being watched is *selection/cursor movement*, which doesn't change any document version — so a version/revision poll wouldn't help. The realistic win is to stop polling by default.

## What changed

Auditing the consumers showed almost nothing needs *pushed* selection updates — draft, revise, and chat all read the document context at **action time** (button click, timer tick, message send), not reactively. Only the tag linker genuinely reacts to selection as the user moves it.

- **`useDocContext`** is now pull-based: it pulls on mount and whenever the sidebar regains focus / becomes visible, and returns a `refresh()` that callers invoke at action time for the freshest value. It no longer registers a selection-change handler, so it no longer triggers polling.
- **draft / revise / chat** pull via `refresh()` at click / request / send time.
- **chat**'s doc-context message building moved into pure helpers (`docContextMessageContent`, `withCurrentDocContext`) — seed the conversation when empty, otherwise replace the doc-context message in place — removing the previous render-time mutation.
- **`googleDocsEditorAPI`** now polls only while a handler is registered **and** the sidebar is visible and focused. It pauses on blur/hide, resumes (with an immediate pull) on return, and makes **no** Apps Script calls at all while inactive. The tag linker keeps using `addSelectionChangeHandler` and is the sole remaining poll trigger. Word's implementation is untouched — it still uses the native event.

## Design decision

For the reactive case, I gated the poll on **focus + visibility** (the "only poll while interacting with the sidebar" idea) rather than just a slower interval — it's the bigger saving and matches how the user actually moves between the doc and the sidebar.

## Tests

Node-based unit tests (no jsdom dependency added; matches the existing suite):

- `googleDocsEditorAPI.test.ts` — polling gating: pulls + notifies on selection change while active; no Apps Script calls while inactive; pauses on blur and resumes on focus; stops entirely when the last handler is removed.
- `chat/__tests__/docContextMessage.test.ts` — cursor vs. selection formatting; seed-when-empty vs. replace-in-place; input array not mutated.

Full suite: 37 passing. `tsc --noEmit` clean. `npm run build:google-docs` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmeEHgurJEnnger7Bo8a4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmeEHgurJEnnger7Bo8a4Q)_