### PR TITLE
feat(navbar): page registry with core/lab tiers and a Labs overflow menu

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -21,6 +21,30 @@ TypeScript/React Microsoft Office Add-in for Word + standalone editor
   and `public/assets/`). Images imported in code live in `src/assets/`.
 - **Manifest**: `frontend/public/manifest.xml` for Office Add-in configuration
 
+### Pages and the navbar
+
+`src/pages/registry.tsx` is the single source of truth for which pages exist and
+where they appear. Adding a page is one `PageName` member (`src/contexts/
+pageContext.tsx`) plus one registry entry — the navbar and `pages/app` both read
+from the registry, so neither needs editing.
+
+- `tier: 'core'` — an inline tab. **Capped at three** (`MAX_CORE_PAGES`), which
+  `src/pages/__tests__/registry.test.ts` enforces.
+- `tier: 'lab'` — in progress; reachable from the Labs (···) menu instead. Every
+  lab page shares that one button, so the strip's width doesn't grow with the
+  number of experiments in flight.
+
+The cap is a platform constraint, not a style rule: the Google Docs sidebar is
+locked at ~300px with no splitter, which leaves 57.3px of label per tab beside the
+Labs button. A fourth core tab drops that to 37.0px, under the widest label
+("Revise", 39.8px). In-progress work belongs in `lab`.
+
+`enabled` (optional) hides a page entirely — see `src/pages/flags.ts`. Note the
+URL override there only reaches the standalone editor and dev server: the Word
+task pane's URL comes from `manifest.xml`, and the Google Docs bundle runs inside
+an Apps Script sandbox iframe with no addressable URL. The Labs menu is the
+cross-surface way in; flags are for keeping something out of even that.
+
 ### Testing
 
 Two runners own two disjoint directories — never mix them:

--- a/frontend/src/components/navbar/index.tsx
+++ b/frontend/src/components/navbar/index.tsx
@@ -1,47 +1,144 @@
-import {
-	PageName,
-	pageNameAtom,
-} from '@/contexts/pageContext';
-
 import { useAtom } from 'jotai';
+import { useEffect, useRef, useState } from 'react';
+import { pageNameAtom } from '@/contexts/pageContext';
+import { type PageDef, pagesByTier, resolvePage } from '@/pages/registry';
 import classes from './styles.module.css';
 
 /**
- * An array of objects representing the names and titles of pages.
- * Each object contains the following properties:
+ * The tab strip.
  *
- * @property {PageName} name - The name identifier of the page.
- * @property {string} title - The display title of the page.
+ * Core pages render inline; lab pages live behind the single Labs (···) button so
+ * the strip's width never depends on how many are in flight. What pages exist and
+ * which tier they're in is decided in `pages/registry.tsx`, not here.
+ *
+ * Whether a tab shows its hint is a CSS media query, not state — see the
+ * breakpoint in styles.module.css. Doing it there rather than with a width hook
+ * keeps a resize listener (and a re-render per resize tick) out of the strip, and
+ * leaves one definition of the threshold instead of a JS copy drifting from a CSS
+ * one. The `title` tooltip carries the hint at every width regardless.
  */
