### PR TITLE
Fix/auth flow

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -44,6 +44,9 @@ export function createApp({ auth }: { auth?: Auth } = {}): Hono {
 	}
 
 	app.onError(async (err, c) => {
+		// Also log to stderr: PostHog alone made route errors invisible during
+		// development (and container logs are the first place anyone looks).
+		console.error(`[${c.req.method} ${c.req.path}]`, err);
 		await captureException(err, { path: c.req.path, method: c.req.method });
 		return c.json({ detail: 'Internal server error' }, 500);
 	});

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -125,7 +125,10 @@ export const auth = betterAuth({
 			verificationUri: '/api/device', // nginx forwards /api/* to Hono
 			// Short expiry shrinks the brute-force window for the manually-entered
 			// user code (default length 8). No per-code attempt lockout yet.
-			expiresIn: '4m',
+			// 6m (was 4m): a Google 2FA detour was observed to outlive 4 minutes,
+			// and the user only learned at Approve time. The client shows a
+			// countdown from expires_in, so keep these in sync by feel.
+			expiresIn: '6m',
 			interval: '5s',
 			schema: {}, // workaround for https://github.com/better-auth/better-auth/issues/9422
 			validateClient: (clientId) => deviceClientIds().includes(clientId),

--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -126,8 +126,9 @@ export const auth = betterAuth({
 			// Short expiry shrinks the brute-force window for the manually-entered
 			// user code (default length 8). No per-code attempt lockout yet.
 			// 6m (was 4m): a Google 2FA detour was observed to outlive 4 minutes,
-			// and the user only learned at Approve time. The client shows a
-			// countdown from expires_in, so keep these in sync by feel.
+			// and the user only learned at Approve time. The client's countdown
+			// reads expires_in from the device-code response, so it tracks this
+			// value automatically — no client-side duration to keep in sync.
 			expiresIn: '6m',
 			interval: '5s',
 			schema: {}, // workaround for https://github.com/better-auth/better-auth/issues/9422

--- a/backend/src/routes/device-approval.ts
+++ b/backend/src/routes/device-approval.ts
@@ -3,12 +3,18 @@ import type { Context } from 'hono';
 // Browser-facing device authorization approval page at GET /api/device.
 // Must be on the backend's origin so Google session cookies reach Better Auth.
 // Registered whenever auth is enabled (see index.ts).
+
+// User-facing product name, in one place so it's tunable. Interpolated into the
+// template below (static HTML and the inline script alike). Cross-app naming
+// (manifest DisplayName, frontend) is a broader cleanup tracked separately.
+const PRODUCT_NAME = 'Thoughtful AI Tools';
+
 const DEVICE_HTML = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Authorize Writing Tools</title>
+  <title>Authorize ${PRODUCT_NAME}</title>
   <style>
     body { font-family: sans-serif; max-width: 520px; margin: 3rem auto; padding: 0 1.5rem; line-height: 1.5; }
     h1 { font-size: 1.4rem; }
@@ -25,8 +31,8 @@ const DEVICE_HTML = `<!DOCTYPE html>
   </style>
 </head>
 <body>
-  <h1>Authorize Writing Tools</h1>
-  <p class="muted">A device is requesting access to your Writing Tools account.</p>
+  <h1>Authorize ${PRODUCT_NAME}</h1>
+  <p class="muted">A device is requesting access to your ${PRODUCT_NAME} account.</p>
   <div id="content">Loading…</div>
   <div id="status"></div>
 
@@ -118,6 +124,10 @@ const DEVICE_HTML = `<!DOCTYPE html>
     // the user clicking Approve (e.g. a slow 2FA detour during Google sign-in).
     function renderDeviceError(data, action) {
       const desc = String((data && (data.error_description || data.error)) || '');
+      // Better Auth's device endpoint returns OAuth-style errors. Observed live for
+      // a dead/wrong code: { error: 'invalid_request', error_description: 'Invalid
+      // user code' }; an expired code surfaces error: 'expired_token'. Match those
+      // codes; the description regex is a defensive fallback only.
       const codeGone =
         data?.error === 'expired_token' ||
         data?.error === 'invalid_request' ||
@@ -126,7 +136,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
         showContent(); // the Approve/Deny buttons are useless for a dead code
         setStatus(
           el('p', 'err', action + ' failed: this code is no longer valid — it likely expired.'),
-          el('p', null, 'Codes only last a few minutes. Start sign-in again in Writing Tools to get a fresh code, then enter it here.'),
+          el('p', null, 'Codes only last a few minutes. Start sign-in again in ${PRODUCT_NAME} to get a fresh code, then enter it here.'),
           btn('approve', 'Enter a new code', () => init()),
         );
       } else {
@@ -145,7 +155,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
       const data = await res.json();
       if (res.ok && data?.success) {
         showContent();
-        setStatus(el('p', 'ok', 'Authorization complete. You can close this tab and return to Writing Tools.'));
+        setStatus(el('p', 'ok', 'Authorization complete. You can close this tab and return to ${PRODUCT_NAME}.'));
       } else {
         renderDeviceError(data, 'Approve');
       }
@@ -228,7 +238,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
       const switchP = el('p');
       switchP.append(linkButton('Use a different account', switchAccount));
 
-      const p = el('p', null, 'Enter the code shown in Writing Tools:');
+      const p = el('p', null, 'Enter the code shown in ${PRODUCT_NAME}:');
       const input = el('input', 'code-input');
       input.type = 'text';
       input.setAttribute('autocomplete', 'one-time-code');
@@ -253,7 +263,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
       const session = await getSession();
       if (!session) {
         const nodes = [
-          el('p', null, 'Sign in with Google, then enter the code shown in Writing Tools.'),
+          el('p', null, 'Sign in with Google, then enter the code shown in ${PRODUCT_NAME}.'),
           btn('approve', 'Sign in with Google', signIn),
         ];
         if (authError) {

--- a/backend/src/routes/device-approval.ts
+++ b/backend/src/routes/device-approval.ts
@@ -72,13 +72,20 @@ const DEVICE_HTML = `<!DOCTYPE html>
     }
 
     async function signIn() {
-      // Return to this same page (without any query) after Google sign-in.
+      // Return to this same page (without any query) after Google sign-in. OAuth
+      // failures come back here too, tagged ?auth_error=1 (errorCallbackURL) —
+      // without it, Better Auth renders its default error page whose "Go Home"
+      // link points at the backend root, a 404 dead end for the user.
       const callbackURL = window.location.origin + window.location.pathname;
       const res = await fetch(BASE + '/api/auth/sign-in/social', {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'google', callbackURL }),
+        body: JSON.stringify({
+          provider: 'google',
+          callbackURL,
+          errorCallbackURL: callbackURL + '?auth_error=1',
+        }),
       });
       const data = await res.json();
       if (data?.url) window.location.href = data.url;
@@ -103,6 +110,31 @@ const DEVICE_HTML = `<!DOCTYPE html>
       await signIn();
     }
 
+    // Render a device-endpoint failure. Expired/invalid codes replace the
+    // approval UI (retrying a dead code is pointless) with guidance plus a
+    // restart button. Unknown errors leave the Approve/Deny buttons in place so
+    // a transient failure (network blip, momentary 500) stays retryable — the
+    // common case here is a code that expired between the device showing it and
+    // the user clicking Approve (e.g. a slow 2FA detour during Google sign-in).
+    function renderDeviceError(data, action) {
+      const desc = String((data && (data.error_description || data.error)) || '');
+      const codeGone =
+        data?.error === 'expired_token' ||
+        data?.error === 'invalid_request' ||
+        /invalid user code|expired/i.test(desc);
+      if (codeGone) {
+        showContent(); // the Approve/Deny buttons are useless for a dead code
+        setStatus(
+          el('p', 'err', action + ' failed: this code is no longer valid — it likely expired.'),
+          el('p', null, 'Codes only last a few minutes. Start sign-in again in Writing Tools to get a fresh code, then enter it here.'),
+          btn('approve', 'Enter a new code', () => init()),
+        );
+      } else {
+        // Leave content (Approve/Deny) intact so the user can simply retry.
+        setStatus(el('span', 'err', action + ' failed: ' + JSON.stringify(data)));
+      }
+    }
+
     async function approve(userCode) {
       const res = await fetch(BASE + '/api/auth/device/approve', {
         method: 'POST',
@@ -115,7 +147,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
         showContent();
         setStatus(el('p', 'ok', 'Authorization complete. You can close this tab and return to Writing Tools.'));
       } else {
-        setStatus(el('span', 'err', 'Approve failed: ' + JSON.stringify(data)));
+        renderDeviceError(data, 'Approve');
       }
     }
 
@@ -131,7 +163,7 @@ const DEVICE_HTML = `<!DOCTYPE html>
         showContent();
         setStatus(el('p', 'err', 'Authorization denied. The device will not be granted access.'));
       } else {
-        setStatus(el('span', 'err', 'Deny failed: ' + JSON.stringify(data)));
+        renderDeviceError(data, 'Deny');
       }
     }
 
@@ -211,14 +243,26 @@ const DEVICE_HTML = `<!DOCTYPE html>
     }
 
     async function init() {
+      // An OAuth failure routed back via errorCallbackURL lands here with
+      // ?auth_error=1. Show an honest retry UI, and clean the URL so a refresh
+      // doesn't re-show a stale error.
+      const authError = new URLSearchParams(window.location.search).has('auth_error');
+      if (authError) {
+        history.replaceState(null, '', window.location.pathname);
+      }
       const session = await getSession();
       if (!session) {
-        showContent(
+        const nodes = [
           el('p', null, 'Sign in with Google, then enter the code shown in Writing Tools.'),
           btn('approve', 'Sign in with Google', signIn),
-        );
+        ];
+        if (authError) {
+          nodes.unshift(el('p', 'err', "Google sign-in didn't complete. Nothing was authorized — you can try again."));
+        }
+        showContent(...nodes);
         return;
       }
+      setStatus();
       showCodeEntry(session);
     }
 

--- a/frontend/src/api/__tests__/deviceAuth.test.ts
+++ b/frontend/src/api/__tests__/deviceAuth.test.ts
@@ -51,6 +51,19 @@ describe('requestDeviceCode', () => {
 		fetchMock.mockResolvedValueOnce(resp({ error: 'invalid_client' }));
 		await expect(requestDeviceCode()).rejects.toThrow(/device\/code failed/);
 	});
+
+	it('surfaces a readable error on a non-ok response with an unparseable body', async () => {
+		// A proxy 502 with an empty body used to crash with "Unexpected end of
+		// JSON input", masking the real failure.
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			status: 502,
+			json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+		} as unknown as Response);
+		await expect(requestDeviceCode()).rejects.toThrow(
+			/device\/code failed \(502\).*backend running/,
+		);
+	});
 });
 
 describe('pollForToken', () => {
@@ -105,6 +118,21 @@ describe('pollForToken', () => {
 		await vi.runAllTimersAsync();
 		const result = await promise;
 		expect(result.type).toBe('error');
+	});
+
+	it('returns a readable poll error on an unparseable body instead of crashing', async () => {
+		vi.useFakeTimers();
+		fetchMock.mockResolvedValueOnce({
+			ok: false,
+			status: 502,
+			json: () => Promise.reject(new SyntaxError('Unexpected end of JSON input')),
+		} as unknown as Response);
+		const promise = pollForToken('dev', 1);
+		await vi.runAllTimersAsync();
+		await expect(promise).resolves.toEqual({
+			type: 'error',
+			message: expect.stringMatching(/device\/token failed \(502\).*backend running/),
+		});
 	});
 
 	it('returns aborted when the signal is already aborted', async () => {

--- a/frontend/src/api/deviceAuth.ts
+++ b/frontend/src/api/deviceAuth.ts
@@ -53,13 +53,17 @@ export async function requestDeviceCode(
 		}),
 		signal,
 	});
-	const data = await res.json();
+	// Check ok before parsing: a proxy 502 with an empty body used to throw
+	// "Unexpected end of JSON input" here, masking the real failure (backend
+	// down/unreachable) behind a parse error.
 	if (!res.ok) {
-		throw new Error(
-			`device/code failed (${res.status}): ${JSON.stringify(data)}`,
-		);
+		const detail = await res
+			.json()
+			.then((d) => JSON.stringify(d))
+			.catch(() => 'no response body — is the backend running?');
+		throw new Error(`device/code failed (${res.status}): ${detail}`);
 	}
-	return data as DeviceCodeResponse;
+	return (await res.json()) as DeviceCodeResponse;
 }
 
 const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
@@ -120,7 +124,18 @@ export async function pollForToken(
 			return { type: 'error', message: (e as Error).message };
 		}
 
-		const data = await res.json();
+		// Same parse-safety as requestDeviceCode: an empty/non-JSON body (proxy
+		// error, backend restart) must surface as a readable poll error, not a
+		// JSON parse crash.
+		let data: { access_token?: unknown; error?: unknown };
+		try {
+			data = await res.json();
+		} catch {
+			return {
+				type: 'error',
+				message: `device/token failed (${res.status}): no response body — is the backend running?`,
+			};
+		}
 
 		if (res.ok && data.access_token) {
 			return { type: 'token', accessToken: data.access_token as string };

--- a/frontend/src/contexts/appAuthContext.tsx
+++ b/frontend/src/contexts/appAuthContext.tsx
@@ -48,10 +48,19 @@ export interface AppAuthSession {
 		status: 'pending' | 'polling' | 'error';
 		userCode?: string;
 		verificationUri?: string;
+		/** Epoch ms when the user code expires; drives the sign-in countdown. */
+		expiresAt?: number;
 		error?: string;
 	};
 	getAccessToken: () => Promise<string>;
 	login: () => Promise<void>;
+	/**
+	 * Abort an in-flight device sign-in and return to the idle login screen.
+	 * Abandoned attempts left polling forever are what produced overlapping
+	 * flows (and the state_mismatch artifacts) — always render a Cancel while
+	 * `isAuthorizing` so the user has a clean way out.
+	 */
+	cancelLogin: () => void;
 	logout: () => Promise<void>;
 }
 
@@ -68,6 +77,7 @@ const DEFAULT_SESSION: AppAuthSession = {
 		return Promise.resolve('');
 	},
 	login: () => Promise.resolve(),
+	cancelLogin: () => {},
 	logout: () => Promise.resolve(),
 };
 
@@ -94,6 +104,7 @@ function BetterAuthProvider({ children }: { children: ReactNode }) {
 				status: 'polling',
 				userCode: device.userCode,
 				verificationUri: device.verificationUri,
+				expiresAt: device.expiresAt,
 			};
 		} else if (device.status === 'error') {
 			authorization = { status: 'error', error: device.error };
@@ -121,6 +132,7 @@ function BetterAuthProvider({ children }: { children: ReactNode }) {
 				);
 			},
 			login: device.start,
