### PR TITLE
fix(frontend): make failed generations visible instead of silent

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -45,6 +45,25 @@ task pane's URL comes from `manifest.xml`, and the Google Docs bundle runs insid
 an Apps Script sandbox iframe with no addressable URL. The Labs menu is the
 cross-surface way in; flags are for keeping something out of even that.
 
+### Generation calls and failures
+
+Pages must generate through `src/api/generate.ts` (`streamTextDeltas`,
+`generateFullText`), never by calling `streamText` directly. `streamText` does not
+throw on model or transport errors: it puts them in the stream as an `error` part,
+and `result.textStream` forwards only `text-delta` parts. A failed generation is
+therefore indistinguishable from an empty successful one — the loop ends, `await
+result.text` gives `''`, and the surrounding `try/catch` never runs. That is how a
+quota failure reached writers as a blank panel. The helpers read `fullStream`
+instead and throw a `GenerationError`.
+
+Catch it, run the value through `describeGenerationError` (`src/api/errors.ts`),
+and render the result with `<GenerationErrorNotice>`
+(`src/components/errorNotice/`) — one writer-facing sentence, the provider's own
+text behind a "Technical details" toggle, and Retry only when `info.retryable`.
+Log `info.detail` (provider text) and `info.code`, not the sentence shown on
+screen. A successful-but-empty generation is also a visible outcome (`tone="info"`
+notice), never silence.
+
 ### Testing
 
 Two runners own two disjoint directories — never mix them:
@@ -54,7 +73,8 @@ Two runners own two disjoint directories — never mix them:
   (or `npm run test:watch`). Node environment by default; for a component test add
   `// @vitest-environment jsdom` at the top of that file.
   - LLM calls are tested by passing a `MockLanguageModelV2` (from `ai/test`) as the
-    `model` arg to `streamText`/`generateText` — see `src/api/__tests__/generate.test.ts`.
+    `model` arg to `streamTextDeltas`/`generateFullText` — see
+    `src/api/__tests__/generate.test.ts`, including how to stream an `error` part.
 - **Playwright** (E2E/visual) — `tests/`, files named `*.spec.ts`. Scoped via
   `testDir` in `playwright.config.ts`. Run with `npx playwright test`.
 

--- a/frontend/src/api/__tests__/errors.test.ts
+++ b/frontend/src/api/__tests__/errors.test.ts
@@ -1,0 +1,109 @@
+import { APICallError } from 'ai';
+import { describe, expect, it } from 'vitest';
+import { describeGenerationError, GenerationError } from '../errors';
+
+function apiCallError({
+	statusCode,
+	responseBody,
+}: {
+	statusCode: number;
+	responseBody?: string;
+}) {
+	return new APICallError({
+		message: 'request failed',
+		url: 'https://example.test/openai/responses',
+		requestBodyValues: {},
+		statusCode,
+		responseBody,
+	});
+}
+
+describe('describeGenerationError', () => {
+	it('reads a code out of a mid-stream provider chunk', () => {
+		// The shape @ai-sdk/openai forwards for an `error` SSE event.
+		const info = describeGenerationError({
+			type: 'error',
+			sequence_number: 2,
+			error: {
+				type: 'insufficient_quota',
+				code: 'insufficient_quota',
+				message: 'You exceeded your current quota.',
+			},
+		});
+
+		expect(info.code).toBe('insufficient_quota');
+		expect(info.message).toMatch(/out of credit/i);
+		expect(info.detail).toBe('You exceeded your current quota.');
+		expect(info.retryable).toBe(false);
+	});
+
+	it('reads a code out of an APICallError response body', () => {
+		const info = describeGenerationError(
+			apiCallError({
+				statusCode: 429,
+				responseBody: JSON.stringify({
+					error: {
+						code: 'rate_limit_exceeded',
+						message: 'Slow down.',
+					},
+				}),
+			}),
+		);
+
+		expect(info.code).toBe('rate_limit_exceeded');
+		expect(info.status).toBe(429);
+		expect(info.message).toMatch(/rate-limited/i);
+		expect(info.retryable).toBe(true);
+	});
+
+	it('falls back to the HTTP status when no code is reported', () => {
+		const info = describeGenerationError(
+			apiCallError({ statusCode: 401, responseBody: 'Unauthorized' }),
+		);
+
+		expect(info.code).toBeUndefined();
+		expect(info.status).toBe(401);
+		expect(info.message).toMatch(/signed in/i);
+		expect(info.retryable).toBe(false);
+
+		const serverError = describeGenerationError(
+			apiCallError({ statusCode: 503 }),
+		);
+		expect(serverError.message).toMatch(/temporarily unavailable/i);
+		expect(serverError.retryable).toBe(true);
+	});
+
+	it('gives timeouts and aborts their own copy', () => {
+		const timeout = new DOMException('signal timed out', 'TimeoutError');
+		expect(describeGenerationError(timeout).message).toMatch(
+			/took too long/i,
+		);
+
+		const abort = new DOMException('aborted', 'AbortError');
+		expect(describeGenerationError(abort).message).toMatch(/cancelled/i);
+	});
+
+	it('names a dead network rather than blaming the model', () => {
+		const info = describeGenerationError(new TypeError('Failed to fetch'));
+
+		expect(info.message).toMatch(/could not reach the server/i);
+		expect(info.retryable).toBe(true);
+	});
+
+	it('keeps the raw text as detail for anything it cannot classify', () => {
+		const info = describeGenerationError(new Error('something odd'));
+
+		expect(info.message).toMatch(/something went wrong/i);
+		expect(info.detail).toBe('something odd');
+		expect(info.retryable).toBe(true);
+	});
+
+	it('passes an already-described error straight through', () => {
+		const original = describeGenerationError(
+			new TypeError('Failed to fetch'),
+		);
+		expect(describeGenerationError(new GenerationError(original))).toEqual(
+			original,
+		);
+	});
+});