-
-type Page = {
-	name: PageName;
-	title: string;
-	hint: string;
-};
-
-const pageNames: Page[] = [
-	{ name: PageName.Draft, title: 'Draft', hint: 'Generate suggestions' },
-	{ name: PageName.Revise, title: 'Revise', hint: 'Improve your text' },
-	{ name: PageName.Chat, title: 'Chat', hint: 'Ask about your doc' },
-];
-
 export default function Navbar() {
 	const [page, changePage] = useAtom(pageNameAtom);
+	const [labsOpen, setLabsOpen] = useState(false);
+	const labsRef = useRef<HTMLDivElement>(null);
+
+	const corePages = pagesByTier('core');
+	const labPages = pagesByTier('lab');
+	// Highlight what's actually rendered: `pages/app` resolves the same way, so a
+	// stored selection that is no longer visible can't leave the strip with no
+	// active tab while a fallback page is on screen.
+	const activePage = resolvePage(page)?.name;
+
+	// Dismiss the menu on an outside click or Escape. Both listeners are only
+	// attached while it's open, so the closed strip costs nothing.
+	useEffect(() => {
+		if (!labsOpen) return;
+
+		function onPointerDown(event: MouseEvent) {
+			if (!labsRef.current?.contains(event.target as Node)) setLabsOpen(false);
+		}
+		function onKeyDown(event: KeyboardEvent) {
+			if (event.key === 'Escape') setLabsOpen(false);
+		}
+
+		document.addEventListener('mousedown', onPointerDown);
+		document.addEventListener('keydown', onKeyDown);
+		return () => {
+			document.removeEventListener('mousedown', onPointerDown);
+			document.removeEventListener('keydown', onKeyDown);
+		};
+	}, [labsOpen]);
+
+	function select(pageDef: PageDef) {
+		changePage(pageDef.name);
+		setLabsOpen(false);
+	}
 
 	return (
 		<div className={classes.tabs}>
-			{pageNames.map(({ name: pageName, title: pageTitle, hint }) => (
+			{corePages.map((pageDef) => (
 				<button
-					key={pageName}
+					key={pageDef.name}
 					type="button"
-					onClick={() => changePage(pageName)}
-					className={`${classes.tabBtn} ${page === pageName ? classes.active : ''}`}
+					// Carries the hint at every width; below the CSS breakpoint the
+					// tooltip is the only way to read it.
+					title={pageDef.hint}
+					onClick={() => select(pageDef)}
+					className={`${classes.tabBtn} ${
+						activePage === pageDef.name ? classes.active : ''
+					}`}
 				>
-					{pageTitle}
-					<span className={classes.tabHint}>{hint}</span>
+					<span className={classes.tabTitle}>{pageDef.title}</span>
+					<span className={classes.tabHint}>{pageDef.hint}</span>
 				</button>
 			))}
+
+			{labPages.length > 0 ? (
+				<div
+					ref={labsRef}
+					className={classes.labs}
+				>
+					<button
+						type="button"
+						title="Experimental pages"
+						aria-label="Experimental pages"
+						aria-haspopup="menu"
+						aria-expanded={labsOpen}
+						onClick={() => setLabsOpen((open) => !open)}
+						className={`${classes.overflowBtn} ${
+							labsOpen ||
+							labPages.some((pageDef) => pageDef.name === activePage)
+								? classes.active
+								: ''
+						}`}
+					>
+						···
+					</button>
+
+					{labsOpen ? (
+						<ul
+							className={classes.labsMenu}
+							role="menu"
+						>
+							{/*
+								The menu has the width the strip doesn't, so lab entries
+								show their hint inline rather than as a tooltip. The
+								heading does the work an "experimental" badge would have
+								done on an inline tab — grouping says it once, instead of
+								every tab repeating it.
+							*/}
+							<li
+								className={classes.labsHeading}
+								role="presentation"
+							>
+								Experimental
+							</li>
+							{labPages.map((pageDef) => (
+								<li
+									key={pageDef.name}
+									role="none"
+								>
+									<button
+										type="button"
+										role="menuitem"
+										onClick={() => select(pageDef)}
+										className={`${classes.labsItem} ${
+											activePage === pageDef.name
+												? classes.labsItemActive
+												: ''
+										}`}
+									>
+										{pageDef.title}
+										<span className={classes.tabHint}>
+											{pageDef.hint}
+										</span>
+									</button>
+								</li>
+							))}
+						</ul>
+					) : null}
+				</div>
+			) : null}
 		</div>
-		);
+	);
 }

--- a/frontend/src/components/navbar/styles.module.css
+++ b/frontend/src/components/navbar/styles.module.css
@@ -7,6 +7,21 @@
 	flex-shrink: 0;
 	/* Anchors the Labs dropdown, which is positioned against this strip. */
 	position: relative;
+	/*
+	 * Makes the strip itself the thing the hint breakpoint below measures.
+	 *
+	 * A media query would ask the viewport, which is only the same question in
+	 * the Word task pane and the Google Docs sidebar — there the pane *is* the
+	 * viewport. In the standalone editor the strip sits in a sidebar that is
+	 * `flex: 0 1 28rem` with `min-width: 14rem` (editor/styles.module.css), so it
+	 * can be 224px wide inside a 1400px window: the viewport says "wide", the
+	 * strip is anything but, and the hints come back and overflow.
+	 *
+	 * Containment here is inline-size only — no paint containment — so the Labs
+	 * dropdown still draws outside the strip. `.labs` stays the containing block
+	 * for the absolutely-positioned menu, being the nearer positioned ancestor.
+	 */
+	container-type: inline-size;
 }
 
 .tabBtn {
@@ -70,18 +85,29 @@
 /*
  * Drop the hints when the strip is too narrow to hold them on one line.
  *
- * Measured, not guessed: the widest hint ("Generate suggestions") is ~98px, and
- * three tabs beside the 32px Labs button only clear that at ~422px of viewport.
- * 440 is that number with headroom, since the exact figure moves with font
- * loading. Below it the hints wrapped into a ragged multi-line strip of uneven
- * heights — which is what the Google Docs sidebar, locked by the platform at
- * ~300px, has been showing all along.
+ * Measured, not guessed. The widest hint ("Generate suggestions") is ~97.8px,
+ * and each tab gets `(C - 32px Labs - 12px gaps) / 3 - 20px padding` of label
+ * room, so the hints need C >= 397.4px. 416 is that with headroom, since the
+ * exact figure moves with font loading. Below it they wrapped into a ragged
+ * multi-line strip of uneven heights — which is what the Google Docs sidebar,
+ * locked by the platform at ~300px, has been showing all along.
+ *
+ * A @container query, not @media: the width that matters is the strip's, and the
+ * two only coincide where the pane is the viewport. See `container-type` on
+ * .tabs. Container queries are Baseline (Chrome 105 / Safari 16 / Firefox 110),
+ * comfortably inside what this add-in already requires — pages/app warns Trident
+ * and EdgeHTML users the add-in won't run correctly at all.
+ *
+ * C is the strip's CONTENT box: a container query excludes the queried element's
+ * own padding, where a media query would have counted it. That is why this reads
+ * 415 and not the 439 an equivalent viewport breakpoint used — .tabs carries
+ * 24px of horizontal padding, so a 440px-wide strip queries as 416px.
  *
  * The hint is still on every tab as a `title` tooltip, so nothing is lost that
  * a hover can't recover; the Labs menu shows its entries' hints unconditionally,
  * because a dropdown has width the strip doesn't.
  */
-@media (max-width: 439px) {
+@container (max-width: 415px) {
 	/* Scoped to the strip: the Labs menu reuses .tabHint and must keep it. */
 	.tabBtn .tabHint {
 		display: none;

--- a/frontend/src/components/navbar/styles.module.css
+++ b/frontend/src/components/navbar/styles.module.css
@@ -5,10 +5,18 @@
 	border-bottom: 1px solid #e4e0d8;
 	gap: 4px;
 	flex-shrink: 0;
+	/* Anchors the Labs dropdown, which is positioned against this strip. */
+	position: relative;
 }
 
 .tabBtn {
 	flex: 1;
+	/*
+	 * Flex items default to min-width:auto, which refuses to shrink below the
+	 * content's intrinsic width — that's what lets a long label push the strip
+	 * wider than the 300px Google Docs sidebar instead of ellipsing inside it.
+	 */
+	min-width: 0;
 	display: flex;
 	flex-direction: column;
 	align-items: center;
@@ -38,9 +46,137 @@
 	color: #1c1c1c;
 }
 
+/*
+ * Truncate rather than spill. A tab label is usually a single word, and a single
+ * word has no break opportunity — without this it overflows the button and runs
+ * under its neighbour instead of wrapping. Only reachable if someone adds a long
+ * title or a fourth core tab (which registry.test.ts blocks), but the graceful
+ * version costs three lines.
+ */
+.tabTitle {
+	max-width: 100%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
 .tabHint {
 	font-size: 10px;
 	font-weight: 400;
 	color: inherit;
 	opacity: 0.7;
+}
+
+/*
+ * Drop the hints when the strip is too narrow to hold them on one line.
+ *
+ * Measured, not guessed: the widest hint ("Generate suggestions") is ~98px, and
+ * three tabs beside the 32px Labs button only clear that at ~422px of viewport.
+ * 440 is that number with headroom, since the exact figure moves with font
+ * loading. Below it the hints wrapped into a ragged multi-line strip of uneven
+ * heights — which is what the Google Docs sidebar, locked by the platform at
+ * ~300px, has been showing all along.
+ *
+ * The hint is still on every tab as a `title` tooltip, so nothing is lost that
+ * a hover can't recover; the Labs menu shows its entries' hints unconditionally,
+ * because a dropdown has width the strip doesn't.
+ */
+@media (max-width: 439px) {
+	/* Scoped to the strip: the Labs menu reuses .tabHint and must keep it. */
+	.tabBtn .tabHint {
+		display: none;
+	}
+}
+
+/*
+ * Labs (···) — the single entry point for every experimental page.
+ *
+ * `flex: 0 0 auto` is the load-bearing part: keeping this button out of the
+ * `flex: 1` distribution costs a fixed ~32px instead of an equal share, which
+ * leaves the core tabs ~57px of text at the 300px Google Docs width rather than
+ * the ~46px they'd get if Labs were a fourth equal tab.
+ */
+.labs {
+	flex: 0 0 auto;
+	position: relative;
+	display: flex;
+}
+
+.overflowBtn {
+	width: 32px;
+	padding: 8px 0 10px;
+	border: 1px solid transparent;
+	border-bottom: none;
+	border-radius: 6px 6px 0 0;
+	background: transparent;
+	font-size: 13px;
+	line-height: 1;
+	color: #b3aba0;
+	cursor: pointer;
+	font-family: 'DM Sans', sans-serif;
+	transition: all 0.15s;
+	margin-bottom: -1px;
+}
+
+.overflowBtn:hover {
+	color: #6b6b6b;
+}
+
+/*
+ * Right-anchored so the menu grows leftward — at 300px a left-anchored dropdown
+ * would run off the edge of the sidebar, which has nowhere to scroll to.
+ */
+.labsMenu {
+	position: absolute;
+	top: calc(100% + 1px);
+	right: 0;
+	z-index: 10;
+	margin: 0;
+	padding: 4px;
+	list-style: none;
+	min-width: 180px;
+	max-width: calc(100vw - 24px);
+	background: #fafaf8;
+	border: 1px solid #e4e0d8;
+	border-radius: 6px;
+	box-shadow: 0 4px 12px rgba(28, 28, 28, 0.12);
+}
+
+.labsHeading {
+	padding: 6px 10px 4px;
+	font-family: 'DM Sans', sans-serif;
+	font-size: 10px;
+	font-weight: 500;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: #b3aba0;
+}
+
+.labsItem {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 2px;
+	width: 100%;
+	padding: 8px 10px;
+	border: none;
+	border-radius: 4px;
+	background: transparent;
+	font-family: 'DM Sans', sans-serif;
+	font-size: 13px;
+	font-weight: 500;
+	text-align: left;
+	color: #6b6b6b;
+	cursor: pointer;
+	transition: all 0.15s;
+}
+
+.labsItem:hover {
+	background: #ffffff;
+	color: #1c1c1c;
+}
+
+.labsItemActive {
+	background: #ffffff;
+	color: #1c1c1c;
 }

--- a/frontend/src/pages/__tests__/flags.test.ts
+++ b/frontend/src/pages/__tests__/flags.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { enabledFlags, isFlagEnabled, resetFlagCache } from '../flags';
+
+/**
+ * Node environment, no jsdom (see vitest.config.ts — the suite is node-only and
+ * the one existing component test uses renderToStaticMarkup to stay that way).
+ * `window` and `localStorage` are stubbed per test, which also lets us reproduce
+ * the sandboxed-iframe case where touching storage throws.
+ */
+function fakeStorage(initial: Record<string, string> = {}) {
+	const entries = new Map(Object.entries(initial));
+	return {
+		getItem: vi.fn((key: string) => entries.get(key) ?? null),
+		setItem: vi.fn((key: string, value: string) => {
+			entries.set(key, value);
+		}),
+		removeItem: vi.fn((key: string) => {
+			entries.delete(key);
+		}),
+		entries,
+	};
+}
+
+function setSearch(search: string): void {
+	vi.stubGlobal('window', { location: { search } });
+}
+
+describe('feature flags', () => {
+	beforeEach(() => {
+		resetFlagCache();
+		vi.stubGlobal('localStorage', fakeStorage());
+		setSearch('');
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it('defaults to no flags', () => {
+		expect(enabledFlags()).toEqual([]);
+		expect(isFlagEnabled('tool-launcher')).toBe(false);
+	});
+
+	it('reads flags from the URL', () => {
+		setSearch('?ff=tool-launcher');
+
+		expect(isFlagEnabled('tool-launcher')).toBe(true);
+	});
+
+	it('accepts several comma-separated flags, ignoring stray whitespace', () => {
+		setSearch('?ff=tool-launcher, my-words ,');
+
+		expect(enabledFlags()).toEqual(['tool-launcher', 'my-words']);
+	});
+
+	it('persists a URL flag so it survives the reloads the task pane does', () => {
+		const storage = fakeStorage();
+		vi.stubGlobal('localStorage', storage);
+		setSearch('?ff=tool-launcher');
+		enabledFlags();
+
+		// Next page load: same storage, no query string.
+		resetFlagCache();
+		setSearch('');
+
+		expect(isFlagEnabled('tool-launcher')).toBe(true);
+	});
+
+	it('treats an empty ff= as a reset', () => {
+		const storage = fakeStorage({ featureFlags: 'tool-launcher' });
+		vi.stubGlobal('localStorage', storage);
+		setSearch('?ff=');
+
+		expect(enabledFlags()).toEqual([]);
+		expect(storage.entries.has('featureFlags')).toBe(false);
+	});
+
+	it('lets the URL override a stored flag', () => {
+		vi.stubGlobal('localStorage', fakeStorage({ featureFlags: 'my-words' }));
+		setSearch('?ff=tool-launcher');
+
+		expect(enabledFlags()).toEqual(['tool-launcher']);
+	});
+
+	it('resolves once per page load rather than on every lookup', () => {
+		const storage = fakeStorage({ featureFlags: 'tool-launcher' });
+		vi.stubGlobal('localStorage', storage);
+
+		enabledFlags();
+		enabledFlags();
+		enabledFlags();
+
+		// The navbar runs the registry's enabled predicates on every render;
+		// storage must not be re-read (or rewritten) each time.
+		expect(storage.getItem).toHaveBeenCalledTimes(1);
+	});
+
+	it('degrades to no flags when localStorage is unreachable', () => {
+		// A sandboxed iframe without allow-same-origin throws on property access
+		// rather than returning null. A flag lookup must never take the navbar
+		// down with it.
+		vi.stubGlobal('localStorage', {
+			getItem: () => {
+				throw new Error('SecurityError: sandboxed');
+			},
+		});
+
+		expect(() => enabledFlags()).not.toThrow();
+		expect(enabledFlags()).toEqual([]);
+	});
+
+	it('still applies a URL flag when the write to localStorage fails', () => {
+		vi.stubGlobal('localStorage', {
+			getItem: () => null,
+			setItem: () => {
+				throw new Error('QuotaExceededError');
+			},
+			removeItem: () => {},
+		});
+		setSearch('?ff=tool-launcher');
+
+		expect(isFlagEnabled('tool-launcher')).toBe(true);
+	});
+
+	it('degrades to no flags where there is no window at all', () => {
+		vi.stubGlobal('window', undefined);
+
+		expect(() => enabledFlags()).not.toThrow();
+		expect(enabledFlags()).toEqual([]);
+	});
+});

--- a/frontend/src/pages/__tests__/registry.test.ts
+++ b/frontend/src/pages/__tests__/registry.test.ts
@@ -1,0 +1,140 @@
+import type React from 'react';
+import { describe, expect, it } from 'vitest';
+import { PageName } from '@/contexts/pageContext';
+import {
+	DEFAULT_PAGE,
+	MAX_CORE_PAGES,
+	type PageDef,
+	PAGES,
+	pagesByTier,
+	resolvePage,
+	visiblePages,
+} from '../registry';
+
+/**
+ * Stand-in pages for the filtering/fallback tests, so they don't depend on which
+ * real features happen to be in flight. `render` is never called here — these
+ * tests are about selection, not rendering.
+ */
+function page(
+	name: PageName,
+	tier: PageDef['tier'],
+	enabled?: () => boolean,
+): PageDef {
+	return {
+		name,
+		title: name,
+		hint: `${name} hint`,
+		tier,
+		enabled,
+		render: () => null as unknown as React.JSX.Element,
+	};
+}
+
+describe('page registry', () => {
+	describe('the shipped registry', () => {
+		it('fits the core tabs in the 300px Google Docs sidebar', () => {
+			// The sidebar is locked by the platform — this is the one navbar
+			// constraint that can't be fixed by resizing, so it's asserted rather
+			// than left as a comment. If this fails, the new page belongs in the
+			// Labs menu (tier: 'lab'), not the strip.
+			expect(pagesByTier('core').length).toBeLessThanOrEqual(MAX_CORE_PAGES);
+		});
+
+		it('can render whatever the default selection resolves to', () => {
+			expect(resolvePage(DEFAULT_PAGE)).toBeDefined();
+		});
+
+		it('gives every page a unique name', () => {
+			const names = PAGES.map((entry) => entry.name);
+
+			expect(new Set(names).size).toBe(names.length);
+		});
+
+		it('gives every page a title and a hint', () => {
+			for (const entry of PAGES) {
+				expect(entry.title.length).toBeGreaterThan(0);
+				expect(entry.hint.length).toBeGreaterThan(0);
+			}
+		});
+	});
+
+	describe('visibility', () => {
+		it('treats a page with no predicate as always visible', () => {
+			const pages = [page(PageName.Draft, 'core')];
+
+			expect(visiblePages(pages)).toHaveLength(1);
+		});
+
+		it('withholds a page whose predicate is false', () => {
+			const pages = [
+				page(PageName.Draft, 'core'),
+				page(PageName.TagLinker, 'lab', () => false),
+			];
+
+			expect(visiblePages(pages).map((entry) => entry.name)).toEqual([
+				PageName.Draft,
+			]);
+		});
+	});
+
+	describe('tiers', () => {
+		const pages = [
+			page(PageName.Draft, 'core'),
+			page(PageName.Revise, 'core'),
+			page(PageName.TagLinker, 'lab'),
+			page(PageName.Chat, 'lab', () => false),
+		];
+
+		it('keeps lab pages out of the inline strip', () => {
+			expect(pagesByTier('core', pages).map((entry) => entry.name)).toEqual([
+				PageName.Draft,
+				PageName.Revise,
+			]);
+		});
+
+		it('lists only enabled lab pages in the Labs menu', () => {
+			expect(pagesByTier('lab', pages).map((entry) => entry.name)).toEqual([
+				PageName.TagLinker,
+			]);
+		});
+
+		it('preserves registration order within a tier', () => {
+			const reversed = [page(PageName.Revise, 'core'), page(PageName.Draft, 'core')];
+
+			expect(pagesByTier('core', reversed).map((entry) => entry.name)).toEqual([
+				PageName.Revise,
+				PageName.Draft,
+			]);
+		});
+	});
+
+	describe('resolvePage', () => {
+		it('returns the selected page when it is visible', () => {
+			const pages = [page(PageName.Draft, 'core'), page(PageName.Revise, 'core')];
+
+			expect(resolvePage(PageName.Revise, pages)?.name).toBe(PageName.Revise);
+		});
+
+		it('falls back to the default when the selection was flagged off', () => {
+			// A user sitting on a lab page when its flag is turned off: the stored
+			// atom still names a page that should no longer be reachable.
+			const pages = [
+				page(DEFAULT_PAGE, 'core'),
+				page(PageName.TagLinker, 'lab', () => false),
+			];
+
+			expect(resolvePage(PageName.TagLinker, pages)?.name).toBe(DEFAULT_PAGE);
+		});
+
+		it('falls back to the first visible page when even the default is gone', () => {
+			const pages = [page(PageName.Chat, 'core')];
+
+			expect(resolvePage(PageName.TagLinker, pages)?.name).toBe(PageName.Chat);
+		});
+
+		it('returns undefined when nothing is visible', () => {
+			expect(resolvePage(PageName.Draft, [])).toBeUndefined();
+		});
+	});
+});

--- a/frontend/src/pages/app/index.tsx
+++ b/frontend/src/pages/app/index.tsx
@@ -22,9 +22,7 @@ import {
 	pageNameAtom,
 } from '@/contexts/pageContext';
 import { OnboardingCarousel } from '../carousel/OnboardingCarousel';
-import Chat from '../chat';
-import Draft from '../draft';
-import Revise from '../revise';
+import { resolvePage } from '../registry';
 import classes from './styles.module.css';
 import Navbar from '@/components/navbar';
 import { Reshaped, Button } from 'reshaped';
@@ -336,16 +334,13 @@ function AppInner() {
 		);
 	}
 
+	// Which page renders is the registry's call, not a switch here — see
+	// pages/registry.tsx. resolvePage also handles a stored selection that is no
+	// longer visible (a lab page whose flag was turned off) by falling back to the
+	// default page; the navbar highlights the same resolved page, so the strip and
+	// the content can't disagree.
 	function getComponent(pageName: PageName): React.JSX.Element | null {
-		switch (pageName) {
-			case PageName.Revise:
-				return <Revise />;
-			case PageName.Chat:
-				return <Chat />;
-			case PageName.Draft:
-				return <Draft />;
-		}
-		return null;
+		return resolvePage(pageName)?.render() ?? null;
 	}
 
 	return (

--- a/frontend/src/pages/flags.ts
+++ b/frontend/src/pages/flags.ts
@@ -1,0 +1,98 @@
+/**
+ * Feature flags for in-progress pages.
+ *
+ * Deliberately tiny: a flag is a string, it is off unless switched on, and the
+ * only thing it gates today is whether a page appears in the Labs menu. This is
+ * not an experimentation system. If we ever need percentage rollout or per-user
+ * targeting, that belongs on the session server-side — the `alwaysAllow` /
+ * `isAllowed` pair in `backend/src/auth.ts` is the pattern to copy — not here,
+ * because anything decided in this file is decided on the user's machine and can
+ * be switched on by anyone who opens devtools. Flags here hide unfinished work
+ * from a closed beta; they are not an access control.
+ *
+ * ## Turning one on
+ *
+ * Append `?ff=<flag>` to the URL (comma-separate several: `?ff=a,b`). The choice
+ * is written to localStorage, so it survives the reloads the task pane does on
+ * its own. `?ff=` with an empty value clears everything.
+ *
+ * ## Which surfaces the URL override actually reaches
+ *
+ * Only the standalone editor and the dev server. The Word task pane loads the URL
+ * named in `manifest.xml`, and on Google Docs the bundle runs inside an Apps
+ * Script sandbox iframe whose location is not addressable — on neither surface is
+ * there a query string a user can edit.
+ *
+ * That is a deliberate consequence of the design rather than a gap to close: the
+ * Labs menu, not the URL, is how a lab page is meant to be reached, and it works
+ * identically on all three surfaces. Reach for a flag only when something must
+ * stay out of even the Labs menu, and expect to demo it from the editor.
+ */
+
+const STORAGE_KEY = 'featureFlags';
+const URL_PARAM = 'ff';
+
+/**
+ * localStorage is not reachable everywhere this bundle runs: a sandboxed iframe
+ * without `allow-same-origin` throws on property access rather than returning
+ * null, and Safari throws in private browsing. A flag lookup failing must never
+ * take the navbar down with it, so every access is guarded and degrades to "no
+ * flags set".
+ */
+function readStored(): string[] {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		return raw ? parseList(raw) : [];
+	} catch {
+		return [];
+	}
+}
+
+function persist(flags: string[]): void {
+	try {
+		if (flags.length === 0) localStorage.removeItem(STORAGE_KEY);
+		else localStorage.setItem(STORAGE_KEY, flags.join(','));
+	} catch {
+		// Non-fatal: the flag still applies for this page load, just not the next.
+	}
+}
+
+/** null when the parameter is absent — distinct from `?ff=`, which clears. */
+function readUrl(): string[] | null {
+	try {
+		const raw = new URLSearchParams(window.location.search).get(URL_PARAM);
+		return raw === null ? null : parseList(raw);
+	} catch {
+		return null;
+	}
+}
+
+function parseList(raw: string): string[] {
+	return raw
+		.split(',')
+		.map((flag) => flag.trim())
+		.filter(Boolean);
+}
+
+// Resolved once per page load. The registry's `enabled` predicates run on every
+// navbar render, and re-reading (and re-writing) storage each time would make
+// rendering do I/O for a value that cannot change without a reload.
+let cache: string[] | null = null;
+
+/** The flags in effect for this page load. URL wins over storage, and updates it. */
+export function enabledFlags(): string[] {
+	if (cache) return cache;
+	const fromUrl = readUrl();
+	if (fromUrl !== null) persist(fromUrl);
+	cache = fromUrl ?? readStored();
+	return cache;
+}
+
+export function isFlagEnabled(flag: string): boolean {
+	return enabledFlags().includes(flag);
+}
+
+/** Test seam — drops the per-load cache so a test can change the environment. */
+export function resetFlagCache(): void {
+	cache = null;
+}

--- a/frontend/src/pages/registry.tsx
+++ b/frontend/src/pages/registry.tsx
@@ -1,0 +1,139 @@
+/**
+ * The page registry — the single source of truth for which pages exist, how they
+ * are labelled, where they appear in the navbar, and how they render.
+ *
+ * Adding a page used to mean editing three places: the `PageName` enum, the
+ * navbar's `pageNames` array, and a `switch` in `pages/app`. Every in-flight
+ * feature branch touched all three, so every branch conflicted with every other
+ * one in exactly those files. Now a page is one enum member plus one entry here.
+ *
+ * ## Tiers
+ *
+ * - `core` — a primary destination, rendered inline in the tab strip.
+ * - `lab`  — in progress. Reachable from the Labs (···) menu instead of the strip.
+ *
+ * The tier split exists for space, and the binding constraint is the Google Docs
+ * sidebar: the platform locks it to ~300px with no splitter to drag, which leaves
+ * roughly 57px of text per tab once the fixed-width Labs button is subtracted (see
+ * `components/navbar/styles.module.css`). Three text tabs is what fits. Because
+ * every lab page shares the single Labs button, the strip's width stops being a
+ * function of how many experiments are in flight — that, not tidiness, is the
+ * point. Promote a page by changing one word; do not add a fourth core tab
+ * without re-checking it against 300px.
+ *
+ * ## Visibility
+ *
+ * `enabled` is optional and defaults to always-on. Give a lab page one when it
+ * should stay out of even the Labs menu — see `flags.ts`, and note the caveat
+ * there about which surfaces the URL override actually reaches.
+ */
+import type React from 'react';
+import { PageName } from '@/contexts/pageContext';
+import Chat from './chat';
+import Draft from './draft';
+import Revise from './revise';
+
+export type PageTier = 'core' | 'lab';
+
+export type PageDef = {
+	/** Stable identifier; also what `pageNameAtom` stores. */
+	name: PageName;
+	/** Tab label. Keep it short — see the 300px budget above. */
+	title: string;
+	/**
+	 * One-line description. Shown under the title on wide task panes, as the
+	 * button's tooltip when the strip is too narrow for it, and always as the
+	 * second line of a Labs menu entry (the dropdown has room the strip doesn't).
+	 */
+	hint: string;
+	tier: PageTier;
+	/** Defaults to always-visible. Return false to withhold the page entirely. */
+	enabled?: () => boolean;
+	render: () => React.JSX.Element;
+};
+
+/**
+ * Registration order is display order, within each tier.
+ *
+ * `render` is a thunk rather than a component reference so an entry can pass
+ * props later without every consumer learning about them.
+ */
+export const PAGES: PageDef[] = [
+	{
+		name: PageName.Draft,
+		title: 'Draft',
+		hint: 'Generate suggestions',
+		tier: 'core',
+		render: () => <Draft />,
+	},
+	{
+		name: PageName.Revise,
+		title: 'Revise',
+		hint: 'Improve your text',
+		tier: 'core',
+		render: () => <Revise />,
+	},
+	{
+		name: PageName.Chat,
+		title: 'Chat',
+		hint: 'Ask about your doc',
+		tier: 'core',
+		render: () => <Chat />,
+	},
+];
+
+/** The page shown when nothing is selected, or when the selection isn't visible. */
+export const DEFAULT_PAGE = PageName.Draft;
+
+/**
+ * The maximum core tabs the narrowest surface can hold.
+ *
+ * Measured, not chosen. The Google Docs sidebar is locked at ~300px, where three
+ * tabs beside the fixed-width Labs button get 57.3px of text each and the widest
+ * label ("Revise", 39.8px) fits comfortably. A fourth drops that to 37.0px —
+ * under the label — and because a one-word label has no break opportunity it
+ * doesn't wrap, it overflows its button. `registry.test.ts` asserts this bound,
+ * so adding a core page fails the suite instead of the sidebar.
+ *
+ * The figure assumes the Labs button is present, which it is whenever any lab
+ * page exists. Four tabs would fit without it (46.0px), but the strip is not
+ * worth making conditional on that.
+ */
+export const MAX_CORE_PAGES = 3;
+
+/**
+ * `pages` is a seam for tests — production callers pass nothing and get the real
+ * registry. It exists because the interesting logic is the filtering and the
+ * fallback, and exercising those otherwise means mutating a module-level const.
+ */
+
+/** Every page whose `enabled` predicate passes, in registration order. */
+export function visiblePages(pages: PageDef[] = PAGES): PageDef[] {
+	return pages.filter((page) => page.enabled?.() ?? true);
+}
+
+/** Visible pages in one tier — what the navbar renders from. */
+export function pagesByTier(tier: PageTier, pages: PageDef[] = PAGES): PageDef[] {
+	return visiblePages(pages).filter((page) => page.tier === tier);
+}
+
+/**
+ * The page to actually render for a stored selection.
+ *
+ * Falls back to DEFAULT_PAGE when the selection isn't visible, which is what
+ * happens if a user is sitting on a lab page and its flag is then turned off:
+ * the stored atom still names a page that should no longer be reachable. Callers
+ * use this for both rendering and active-tab highlighting so the two can't
+ * disagree. Returns undefined only if the registry has no visible pages at all.
+ */
+export function resolvePage(
+	name: PageName,
+	pages: PageDef[] = PAGES,
+): PageDef | undefined {
+	const visible = visiblePages(pages);
+	return (
+		visible.find((page) => page.name === name) ??
+		visible.find((page) => page.name === DEFAULT_PAGE) ??
+		visible[0]
+	);
+}


### PR DESCRIPTION
Lands the navbar half of the feature-flag discussion, on its own and ahead of any feature branch, so `feat/tool-launcher` and the my-words tree can merge into it rather than around each other.

## Why

Adding a page meant editing three files — the `PageName` enum, the navbar's hardcoded `pageNames` array, and a `switch` in `pages/app`. `feat/tool-launcher` and `claude/voice-native-conversation-research-k7uirl` each touch **exactly those three**, so today they conflict with each other in all three places. A page is now one enum member plus one registry entry (`frontend/src/pages/registry.tsx`).

The second problem is space. `index-gdocs.tsx` mounts the same `App`, so the identical tab strip renders inside the Google Docs sidebar, which the platform locks at ~300px with no splitter to drag. Lab pages therefore render behind a single Labs (···) button instead of inline, which makes strip width independent of how many experiments are in flight.

## Measured, not estimated

Numbers below are from Chromium against the real stylesheet, not arithmetic:

| layout @300px | label width per core tab |
|---|---|
| 3 core + fixed-width Labs button | **57.3px** |
| 4 core + Labs button | 37.0px |
| 4 core, no Labs button | 46.0px |

- The widest label, "Revise", needs **39.8px**. Three core tabs fit; a fourth does not, and since a one-word label has no break opportunity it *overflows its button* rather than wrapping. `MAX_CORE_PAGES` encodes this and `registry.test.ts` enforces it, so a fourth core page fails the suite instead of the sidebar.
- Keeping the Labs button out of the `flex: 1` distribution (`flex: 0 0 auto`, 32px) is load-bearing — it buys 57.3px per tab where a fourth equal tab would give 46.0px.

## Bug this fixes

The widest hint, "Generate suggestions", needs **97.8px**, which three tabs only clear at a **~422px** viewport. The hints have been wrapping into a ragged multi-line strip on Google Docs all along — this is a present-tense bug, not one the new pages introduce. They now drop out below a 440px media query and remain as `title` tooltips. The Labs menu shows its entries' hints inline, having the width the strip doesn't.

An earlier cut of this used a JS width hook at 400px; the measurements showed 400 is still too narrow, and the threshold moved to CSS — one definition instead of a JS copy drifting from a CSS one, and no resize listener in the strip.

## Also

- `text-overflow: ellipsis` on the label, so an over-long title truncates instead of running under its neighbour.
- `flags.ts` for hiding a page from even the Labs menu. **Its `?ff=` override only reaches the standalone editor and the dev server** — the Word task pane's URL comes from `manifest.xml`, and the Google Docs bundle runs inside an Apps Script sandbox iframe with no addressable URL. The Labs menu, not the URL, is the cross-surface way in; flags are for keeping something out of even that. Storage access is guarded throughout (a sandboxed iframe throws on access rather than returning null), so a flag lookup can't take the navbar down.
- `resolvePage` handles a stored selection that is no longer visible — a user sitting on a lab page whose flag is then turned off gets the default page, and the navbar highlights the same resolved page so strip and content can't disagree.

## Scope

No behaviour change for Draft/Revise/Chat beyond the hint breakpoint. No lab pages are registered here — the registry ships with the three existing core pages, so this is inert until a feature branch adds an entry.

## Verification

`npm test` 69 passed (10 files, 23 new), `typecheck` clean, `lint` clean (the 2 remaining warnings are pre-existing in `draft/index.tsx`), and both `build` and `build:google-docs` succeed.

Note: `npm ci` fails on `main` — `frontend/package-lock.json` is out of sync with `package.json` (missing `esbuild@0.28.1` and its platform packages). Pre-existing and untouched here; I installed with `--no-save` so no lockfile change is in this diff.

## Follow-up

`feat/tool-launcher` has testers on it, so it should **merge** `main` rather than rebase, then replace its three-file nav diff with a single `tier: 'lab'` entry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RoWkRJYiXGdHTxsyrffv6A)_