### PR TITLE
experiment: log participant subject line

### DIFF
--- a/experiment/components/WritingArea.tsx
+++ b/experiment/components/WritingArea.tsx
@@ -11,8 +11,8 @@ export interface WritingAreaRef {
 }
 
 interface WritingAreaProps {
-  onSend?: (content: string) => Promise<void>;
-  onUpdate?: (state: TextEditorState) => Promise<void>;
+  onSend?: (content: string, subject: string) => Promise<void>;
+  onUpdate?: (state: TextEditorState, subject: string) => Promise<void>;
   showSendButton?: boolean;
 }
 
@@ -54,7 +54,17 @@ const WritingArea = forwardRef<WritingAreaRef, WritingAreaProps>(
       const newBody = e.target.value;
       setBody(newBody);
       if (onUpdate) {
-        onUpdate(getEditorState()).catch((e) =>
+        onUpdate(getEditorState(), subject).catch((e) =>
+          console.error('Failed to log document update:', e)
+        );
+      }
+    };
+
+    const handleSubjectChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newSubject = e.target.value;
+      setSubject(newSubject);
+      if (onUpdate) {
+        onUpdate(getEditorState(), newSubject).catch((e) =>
           console.error('Failed to log document update:', e)
         );
       }
@@ -64,7 +74,7 @@ const WritingArea = forwardRef<WritingAreaRef, WritingAreaProps>(
       if (onSend) {
         setIsSending(true);
         try {
-          await onSend(body);
+          await onSend(body, subject);
         } catch (error) {
           console.error('Failed to send:', error);
         } finally {
@@ -106,7 +116,7 @@ const WritingArea = forwardRef<WritingAreaRef, WritingAreaProps>(
                   className="flex-1 border border-gray-300 px-2 py-1 rounded text-sm bg-white text-gray-900 placeholder-gray-400"
                   placeholder="Enter subject..."
                   value={subject}
-                  onChange={(e) => setSubject(e.target.value)}
+                  onChange={handleSubjectChange}
                 />
               </div>
             </div>

--- a/experiment/components/study/TaskPage.tsx
+++ b/experiment/components/study/TaskPage.tsx
@@ -43,13 +43,14 @@ export default function TaskPage() {
     return () => clearTimeout(timer);
   }, []);
 
-  const handleSendTask = async (content: string) => {
+  const handleSendTask = async (content: string, subject: string) => {
     // Log task completion
     await log({
       username,
       event: 'taskComplete',
       extra_data: {
         finalText: content,
+        subject,
         wordCount: content.split(/\s+/).length,
         documentLength: content.length,
       },
@@ -61,13 +62,14 @@ export default function TaskPage() {
     window.location.href = `/study?${params.toString()}`;
   };
 
-  const handleDocumentUpdate = async (editorState: TextEditorState) => {
+  const handleDocumentUpdate = async (editorState: TextEditorState, subject: string) => {
     const fullContent = editorState.beforeCursor + editorState.selectedText + editorState.afterCursor;
     await log({
       username,
       event: 'documentUpdate',
       extra_data: {
         editorState,
+        subject,
         wordCount: fullContent.split(/\s+/).length,
         documentLength: fullContent.length,
       },


### PR DESCRIPTION
## Summary
- `WritingArea` now passes the subject line alongside the email body to its `onSend`/`onUpdate` callbacks, and calls `onUpdate` when the subject field changes (previously only body edits triggered it).
- `TaskPage`'s `documentUpdate` and `taskComplete` log events now include the participant-written `subject` in `extra_data`, so the subject line is captured in the study logs alongside the body text.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — no new warnings/errors introduced (pre-existing issues unrelated to this change remain)
- [x] `npm test` — all 20 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpZ42DPQr7X3QFgtRXFUty)_