--- a/frontend/src/api/__tests__/generate.test.ts
+++ b/frontend/src/api/__tests__/generate.test.ts
@@ -1,0 +1,160 @@
+import type { LanguageModelV2StreamPart } from '@ai-sdk/provider';
+import { MockLanguageModelV2 } from 'ai/test';
+import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
+import { describe, expect, it, vi } from 'vitest';
+import { GenerationError } from '../errors';
+import { generateFullText, streamTextDeltas } from '../generate';
+
+/**
+ * The quota failure that motivated these helpers: OpenAI's Responses API sends
+ * an `error` SSE event mid-stream, and `@ai-sdk/openai` forwards the whole
+ * chunk as the error part's payload.
+ */
+const QUOTA_ERROR = {
+	type: 'error',
+	sequence_number: 2,
+	error: {
+		type: 'insufficient_quota',
+		code: 'insufficient_quota',
+		message:
+			'You exceeded your current quota, please check your plan and billing details.',
+	},
+};
+
+function modelStreaming(parts: LanguageModelV2StreamPart[]) {
+	return new MockLanguageModelV2({
+		doStream: () =>
+			Promise.resolve({ stream: convertArrayToReadableStream(parts) }),
+	});
+}
+
+function textParts(...deltas: string[]): LanguageModelV2StreamPart[] {
+	return [
+		{ type: 'stream-start', warnings: [] },
+		{ type: 'text-start', id: '1' },
+		...deltas.map((delta): LanguageModelV2StreamPart => ({
+			type: 'text-delta',
+			id: '1',
+			delta,
+		})),
+		{ type: 'text-end', id: '1' },
+	];
+}
+
+const FINISH: LanguageModelV2StreamPart = {
+	type: 'finish',
+	finishReason: 'stop',
+	usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+};
+
+async function collect(deltas: AsyncIterable<string>): Promise<string[]> {
+	const out: string[] = [];
+	for await (const delta of deltas) out.push(delta);
+	return out;
+}
+
+describe('streamTextDeltas', () => {
+	it('yields the text deltas of a successful generation', async () => {
+		const deltas = streamTextDeltas({
+			model: modelStreaming([...textParts('Hello', ', world'), FINISH]),
+			prompt: 'hi',
+		});
+
+		expect(await collect(deltas)).toEqual(['Hello', ', world']);
+	});
+
+	it('throws a GenerationError when the stream carries an error part', async () => {
+		// The SDK's default onError logs; keep the test output clean.
+		const consoleError = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+		const deltas = streamTextDeltas({
+			model: modelStreaming([
+				{ type: 'stream-start', warnings: [] },
+				{ type: 'error', error: QUOTA_ERROR },
+				FINISH,
+			]),
+			prompt: 'hi',
+		});
+
+		await expect(collect(deltas)).rejects.toThrow(GenerationError);
+		consoleError.mockRestore();
+	});
+
+	it('reports the quota failure in language the writer can act on', async () => {
+		const consoleError = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+		const deltas = streamTextDeltas({
+			model: modelStreaming([
+				{ type: 'stream-start', warnings: [] },
+				{ type: 'error', error: QUOTA_ERROR },
+				FINISH,
+			]),
+			prompt: 'hi',
+		});
+
+		const err = await collect(deltas).catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(GenerationError);
+		const { info } = err as GenerationError;
+		expect(info.code).toBe('insufficient_quota');
+		expect(info.message).toMatch(/out of credit/i);
+		expect(info.detail).toMatch(/exceeded your current quota/i);
+		expect(info.retryable).toBe(false);
+		consoleError.mockRestore();
+	});
+
+	it('keeps the text that arrived before a mid-stream failure', async () => {
+		const consoleError = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+		const deltas = streamTextDeltas({
+			model: modelStreaming([
+				...textParts('Partial answer'),
+				{ type: 'error', error: QUOTA_ERROR },
+				FINISH,
+			]),
+			prompt: 'hi',
+		});
+
+		const received: string[] = [];
+		await expect(
+			(async () => {
+				for await (const delta of deltas) received.push(delta);
+			})(),
+		).rejects.toThrow(GenerationError);
+		expect(received).toEqual(['Partial answer']);
+		consoleError.mockRestore();
+	});
+});
+
+describe('generateFullText', () => {
+	it('returns the whole generation', async () => {
+		const text = await generateFullText({
+			model: modelStreaming([...textParts('One', ' two'), FINISH]),
+			prompt: 'hi',
+		});
+
+		expect(text).toBe('One two');
+	});
+
+	it('throws instead of resolving to an empty string when generation fails', async () => {
+		const consoleError = vi
+			.spyOn(console, 'error')
+			.mockImplementation(() => {});
+
+		// This is the regression that made Draft say "No suggestions yet" on a
+		// quota error: `streamText(...).text` resolves to '' rather than throwing.
+		await expect(
+			generateFullText({
+				model: modelStreaming([
+					{ type: 'stream-start', warnings: [] },
+					{ type: 'error', error: QUOTA_ERROR },
+					FINISH,
+				]),
+				prompt: 'hi',
+			}),
+		).rejects.toThrow(GenerationError);
+		consoleError.mockRestore();
+	});
+});

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -1,0 +1,244 @@
+/**
+ * Turning a failed generation into something the writer can read and act on.
+ *
+ * Model failures reach us in several unrelated shapes, and none of them is
+ * presentable on its own:
+ *
+ * - A mid-stream provider error arrives as the raw SSE chunk the provider sent,
+ *   e.g. `{ type: 'error', sequence_number: 2, error: { type, code, message } }`
+ *   (see `@ai-sdk/openai`'s responses stream: it enqueues the whole chunk as the
+ *   `error` part's payload). It is a plain object, not an `Error`.
+ * - A non-2xx response from our proxy throws an `APICallError`, whose
+ *   `responseBody` is the provider's JSON error envelope as text.
+ * - Aborts and timeouts throw a `DOMException` named `AbortError`/`TimeoutError`.
+ * - A dead network throws `TypeError: Failed to fetch`.
+ *
+ * {@link describeGenerationError} normalizes all of them into one
+ * {@link GenerationErrorInfo}: a plain-language sentence for the writer, the raw
+ * provider text kept aside for a details disclosure and the event log, and
+ * whether retrying unchanged is worth offering.
+ */
+import { APICallError } from 'ai';
+
+export interface GenerationErrorInfo {
+	/** One plain-language sentence for the writer, naming a next step. */
+	message: string;
+	/** Raw provider/transport text, for the details disclosure and event logs. */
+	detail: string;
+	/** Provider error code when one was reported (e.g. `insufficient_quota`). */
+	code?: string;
+	/** HTTP status when the failure came back as an HTTP response. */
+	status?: number;
+	/** Whether re-running the same request has a reasonable chance of working. */
+	retryable: boolean;
+}
+
+/**
+ * An `Error` carrying a {@link GenerationErrorInfo}. Thrown by the helpers in
+ * `@/api/generate` so callers get a real `Error` (with a useful `message` and
+ * the original failure as `cause`) no matter what the provider threw at us.
+ */
+export class GenerationError extends Error {
+	readonly info: GenerationErrorInfo;
+	/** The original thrown value or streamed error part. Assigned rather than
+	 * passed to `super`: the build targets ES2020, which predates `cause`. */
+	readonly cause: unknown;
+
+	constructor(info: GenerationErrorInfo, cause?: unknown) {
+		super(info.message);
+		this.name = 'GenerationError';
+		this.info = info;
+		this.cause = cause;
+	}
+}
+
+const GENERIC_MESSAGE =
+	'Something went wrong while generating. Please try again.';
+
+/** Per-code copy. Codes come from the provider's error envelope. */
+const BY_CODE: Record<string, { message: string; retryable: boolean }> = {
+	insufficient_quota: {
+		message:
+			'The AI account behind this add-in is out of credit, so nothing can be generated right now. This is not something you can fix from here — please let the team know so billing can be topped up.',
+		retryable: false,
+	},
+	billing_hard_limit_reached: {
+		message:
+			'The AI account behind this add-in has hit its billing limit, so nothing can be generated right now. Please let the team know so billing can be raised.',
+		retryable: false,
+	},
+	rate_limit_exceeded: {
+		message:
+			'The AI service is busy and rate-limited this request. Wait a few seconds and try again.',
+		retryable: true,
+	},
+	invalid_api_key: {
+		message:
+			'The AI service rejected our credentials. Please let the team know — this needs fixing on the server.',
+		retryable: false,
+	},
+	context_length_exceeded: {
+		message:
+			'This document is too long to send in one request. Try selecting a smaller part of it and running again.',
+		retryable: false,
+	},
+	server_error: {
+		message:
+			'The AI service had an internal error. Please try again in a moment.',
+		retryable: true,
+	},
+};
+
+/** Fallback copy keyed by HTTP status when no code matched. */
+function byStatus(
+	status: number,
+): { message: string; retryable: boolean } | null {
+	if (status === 401)
+		return {
+			message:
+				'Your session is not signed in to the AI service. Try signing in again, then re-run this.',
+			retryable: false,
+		};
+	if (status === 403)
+		return {
+			message:
+				'This account is not allowed to use the AI service. Please let the team know.',
+			retryable: false,
+		};
+	if (status === 429) return BY_CODE.rate_limit_exceeded;
+	if (status >= 500)
+		return {
+			message:
+				'The AI service is temporarily unavailable. Please try again in a moment.',
+			retryable: true,
+		};
+	return null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+	return typeof value === 'object' && value !== null
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === 'string' && value !== '' ? value : undefined;
+}
+
+function parseJson(text: unknown): unknown {
+	if (typeof text !== 'string') return null;
+	try {
+		return JSON.parse(text);
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Dig a `{ code, message }` pair out of a provider error envelope. Providers
+ * nest the real error one or more levels deep (`{ error: { error: {...} } }`
+ * happens when a proxy re-wraps), so recurse and let the innermost values win.
+ */
+function findProviderError(
+	value: unknown,
+	depth = 0,
+): { code?: string; message?: string } {
+	const record = asRecord(value);
+	if (!record || depth > 4) return {};
+	const nested = findProviderError(record.error, depth + 1);
+	return {
+		code: nested.code ?? asString(record.code),
+		message: nested.message ?? asString(record.message),
+	};
+}
+
+/** First candidate that yielded a code or a message; `{}` if none did. */
+function firstProviderError(...candidates: unknown[]): {
+	code?: string;
+	message?: string;
+} {
+	for (const candidate of candidates) {
+		const found = findProviderError(candidate);
+		if (found.code !== undefined || found.message !== undefined)
+			return found;
+	}
+	return {};
+}
+
+/** True for aborts and timeouts, which need their own copy. */
+function abortKind(err: unknown): 'timeout' | 'abort' | null {
+	for (let cur: unknown = err, depth = 0; cur && depth < 4; depth++) {
+		const name = asRecord(cur)?.name;
+		if (name === 'TimeoutError') return 'timeout';
+		if (name === 'AbortError') return 'abort';
+		cur = asRecord(cur)?.cause;
+	}
+	return null;
+}
+
+/**
+ * Normalize any thrown value (or streamed error part) into presentable form.
+ * Never throws; unrecognized input degrades to a generic message plus whatever
+ * text we could salvage as `detail`.
+ */
+export function describeGenerationError(err: unknown): GenerationErrorInfo {
+	if (err instanceof GenerationError) return err.info;
+
+	const aborted = abortKind(err);
+	if (aborted !== null) {
+		return {
+			message:
+				aborted === 'timeout'
+					? 'That took too long and was stopped. Please try again.'
+					: 'That request was cancelled.',
+			detail: err instanceof Error ? err.message : String(err),
+			retryable: true,
+		};
+	}
+
+	// APICallError keeps the provider's JSON body as text; everything else we
+	// read straight off the value we were handed.
+	const isApiCallError = APICallError.isInstance(err);
+	const status = isApiCallError ? err.statusCode : undefined;
+	const provider = isApiCallError
+		? firstProviderError(parseJson(err.responseBody), err.data)
+		: firstProviderError(err);
+
+	const detail =
+		provider.message ??
+		(isApiCallError ? (err.responseBody ?? err.message) : undefined) ??
+		(err instanceof Error ? err.message : undefined) ??
+		(typeof err === 'string' ? err : JSON.stringify(err) || String(err));
+
+	const matched =
+		(provider.code !== undefined ? BY_CODE[provider.code] : undefined) ??
+		(status !== undefined ? byStatus(status) : null);
+
+	if (matched) {
+		return {
+			message: matched.message,
+			detail,
+			code: provider.code,
+			status,
+			retryable: matched.retryable,
+		};
+	}
+
+	// A failed `fetch` throws a bare TypeError with no status and no body.
+	if (err instanceof TypeError) {
+		return {
+			message:
+				'Could not reach the server. Check your connection and try again.',
+			detail,
+			retryable: true,
+		};
+	}
+
+	return {
+		message: GENERIC_MESSAGE,
+		detail,
+		code: provider.code,
+		status,
+		retryable: true,
+	};
+}

--- a/frontend/src/api/generate.ts
+++ b/frontend/src/api/generate.ts
@@ -1,0 +1,68 @@
+/**
+ * The generation calls every page goes through.
+ *
+ * These exist because `streamText` from the AI SDK does not fail loudly. It
+ * routes model and transport errors into the stream as an `error` part rather
+ * than throwing, and `result.textStream` only forwards `text-delta` parts — so
+ * an errored generation looks exactly like an empty successful one: the
+ * `for await` loop ends normally, `await result.text` resolves to `''`, and any
+ * surrounding `try/catch` never runs. That is how a quota failure reached the
+ * writer as a blank panel.
+ *
+ * {@link streamTextDeltas} reads `fullStream` instead, so it sees the `error`
+ * part and throws a {@link GenerationError} the moment one arrives. Pages should
+ * use these helpers rather than calling `streamText` directly; a page that calls
+ * `streamText` itself silently reintroduces the blank-panel bug.
+ */
+import { streamText } from 'ai';
+import { describeGenerationError, GenerationError } from './errors';
+
+type StreamTextOptions = Parameters<typeof streamText>[0];
+
+/** Wrap whatever the stream (or the transport) failed with. */
+function asGenerationError(raw: unknown): GenerationError {
+	return raw instanceof GenerationError
+		? raw
+		: new GenerationError(describeGenerationError(raw), raw);
+}
+
+/**
+ * Stream a generation, yielding text deltas as they arrive.
+ *
+ * Throws a {@link GenerationError} as soon as the model or transport fails —
+ * including mid-stream, after deltas have already been yielded, so a caller that
+ * renders partial text keeps what arrived and can show the error alongside it.
+ * Aborting via `abortSignal` ends the iteration; callers that abort on purpose
+ * should check their own signal before treating a throw as a real failure.
+ */
+export async function* streamTextDeltas(
+	options: StreamTextOptions,
+): AsyncGenerator<string, void, void> {
+	const result = streamText(options);
+	// `fullStream`, not `textStream`: the latter drops `error` parts on the floor.
+	// (Still true in ai@7, which only renames `fullStream` to `stream` and keeps
+	// the old name as a deprecated alias — switch this line when we upgrade.)
+	for await (const part of result.fullStream) {
+		if (part.type === 'text-delta') {
+			yield part.text;
+		} else if (part.type === 'error') {
+			// Breaking out of the loop cancels the underlying stream.
+			throw asGenerationError(part.error);
+		}
+	}
+}
+
+/**
+ * Run a generation to completion and return the whole text. Same error
+ * behaviour as {@link streamTextDeltas} — a failed generation throws instead of
+ * resolving to an empty string.
+ */
+export async function generateFullText(
+	options: StreamTextOptions,
+): Promise<string> {
+	let text = '';
+	for await (const delta of streamTextDeltas(options)) {
+		text += delta;
+	}
+	return text;
+}

--- a/frontend/src/api/logging.ts
+++ b/frontend/src/api/logging.ts
@@ -37,8 +37,11 @@ import type { LogFn } from '@/hooks/useLog';
  * History:
  *   1 — Initial page-scoped schema (Draft / Revise / Chat).
  *   2 — Added the Tools page (external tool launcher) and its events.
+ *   3 — Error events carry an optional `code` (the provider's error code, e.g.
+ *       `insufficient_quota`), and their `error` field now holds the provider's
+ *       message rather than the sentence shown to the user.
  */
-export const LOG_SCHEMA_VERSION = 2;
+export const LOG_SCHEMA_VERSION = 3;
 
 /** Pages that emit events. Matches the user-facing tabs. */
 export type LogPage = 'draft' | 'revise' | 'chat' | 'tools';
@@ -100,7 +103,12 @@ export const draftLog = {
 	/** A suggestion request failed (timeout or model error). */
 	generationError(
 		log: LogFn,
-		data: { generationType: string; docContext: DocContext; error: string },
+		data: {
+			generationType: string;
+			docContext: DocContext;
+			error: string;
+			code?: string;
+		},
 	) {
 		return emit(log, 'draft', 'generation_error', data);
 	},
@@ -141,7 +149,10 @@ export const reviseLog = {
 		return emit(log, 'revise', 'visualization_completed', data);
 	},
 	/** A visualization request failed (and was not merely cancelled). */
-	visualizationError(log: LogFn, data: { feature: string; error: string }) {
+	visualizationError(
+		log: LogFn,
+		data: { feature: string; error: string; code?: string },
+	) {
 		return emit(log, 'revise', 'visualization_error', data);
 	},
 	/** The writer clicked a document reference (doctext link) in a result. */
@@ -166,7 +177,7 @@ export const chatLog = {
 		return emit(log, 'chat', 'response_completed', data);
 	},
 	/** The assistant response failed to stream (and was not cancelled). */
-	responseError(log: LogFn, data: { error: string }) {
+	responseError(log: LogFn, data: { error: string; code?: string }) {
 		return emit(log, 'chat', 'response_error', data);
 	},
 };

--- a/frontend/src/components/__tests__/ErrorNotice.test.tsx
+++ b/frontend/src/components/__tests__/ErrorNotice.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { GenerationErrorInfo } from '@/api/errors';
+import { ErrorNotice, GenerationErrorNotice } from '../errorNotice';
+
+const quotaFailure: GenerationErrorInfo = {
+	message: 'The AI account behind this add-in is out of credit.',
+	detail: 'You exceeded your current quota.',
+	code: 'insufficient_quota',
+	retryable: false,
+};
+
+describe('ErrorNotice', () => {
+	it('announces the failure and shows the writer-facing message', () => {
+		const html = renderToStaticMarkup(
+			<ErrorNotice message="Something specific went wrong." />,
+		);
+
+		expect(html).toContain('role="alert"');
+		expect(html).toContain('Something specific went wrong.');
+	});
+
+	it('keeps the raw provider text collapsed behind a toggle', () => {
+		const html = renderToStaticMarkup(
+			<ErrorNotice message="Failed." detail="insufficient_quota" />,
+		);
+
+		expect(html).toContain('Technical details');
+		expect(html).not.toContain('>insufficient_quota<');
+	});
+
+	it('omits Retry when there is nothing to retry with', () => {
+		const html = renderToStaticMarkup(<ErrorNotice message="Failed." />);
+
+		expect(html).not.toContain('Try again');
+	});
+
+	it('uses a non-alerting role for informational notices', () => {
+		const html = renderToStaticMarkup(
+			<ErrorNotice tone="info" message="Nothing came back." />,
+		);
+
+		expect(html).toContain('role="status"');
+	});
+});
+
+describe('GenerationErrorNotice', () => {
+	it('does not offer Retry for a failure retrying cannot clear', () => {
+		const html = renderToStaticMarkup(
+			<GenerationErrorNotice info={quotaFailure} onRetry={vi.fn()} />,
+		);
+
+		expect(html).toContain('out of credit');
+		expect(html).not.toContain('Try again');
+	});
+
+	it('offers Retry for a transient failure', () => {
+		const html = renderToStaticMarkup(
+			<GenerationErrorNotice
+				info={{ ...quotaFailure, retryable: true }}
+				onRetry={vi.fn()}
+			/>,
+		);
+
+		expect(html).toContain('Try again');
+	});
+});

--- a/frontend/src/components/errorNotice/index.tsx
+++ b/frontend/src/components/errorNotice/index.tsx
@@ -1,0 +1,106 @@
+/**
+ * The one way a page tells the writer that something did not work.
+ *
+ * Every failure the writer can see should go through this component, so a
+ * failed generation never looks like an empty result. It shows the
+ * plain-language sentence from {@link GenerationErrorInfo}, keeps the raw
+ * provider text behind a collapsed disclosure (so a bug report can carry the
+ * real error without putting `insufficient_quota` in the writer's face), and
+ * offers Retry only when retrying could plausibly work.
+ */
+import { useState } from 'react';
+import {
+	AiOutlineExclamationCircle,
+	AiOutlineInfoCircle,
+} from 'react-icons/ai';
+import type { GenerationErrorInfo } from '@/api/errors';
+import classes from './styles.module.css';
+
+interface ErrorNoticeProps {
+	/** `error` for a failure, `info` for a benign non-result (e.g. empty output). */
+	tone?: 'error' | 'info';
+	/** Overrides the default heading ("Something went wrong" / "No results"). */
+	title?: string;
+	message: string;
+	/** Raw provider/transport text, shown under "Technical details". */
+	detail?: string;
+	/** Rendered as a Retry button when provided. */
+	onRetry?: () => void;
+}
+
+export function ErrorNotice({
+	tone = 'error',
+	title,
+	message,
+	detail,
+	onRetry,
+}: ErrorNoticeProps) {
+	const [showDetail, setShowDetail] = useState(false);
+	const Icon =
+		tone === 'error' ? AiOutlineExclamationCircle : AiOutlineInfoCircle;
+	const heading =
+		title ?? (tone === 'error' ? 'Something went wrong' : 'No results');
+	// Assertive for errors: the writer is waiting on a result that is not coming.
+	const role = tone === 'error' ? 'alert' : 'status';
+
+	return (
+		<div className={`${classes.notice} ${classes[tone]}`} role={role}>
+			<div className={classes.head}>
+				<Icon className={classes.icon} aria-hidden="true" />
+				<div className={classes.title}>{heading}</div>
+			</div>
+			<div className={classes.message}>{message}</div>
+			{detail || onRetry ? (
+				<div className={classes.actions}>
+					{onRetry ? (
+						<button
+							type="button"
+							className={classes.retry}
+							onClick={onRetry}
+						>
+							Try again
+						</button>
+					) : null}
+					{detail ? (
+						<button
+							type="button"
+							className={classes.detailToggle}
+							aria-expanded={showDetail}
+							onClick={() => setShowDetail((shown) => !shown)}
+						>
+							{showDetail ? 'Hide details' : 'Technical details'}
+						</button>
+					) : null}
+				</div>
+			) : null}
+			{detail && showDetail ? (
+				<pre className={classes.detail}>{detail}</pre>
+			) : null}
+		</div>
+	);
+}
+
+/**
+ * Convenience wrapper for the common case: a {@link GenerationErrorInfo} from
+ * `describeGenerationError`. Retry is offered only when the failure is one that
+ * retrying can clear — an out-of-credit account is not.
+ */
+export function GenerationErrorNotice({
+	info,
+	title,
+	onRetry,
+}: {
+	info: GenerationErrorInfo;
+	title?: string;
+	onRetry?: () => void;
+}) {
+	return (
+		<ErrorNotice
+			tone="error"
+			title={title}
+			message={info.message}
+			detail={info.detail}
+			onRetry={info.retryable ? onRetry : undefined}
+		/>
+	);
+}

--- a/frontend/src/components/errorNotice/styles.module.css
+++ b/frontend/src/components/errorNotice/styles.module.css
@@ -1,0 +1,105 @@
+/* Token fallbacks: not every page defines the design tokens. */
+.notice {
+	width: 100%;
+	border: 1px solid;
+	border-radius: var(--radius, 10px);
+	padding: 10px 12px;
+	margin-bottom: 8px;
+	font-size: 13px;
+	line-height: 1.5;
+	text-align: left;
+	animation: noticeIn 0.2s ease both;
+}
+
+.error {
+	background: #fdf3f2;
+	border-color: #f0cfcb;
+	color: #7a2e26;
+}
+
+.info {
+	background: var(--surface-2, #f0eee9);
+	border-color: var(--border, rgba(0, 0, 0, 0.08));
+	color: var(--text-secondary, #6b6860);
+}
+
+.head {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	margin-bottom: 4px;
+}
+
+.icon {
+	flex-shrink: 0;
+	font-size: 15px;
+}
+
+.title {
+	font-weight: 600;
+	font-size: 13px;
+}
+
+.message {
+	color: inherit;
+	opacity: 0.95;
+}
+
+.actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 8px;
+	margin-top: 8px;
+}
+
+.retry,
+.detailToggle {
+	background: transparent;
+	border: 1px solid currentColor;
+	border-radius: var(--radius-sm, 6px);
+	color: inherit;
+	cursor: pointer;
+	font: inherit;
+	font-size: 12px;
+	padding: 3px 9px;
+}
+
+.detailToggle {
+	border-color: transparent;
+	text-decoration: underline;
+	padding-left: 0;
+	padding-right: 0;
+	opacity: 0.8;
+}
+
+.retry:hover,
+.detailToggle:hover {
+	opacity: 1;
+	background: rgba(0, 0, 0, 0.04);
+}
+
+.detail {
+	margin: 8px 0 0;
+	padding: 8px;
+	background: rgba(0, 0, 0, 0.04);
+	border-radius: var(--radius-sm, 6px);
+	font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+	font-size: 11px;
+	line-height: 1.45;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	max-height: 160px;
+	overflow-y: auto;
+}
+
+@keyframes noticeIn {
+	from {
+		opacity: 0;
+		transform: translateY(-2px);
+	}
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}

--- a/frontend/src/pages/chat/index.tsx
+++ b/frontend/src/pages/chat/index.tsx
@@ -1,4 +1,4 @@
-import { streamText, type ModelMessage } from 'ai';
+import { type ModelMessage } from 'ai';
 import {
 	useCallback,
 	useContext,
@@ -10,8 +10,14 @@ import {
 import { AiOutlineArrowDown, AiOutlineSend } from 'react-icons/ai';
 import { Remark } from 'react-remark';
 
+import {
+	describeGenerationError,
+	type GenerationErrorInfo,
+} from '@/api/errors';
+import { streamTextDeltas } from '@/api/generate';
 import { chatLog } from '@/api/logging';
 import { languageModel, openaiProviderOptions } from '@/api/openai';
+import { GenerationErrorNotice } from '@/components/errorNotice';
 import { ChatContext } from '@/contexts/chatContext';
 import { EditorContext } from '@/contexts/editorContext';
 import { useLog } from '@/hooks/useLog';
@@ -73,6 +79,16 @@ export default function Chat() {
 	const messagesContainerRef = useRef<HTMLDivElement>(null);
 	const textareaRef = useRef<HTMLTextAreaElement>(null);
 	const [showScrollButton, setShowScrollButton] = useState(false);
+	const [errorInfo, setErrorInfo] = useState<GenerationErrorInfo | null>(null);
+	/**
+	 * The message of a failed turn that was rolled back out of the transcript.
+	 * Only such a turn can be retried — retrying one still in the transcript
+	 * would send it twice.
+	 */
+	const [failedMessage, setFailedMessage] = useState<{
+		text: string;
+		source: 'input' | 'suggested';
+	} | null>(null);
 
 	// Show the "scroll to bottom" button when the user scrolls up, and hide it when they are near the bottom.
 	const handleScroll = useCallback(() => {
@@ -153,6 +169,8 @@ export default function Chat() {
 
 		chatLog.messageSent(log, { message: text, source });
 		updateSendingMessage(true);
+		setErrorInfo(null);
+		setFailedMessage(null);
 
 		// Pull the current document context at send time so the model sees the
 		// document as it is now, then inject it as the doc-context message.
@@ -168,7 +186,7 @@ export default function Chat() {
 		updateMessage('');
 
 		try {
-			const result = streamText({
+			const deltas = streamTextDeltas({
 				model: languageModel,
 				providerOptions: openaiProviderOptions,
 				messages: newMessages.slice(0, -1) as ModelMessage[],
@@ -176,7 +194,7 @@ export default function Chat() {
 				abortSignal: requestController.signal,
 			});
 
-			for await (const delta of result.textStream) {
+			for await (const delta of deltas) {
 				// Need to make a new object to force React to update.
 				newMessages = newMessages.slice();
 				newMessages[newMessages.length - 1].content += delta;
@@ -189,9 +207,21 @@ export default function Chat() {
 			if (requestController.signal.aborted) {
 				return;
 			}
+			const info = describeGenerationError(error);
 			console.error('Error while streaming chat response:', error);
+			// Nothing streamed: roll the turn back (empty assistant bubble + the
+			// user message it was answering) and hand the text back to the input
+			// box, so Retry re-sends it once rather than duplicating the turn.
+			// If part of a reply did arrive, keep it and just show the error under it.
+			if (newMessages[newMessages.length - 1].content === '') {
+				updateChatMessages(newMessages.slice(0, -2));
+				updateMessage(text);
+				setFailedMessage({ text, source });
+			}
+			setErrorInfo(info);
 			chatLog.responseError(log, {
-				error: error instanceof Error ? error.message : String(error),
+				error: info.detail,
+				code: info.code,
 			});
 		} finally {
 			// Ignore stale completions from older requests that were already replaced.
@@ -281,6 +311,19 @@ export default function Chat() {
 							);
 						})
 					)}
+
+					{errorInfo ? (
+						<GenerationErrorNotice
+							info={errorInfo}
+							title="Couldn't get a reply"
+							onRetry={
+								failedMessage
+									? () =>
+											void submitMessage(failedMessage.text, failedMessage.source)
+									: undefined
+							}
+						/>
+					) : null}
 				</div>
 
 				{showScrollButton ? (

--- a/frontend/src/pages/draft/index.tsx
+++ b/frontend/src/pages/draft/index.tsx
@@ -2,12 +2,18 @@
  * @format
  */
 
-import { streamText, type ModelMessage } from 'ai';
+import { type ModelMessage } from 'ai';
 import { useCallback, useContext, useRef, useState } from 'react';
 import { Remark } from 'react-remark';
+import {
+	describeGenerationError,
+	type GenerationErrorInfo,
+} from '@/api/errors';
+import { generateFullText } from '@/api/generate';
 import { draftLog } from '@/api/logging';
 import { languageModel, openaiProviderOptions } from '@/api/openai';
 import { buildMessages } from '@/api/prompts';
+import { ErrorNotice, GenerationErrorNotice } from '@/components/errorNotice';
 import { EditorContext } from '@/contexts/editorContext';
 import { useLog } from '@/hooks/useLog';
 import { useDocContext } from '@/utilities';
@@ -66,23 +72,18 @@ class Fetcher {
 				request.docContext,
 			) as ModelMessage[];
 
-			const stream = streamText({
+			// generateFullText, not `streamText(...).text`: the latter resolves to
+			// an empty string when the generation failed, which is how a quota
+			// error used to surface as "No suggestions yet".
+			const result = await generateFullText({
 				model: languageModel,
 				providerOptions: openaiProviderOptions,
 				messages,
 				abortSignal: AbortSignal.timeout(20000),
 			});
 
-			const result = await stream.text;
-
 			this.previousRequest = request;
 			return { generation_type: request.type, result, extra_data: {} };
-		} catch (err: any) {
-			let errMsg = '';
-			if (err.name === 'AbortError')
-				errMsg = `Generating a suggestion took too long, please try again.`;
-			else errMsg = `${err.name}: ${err.message}. Please try again.`;
-			throw new Error(errMsg);
 		} finally {
 			this.requestInFlight = null;
 		}
@@ -192,9 +193,15 @@ export default function Draft() {
 	const log = useLog();
 	const [isLoading, setIsLoading] = useState(false);
 	const [savedItems, updateSavedItems] = useState<SavedItem[]>([]);
-	const [errorMsg, updateErrorMsg] = useState('');
+	const [errorInfo, updateErrorInfo] = useState<GenerationErrorInfo | null>(
+		null,
+	);
+	/** Set when a request succeeded but the model had nothing to say. */
+	const [emptyResult, setEmptyResult] = useState(false);
 	const [activeMode, setActiveMode] = useState<string | null>(null);
 	const fetcherRef = useRef<Fetcher | null>(null);
+	/** The last request, so the notice's Retry button can re-run it. */
+	const lastRequestRef = useRef<SuggestionRequest | null>(null);
 
 	const getFetcher = useCallback((): Fetcher => {
 		if (!fetcherRef.current) {
@@ -261,7 +268,9 @@ export default function Draft() {
 			suggestionRequest: SuggestionRequest,
 			isUserInitiated = true,
 		) {
-			updateErrorMsg('');
+			updateErrorInfo(null);
+			setEmptyResult(false);
+			lastRequestRef.current = suggestionRequest;
 			if (isUserInitiated) {
 				setIsLoading(true);
 			}
@@ -289,7 +298,9 @@ export default function Draft() {
 				// so we don't show a useless "[]" bullet to the user.
 				const isEmpty = suggestion.result.trim() === '' || suggestion.result.trim() === '[]';
 				if (isEmpty) {
+					// Nothing to show, but say so — silence reads as a broken button.
 					console.warn('Received empty suggestion.');
+					setEmptyResult(true);
 					draftLog.suggestionEmpty(log, {
 						generationType: suggestionRequest.type,
 						docContext: suggestionRequest.docContext,
@@ -297,22 +308,27 @@ export default function Draft() {
 				} else {
 					save(suggestion, suggestionRequest.docContext);
 				}
-			} catch (err: any) {
-				const errMsg: string =
-					err.message ||
-					'An error occurred while generating the suggestion.';
+			} catch (err) {
+				const info = describeGenerationError(err);
+				console.error('Error fetching suggestion:', err);
 				draftLog.generationError(log, {
 					generationType: suggestionRequest.type,
 					docContext: suggestionRequest.docContext,
-					error: errMsg,
+					error: info.detail,
+					code: info.code,
 				});
-				updateErrorMsg(errMsg);
+				updateErrorInfo(info);
 			}
 
 			setIsLoading(false);
 		},
 		[getFetcher, save, log],
 	);
+
+	const retryLastRequest = useCallback(() => {
+		const request = lastRequestRef.current;
+		if (request) void getSuggestion(request, true);
+	}, [getSuggestion]);
 
 	const autoRefreshCallback = useCallback(async () => {
 		if (!shouldAutoRefresh) {
@@ -408,12 +424,21 @@ export default function Draft() {
 						</div>
 						{/* Results Area */}
 						<div className={`${classes.resultsArea} ${savedItems.length > 0 ? classes.hasContent : ''}`}>
-							{errorMsg ? (
-								<div className={classes.errorMessage}>
-									{errorMsg}
-								</div>
+							{errorInfo ? (
+								<GenerationErrorNotice
+									info={errorInfo}
+									onRetry={retryLastRequest}
+								/>
 							) : null}
-							{!errorMsg && savedItems.length === 0 && !isLoading ? (
+							{emptyResult && !errorInfo ? (
+								<ErrorNotice
+									tone="info"
+									title="Nothing to suggest"
+									message="The assistant had nothing to add for this text. Try again, select a different part of your document, or pick another option above."
+									onRetry={retryLastRequest}
+								/>
+							) : null}
+							{!errorInfo && !emptyResult && savedItems.length === 0 && !isLoading ? (
 								<div className={classes.emptyStateContainer}>
 									<div className={classes.emptyTitle}>No suggestions yet</div>
 									<div className={classes.emptyHint}>

--- a/frontend/src/pages/draft/styles.module.css
+++ b/frontend/src/pages/draft/styles.module.css
@@ -436,12 +436,6 @@
 }
 
 /* Results States */
-.errorMessage {
-	color: var(--text-tertiary);
-	font-size: 13px;
-	margin-bottom: 8px;
-}
-
 .emptyStateContainer {
 	text-align: center;
 }

--- a/frontend/src/pages/revise/index.tsx
+++ b/frontend/src/pages/revise/index.tsx
@@ -2,7 +2,7 @@
  * @format
  */
 
-import { streamText, type ModelMessage } from 'ai';
+import { type ModelMessage } from 'ai';
 import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { Remark } from 'react-remark';
 import {
@@ -21,8 +21,14 @@ import {
 	AiOutlineQuestionCircle
 } from 'react-icons/ai';
 import { isRunningInGoogleDocs } from '@/api';
+import {
+	describeGenerationError,
+	type GenerationErrorInfo,
+} from '@/api/errors';
+import { streamTextDeltas } from '@/api/generate';
 import { reviseLog } from '@/api/logging';
 import { languageModel, openaiProviderOptions } from '@/api/openai';
+import { GenerationErrorNotice, ErrorNotice } from '@/components/errorNotice';
 import { EditorContext } from '@/contexts/editorContext';
 import { useLog } from '@/hooks/useLog';
 import { useDocContext } from '@/utilities';
@@ -172,17 +178,28 @@ class Visualization {
 	response: string;
 	id: string;
 	references: string[] = [];
+	/** Set when the generation failed; rendered in place of a result. */
+	error: GenerationErrorInfo | null = null;
+	/** False until the stream ends, so the panel can show per-feature progress. */
+	done = false;
 
 	constructor(
 		public prompt: string,
 		public docContext: DocContext,
+		/** The feature this came from — for the result's label and its Retry. */
+		public feature: Prompt,
 	) {
 		this.prompt = prompt;
 		this.docContext = docContext;
 		this.response = '';
-		this.id = Date.now().toString();
+		// Counter, not a timestamp: features run back-to-back and two created in
+		// the same millisecond would collide as React keys (an immediate failure
+		// takes almost no time at all).
+		this.id = `viz-${++visualizationCounter}`;
 	}
 }
+
+let visualizationCounter = 0;
 
 const makeAnchorWithCallback = (
 	clickCallbackRef: React.MutableRefObject<(href: string) => void>,
@@ -280,7 +297,7 @@ export default function Revise() {
 			// tracking it continuously.
 			const currentContext = await refreshDocContext();
 
-			const newViz = new Visualization(request, currentContext);
+			const newViz = new Visualization(request, currentContext, prompt);
 			setVisualizations((prev) => [...prev, newViz]);
 
 			reviseLog.visualizationRequested(log, {
@@ -304,8 +321,20 @@ ${request}
 
 			setLoading(true);
 
+			// Re-publish the (mutated) visualization so React re-renders it.
+			const publish = () => {
+				setVisualizations((prev) => {
+					const updated = [...prev];
+					const index = updated.findIndex((v) => v.id === newViz.id);
+					if (index !== -1) {
+						updated[index] = newViz;
+					}
+					return updated;
+				});
+			};
+
 			try {
-				const result = streamText({
+				const deltas = streamTextDeltas({
 					model: languageModel,
 					providerOptions: openaiProviderOptions,
 					system: systemPrompt,
@@ -314,19 +343,13 @@ ${request}
 					abortSignal: requestController.signal,
 				});
 
-				for await (const delta of result.textStream) {
+				for await (const delta of deltas) {
 					newViz.response += delta;
-					setVisualizations((prev) => {
-						const updated = [...prev];
-						const index = updated.findIndex((v) => v.id === newViz.id);
-						if (index !== -1) {
-							updated[index] = newViz;
-						}
-						return updated;
-					});
+					publish();
 				}
 
-				console.log('Visualization response complete:', newViz.response);
+				newViz.done = true;
+				publish();
 				reviseLog.visualizationCompleted(log, {
 					feature: prompt.keyword,
 					response: newViz.response,
@@ -335,10 +358,17 @@ ${request}
 				if (requestController.signal.aborted) {
 					return;
 				}
+				const info = describeGenerationError(err);
 				console.error('Error fetching visualization:', err);
+				// Show the failure on the feature that failed, keeping whatever text
+				// had already streamed in.
+				newViz.error = info;
+				newViz.done = true;
+				publish();
 				reviseLog.visualizationError(log, {
 					feature: prompt.keyword,
-					error: err instanceof Error ? err.message : String(err),
+					error: info.detail,
+					code: info.code,
 				});
 			} finally {
 				// Ignore stale completions from older requests that were already replaced.
@@ -349,6 +379,15 @@ ${request}
 			}
 		},
 		[refreshDocContext, log],
+	);
+
+	/** Re-run one feature, dropping the card that failed so it isn't duplicated. */
+	const retryVisualization = useCallback(
+		(viz: Visualization) => {
+			setVisualizations((prev) => prev.filter((v) => v.id !== viz.id));
+			void requestVisualization(viz.feature);
+		},
+		[requestVisualization],
 	);
 
 	const toggleFeature = useCallback(
@@ -532,30 +571,53 @@ ${request}
 								</div>
 								Running {selectedFeatures.length} feature{selectedFeatures.length > 1 ? 's' : ''}...
 							</div> : null}
-						{visualizations.map((viz, index) => (
-							<div key={viz.id}>
-								{index > 0 && <div style={{ borderTop: '1.5px solid var(--border)' }}></div>}
-								<div className={classes.resultHeader}>
-									<span className={classes.resultTag}>
-										{promptList.find(p => p.prompt === viz.prompt)?.keyword || 'Feature'}
-									</span>
-									<span className={classes.resultMeta}>
-										{viz.response.split('\n').length} result{viz.response.split('\n').length > 1 ? 's' : ''}
-									</span>
+						{visualizations.map((viz, index) => {
+							const lineCount = viz.response.split('\n').length;
+							return (
+								<div key={viz.id}>
+									{index > 0 && <div style={{ borderTop: '1.5px solid var(--border)' }}></div>}
+									<div className={classes.resultHeader}>
+										<span className={classes.resultTag}>
+											{viz.feature.keyword}
+										</span>
+										<span className={classes.resultMeta}>
+											{viz.error
+												? 'Failed'
+												: `${lineCount} result${lineCount > 1 ? 's' : ''}`}
+										</span>
+									</div>
+									<div className={classes.resultItem} style={{ animationDelay: `${index * 0.04}s` }}>
+										{viz.response ? (
+											<Remark
+												rehypeReactOptions={{
+													components: {
+														a: AnchorWithCallback,
+													},
+												}}
+											>
+												{viz.response}
+											</Remark>
+										) : null}
+										{viz.error ? (
+											<GenerationErrorNotice
+												info={viz.error}
+												title={`${viz.feature.keyword} failed`}
+												onRetry={() => retryVisualization(viz)}
+											/>
+										) : null}
+										{/* A finished-but-empty run is a real outcome, not a blank card. */}
+										{!viz.error && viz.done && viz.response.trim() === '' ? (
+											<ErrorNotice
+												tone="info"
+												title="Nothing came back"
+												message="The model returned an empty response for this feature. Running it again often helps."
+												onRetry={() => retryVisualization(viz)}
+											/>
+										) : null}
+									</div>
 								</div>
-								<div className={classes.resultItem} style={{ animationDelay: `${index * 0.04}s` }}>
-									<Remark
-										rehypeReactOptions={{
-											components: {
-												a: AnchorWithCallback,
-											},
-										}}
-									>
-										{viz.response}
-									</Remark>
-								</div>
-							</div>
-						))}
+							);
+						})}
 					</div>
 				</div>
 			</div>

--- a/frontend/tests/error-visibility.spec.ts
+++ b/frontend/tests/error-visibility.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import {
+  QUOTA_ERROR_MESSAGE,
+  fulfillOpenAIStreamError,
+  setupMockBackend,
+} from './mockBackend';
+
+/**
+ * A failed generation must never look like an empty result.
+ *
+ * Each test drives one page with the model failing the way it does in
+ * production — HTTP 200, then an `error` event mid-SSE-stream — and asserts the
+ * writer is told, rather than left with a blank panel, a stuck spinner, or
+ * "No suggestions yet".
+ */
+test.beforeEach(async ({ page }) => {
+  await setupMockBackend(page);
+  // Override the success route registered above: later routes win in Playwright.
+  await page.route('**/openai/responses', fulfillOpenAIStreamError);
+  await page.goto('/editor.html?page=demo');
+  await expect(page.locator('button[aria-label="Examples"]')).toBeVisible({
+    timeout: 15000,
+  });
+});
+
+test('Draft: a quota failure is reported instead of "No suggestions yet"', async ({
+  page,
+}) => {
+  await page.locator('button[aria-label="Examples"]').click();
+
+  const notice = page.getByRole('alert');
+  await expect(notice).toBeVisible({ timeout: 10000 });
+  await expect(notice).toContainText(/out of credit/i);
+  await expect(page.getByText('No suggestions yet')).toBeHidden();
+
+  // The provider's own words stay available for a bug report, but only on request.
+  await expect(page.getByText(QUOTA_ERROR_MESSAGE)).toBeHidden();
+  await notice.getByRole('button', { name: 'Technical details' }).click();
+  await expect(page.getByText(QUOTA_ERROR_MESSAGE)).toBeVisible();
+});
+
+test('Revise: the failing feature says so', async ({ page }) => {
+  const editor = page.locator('[contenteditable="true"]');
+  await editor.click();
+  await editor.pressSequentially('Some text to analyze');
+
+  await page.locator('button', { hasText: 'Revise' }).click();
+  await page.locator('button', { hasText: 'Hierarchical Outline' }).click();
+  await page.locator('button', { hasText: /^Run / }).click();
+
+  const notice = page.getByRole('alert');
+  await expect(notice).toBeVisible({ timeout: 10000 });
+  await expect(notice).toContainText('Hierarchical Outline failed');
+  await expect(notice).toContainText(/out of credit/i);
+});
+
+test('Chat: a failed reply is reported and the message is handed back', async ({
+  page,
+}) => {
+  await page.locator('button', { hasText: 'Chat' }).click();
+
+  const input = page.locator('textarea[placeholder*="Ask"]');
+  await input.fill('Is the tone consistent?');
+  await page.locator('button[title="Send message"]').click();
+
+  const notice = page.getByRole('alert');
+  await expect(notice).toBeVisible({ timeout: 10000 });
+  await expect(notice).toContainText(/out of credit/i);
+  // The turn was rolled back, so the message is back in the box, not stranded
+  // above an empty assistant bubble.
+  await expect(input).toHaveValue('Is the tone consistent?');
+});

--- a/frontend/tests/mockBackend.ts
+++ b/frontend/tests/mockBackend.ts
@@ -103,6 +103,38 @@ export async function fulfillOpenAI(route: Route, result: string) {
   });
 }
 
+/**
+ * The failure mode that motivated the error-visibility work: OpenAI answers 200
+ * and then reports the failure as an `error` event inside the SSE stream. The
+ * AI SDK forwards it as an error part rather than throwing, so a page that
+ * ignores those parts renders nothing at all.
+ */
+export const QUOTA_ERROR_MESSAGE =
+  'You exceeded your current quota, please check your plan and billing details.';
+
+export async function fulfillOpenAIStreamError(route: Route) {
+  const event = (payload: object) => `data: ${JSON.stringify(payload)}\n\n`;
+  await route.fulfill({
+    status: 200,
+    headers: { 'content-type': 'text/event-stream; charset=utf-8' },
+    body:
+      event({
+        type: 'response.created',
+        response: { id: 'resp-mock', created_at: 0, model: 'gpt-5.6-terra' },
+      }) +
+      event({
+        type: 'error',
+        sequence_number: 2,
+        error: {
+          type: 'insufficient_quota',
+          code: 'insufficient_quota',
+          message: QUOTA_ERROR_MESSAGE,
+        },
+      }) +
+      'data: [DONE]\n\n',
+  });
+}
+
 export async function setupMockBackend(page: Page) {
   // Demo pages mint an anonymous Better Auth session on load (src/api/anonymousAuth.ts).
   // The Playwright "backend" is just http-server over dist/, which 405s a POST, so the


### PR DESCRIPTION
## The bug

A Revise run against an out-of-credit OpenAI account rendered a blank panel. The console had the error, the UI had nothing:

```
Object { type: "error", sequence_number: 2, error: {…} }
  error: { type: "insufficient_quota", code: "insufficient_quota", message: "You exceeded your current quota…" }
Visualization response complete: <empty string>
```

Note the last line: the `for await` loop **completed**. Draft did the same thing from the other direction — spinner, then "No suggestions yet".

## Why

`streamText` (ai@5) does not throw on model or transport errors. It routes them into the stream as an `error` part, and `result.textStream` forwards only `text-delta` parts ([`ai/dist/index.js:5504`](https://github.com/vercel/ai) — the transform enqueues nothing else). So a failed generation is indistinguishable from an empty successful one:

- the `for await` loop ends normally (Revise, Chat),
- `await result.text` resolves to `''` (Draft),
- and every `catch` block in the app is dead code for provider errors.

Checked against `ai@7.0.37`: `textStream` still drops error parts, and `fullStream` is only renamed to `stream` (old name kept as a deprecated alias). The upgrade does not fix this, and this fix survives it — one line to switch when it lands.

## The fix

- **`src/api/generate.ts`** — `streamTextDeltas` / `generateFullText` read `fullStream` and throw a `GenerationError` the moment an error part arrives, including mid-stream, so partial output is kept and shown alongside the error. Pages must not call `streamText` directly; doing so silently reintroduces the bug.
- **`src/api/errors.ts`** — `describeGenerationError` normalizes the four unrelated shapes a failure arrives in (raw provider SSE chunk, `APICallError` response body, abort/timeout `DOMException`, `TypeError: Failed to fetch`) into one writer-facing sentence, the raw provider text, the error code, and whether a retry could help. `insufficient_quota` says the account is out of credit and needs the team — not a retry.
- **`src/components/errorNotice/`** — one notice used by all three pages: the sentence, the provider's own words behind a "Technical details" toggle, and Retry only when `retryable`.
- **Pages** — Draft, Revise, Chat wired to it. Revise reports the failure on the feature that failed and keeps running the rest of the batch; Chat rolls a failed turn back and hands the message to the input box so Retry doesn't duplicate it; Draft also reports a successful-but-empty generation instead of falling through to the empty state.
- **Logging** — error events now carry the provider's message and its `code` rather than the sentence shown on screen (`schema_version` 3).

## Testing

- `src/api/__tests__/generate.test.ts` — deltas stream; an `error` part throws; partial text before a mid-stream failure is kept; `generateFullText` throws instead of returning `''`.
- `src/api/__tests__/errors.test.ts` — provider chunk, `APICallError` body, status fallbacks, timeout/abort, dead network, unclassifiable.
- `src/components/__tests__/ErrorNotice.test.tsx` — details stay collapsed, Retry suppressed for non-retryable failures.
- `tests/error-visibility.spec.ts` — E2E across Draft, Revise and Chat, failing each the way OpenAI does (HTTP 200 then an `error` SSE event) and asserting the writer is told.

`npm test` 100 passed, `npm run typecheck` clean, `npx eslint src/` clean (2 pre-existing warnings in `draft/index.tsx`). Full Playwright suite passes except `demo-page-visual`, which fails identically on unmodified `main` in this container (browser/font mismatch, unrelated).

---
_Generated by [Claude Code](https://claude.ai/code/session_01249QFavjpojZWHUyw4YVpZ)_