+			cancelLogin: device.reset,
 			logout: device.logout,
 		};
 	}, [device]);
@@ -157,6 +169,7 @@ function DemoAuthProvider({ children }: { children: ReactNode }) {
 					: undefined,
 			getAccessToken: anon.getAccessToken,
 			login: () => Promise.resolve(),
+			cancelLogin: () => {},
 			logout: () => Promise.resolve(),
 		}),
 		[anon],

--- a/frontend/src/hooks/useDeviceAuth.ts
+++ b/frontend/src/hooks/useDeviceAuth.ts
@@ -30,6 +30,8 @@ export interface DeviceAuthState {
 	status: DeviceAuthStatus;
 	userCode?: string;
 	verificationUri?: string;
+	/** Epoch ms when the user code expires (from expires_in); drives the countdown. */
+	expiresAt?: number;
 	/** Present only on status==='success'. Held in memory only. */
 	token?: string;
 	user?: UserInfo;
@@ -100,6 +102,7 @@ export function useDeviceAuth(): UseDeviceAuth {
 			// Generic page with NO code in the URL — the user reads the code from here
 			// and types it on the approval page (intent/anti-phishing hardening).
 			verificationUri: code.verification_uri,
+			expiresAt: Date.now() + code.expires_in * 1000,
 		});
 
 		const result = await pollForToken(

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -47,8 +47,8 @@ function CodeCountdown({ expiresAt }: { expiresAt?: number }) {
 
 	const remaining = Math.max(0, Math.round((expiresAt - now) / 1000));
 	if (remaining === 0) {
-		// The polling loop surfaces the terminal 'expired' error shortly after;
-		// this just keeps the countdown honest in the gap.
+		// The polling loop surfaces the terminal 'expired' error within one poll
+		// interval (~5s); this keeps the countdown honest in that gap.
 		return <p style={{ margin: '0.25rem 0' }}>Code expired.</p>;
 	}
 	const m = Math.floor(remaining / 60);
@@ -62,8 +62,8 @@ function CodeCountdown({ expiresAt }: { expiresAt?: number }) {
 
 // Device-flow status surfaced during Better Auth sign-in. Shows the user code, a
 // link that opens the approval page in a new window/tab, the expiry countdown, and
-// a Cancel that aborts the in-flight flow (abandoned attempts left polling forever
-// are what produced overlapping sign-ins).
+// a Cancel that aborts the in-flight flow, so an abandoned attempt stops polling
+// immediately instead of running until the code expires.
 // Rendered inside the not-logged-in screen, NOT gated by the isLoading "Waiting" screen.
 function DeviceAuthStatus({
 	authorization,

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -35,20 +35,56 @@ const POSTHOG_KEY = 'phc_p3Br0zRnw7PdTVpdNI92vvBTWcBBY0jvkHO8dNvkCTl';
 const POSTHOG_HOST = 'https://e.thoughtful-ai.com/';
 const POSTHOG_ENABLED = true;
 
-// Device-flow status surfaced during Better Auth sign-in. Shows the user code and a
-// button that opens the approval page in a new window/tab.
+// Live countdown to the device code's expiry. Codes are short-lived (minutes) and
+// the user only used to find out at Approve time — show the clock up front.
+function CodeCountdown({ expiresAt }: { expiresAt?: number }) {
+	const [now, setNow] = useState(() => Date.now());
+	useEffect(() => {
+		const timer = setInterval(() => setNow(Date.now()), 1000);
+		return () => clearInterval(timer);
+	}, []);
+	if (!expiresAt) return null;
+
+	const remaining = Math.max(0, Math.round((expiresAt - now) / 1000));
+	if (remaining === 0) {
+		// The polling loop surfaces the terminal 'expired' error shortly after;
+		// this just keeps the countdown honest in the gap.
+		return <p style={{ margin: '0.25rem 0' }}>Code expired.</p>;
+	}
+	const m = Math.floor(remaining / 60);
+	const s = String(remaining % 60).padStart(2, '0');
+	return (
+		<p style={{ margin: '0.25rem 0', opacity: 0.75 }}>
+			Code expires in {m}:{s}
+		</p>
+	);
+}
+
+// Device-flow status surfaced during Better Auth sign-in. Shows the user code, a
+// link that opens the approval page in a new window/tab, the expiry countdown, and
+// a Cancel that aborts the in-flight flow (abandoned attempts left polling forever
+// are what produced overlapping sign-ins).
 // Rendered inside the not-logged-in screen, NOT gated by the isLoading "Waiting" screen.
 function DeviceAuthStatus({
 	authorization,
+	onCancel,
 }: {
 	authorization?: {
 		status: 'pending' | 'polling' | 'error';
 		userCode?: string;
 		verificationUri?: string;
+		expiresAt?: number;
 		error?: string;
 	};
+	onCancel?: () => void;
 }) {
 	if (!authorization) return null;
+
+	const cancelButton = onCancel ? (
+		<Button variant="ghost" size="small" onClick={onCancel}>
+			Cancel
+		</Button>
+	) : null;
 
 	if (authorization.status === 'error') {
 		return (
@@ -62,6 +98,7 @@ function DeviceAuthStatus({
 		return (
 			<div className={classes.loginInfoContainer}>
 				<p>Requesting device code…</p>
+				{cancelButton}
 			</div>
 		);
 	}
@@ -89,12 +126,14 @@ function DeviceAuthStatus({
 			>
 				{authorization.userCode}
 			</p>
+			<CodeCountdown expiresAt={authorization.expiresAt} />
 			{authorization.verificationUri ? (
 				<p style={{ margin: '0.25rem 0 0.75rem' }}>
 					<a href={authorization.verificationUri} target="_blank" rel="noopener">Open approval page</a>
 				</p>
 			) : null}
 			<p>Open the approval page and enter the code above to continue.</p>
+			{cancelButton}
 		</div>
 	);
 }
@@ -198,7 +237,10 @@ function AppInner() {
 							Login
 						</Button>
 
-						<DeviceAuthStatus authorization={authorization} />
+						<DeviceAuthStatus
+							authorization={authorization}
+							onCancel={session.cancelLogin}
+						/>
 
 						<div className={classes.loginInfoContainer}>
 							<p>


### PR DESCRIPTION
Title: fix(auth): device-flow UX, callback error handling, and dev error visibility

Closes several items in [#541](https://github.com/AIToolsLab/writing-tools/issues/541) — the auth-flow defects found while building and live-testing the account page ([#540](https://github.com/AIToolsLab/writing-tools/pull/540)). None of these are new regressions; they're pre-existing issues on main. The two dev-tooling items from [#541](https://github.com/AIToolsLab/writing-tools/issues/541) (manifest script paths, committed migrate command) are not here — they'll be a separate small PR.

Every fix below was verified live end-to-end (device sign-in, cancel, backend-down, OAuth failure, approve-after-expiry), not just via unit tests.

Context: the state_mismatch investigation
Intermittent sign-ins were dying on a state_mismatch error page. A controlled clean run (one backend, one incognito window, one attempt) completed with zero errors — the OAuth state machinery is correct. The failures were multi-attempt artifacts: clicking sign-in twice overwrites the single better-auth.state cookie, and replaying/refreshing an old callback tab consumes-then-misses the verification row. So the fix is prevention (a Cancel button that ends abandoned attempts cleanly), not state-machine surgery. We deliberately did not ship skipStateCookieCheck or storeStateStrategy: 'cookie' — those were diagnostic-only.

Backend (6f9bb1c area)
Device code lifetime 4m → 6m (auth.ts). A Google 2FA detour was observed to outlive the old 4-minute code, and the user only found out at Approve time. 6m clears the observed detour with margin; the brute-force window for an 8-char code is unaffected in practice. The client also now shows a countdown.
Honest approval-page errors (device-approval.ts). Expired/invalid codes now render plain guidance + an "Enter a new code" button instead of raw JSON. Unknown/transient errors keep the Approve/Deny buttons on screen so they stay retryable (an earlier draft wiped them — fixed).
errorCallbackURL on the approval-page Google sign-in. OAuth failures now return to the approval page with an honest retry banner, instead of Better Auth's default error page whose "Go Home" link points at the backend root → 404 dead end. The ?auth_error=1 marker is scrubbed from the URL after display.
Visible route errors (app.onError). Errors now log to stderr alongside PostHog capture. PostHog-only made route errors invisible in dev and in container logs — this hid a consent-save bug for a full live session.
Frontend (f41fb1b area)
Cancellable device sign-in. Exposes useDeviceAuth.reset() through AppAuthSession as cancelLogin and renders a Cancel button while authorizing. This is the root-cause mitigation for the state_mismatch artifacts above — it gives abandoned attempts a clean exit instead of leaving them polling forever.
Expiry countdown. Surfaces expires_in as authorization.expiresAt and shows "Code expires in m:ss" next to the code, so expiry is no longer a surprise at Approve time.
Defensive response parsing in requestDeviceCode / pollForToken. Both now check res.ok before parsing and catch unparseable bodies — an empty proxy 502 used to crash with "Unexpected end of JSON input", masking the real failure ("is the backend running?"). Regression tests added for both paths.
⚠️ Open decision for reviewer — account-deletion freshness
Deliberately left unchanged; flagging for a ruling. Account deletion uses Better Auth's session-freshness gate as its "re-auth is the confirmation" mechanism (built in [#540](https://github.com/AIToolsLab/writing-tools/pull/540)). But Better Auth's default freshAge is ~24 hours, and the account page requires you to already be signed in — so in practice the session is almost never stale, and the re-auth safeguard effectively never fires: deletion happens on a single confirm click. Verified live: a ~4-hour-old session deleted immediately with no re-auth.

Options:

Leave at 24h — deletion is one-click-plus-confirm; the re-auth path stays a rarely-hit edge case (current behavior).
Tighten session.freshAge to ~10–15 min — anyone who signed in more than ~15 min ago is bounced through a fresh device sign-in before deletion. Low collateral (delete-user is our only freshness-gated op, since Google-only accounts have no password/email changes).
Should permanent account deletion always demand a fresh sign-in, or is one confirm enough? Happy to make it a one-line follow-up either way.

Testing
Backend + frontend typecheck clean; all unit tests pass (incl. 2 new defensive-parsing regressions). Live matrix: stale-token recovery, cancel-aborts-polling, backend-down message, OAuth-failure banner, and approve-after-expiry all verified.

Part of [#541](https://github.com/AIToolsLab/writing-tools/issues/541).
