### PR TITLE
Design explorations: discernment in community, and writing to learn

### DIFF
--- a/docs/design/discernment-in-community.md
+++ b/docs/design/discernment-in-community.md
@@ -1,0 +1,698 @@
+# Discernment in Community
+
+*A design exploration — what changes when the writer is not alone. July 2026*
+
+> **Status:** exploration, arguing with our own prior work. Companion to
+> [`interface-concepts.md`](interface-concepts.md) (the five surfaces) and
+> [`interaction-concepts.md`](interaction-concepts.md) (the fourteen concepts).
+> Nothing here is specced for implementation, except §7, which names things
+> already broken or missing in the code.
+
+---
+
+## 1. The assumption nobody wrote down
+
+Read our two design documents back to back and a pattern shows up that neither
+of them states. Every one of the nineteen concepts has exactly one human in it.
+
+The Charter is negotiated between a writer and a machine. The Prior Self
+indexes one person's corpus. Tidelines coaches one person for six months. The
+Loom holds one person's threads. The Table Read stages a room full of readers,
+all of whom are simulations. The Post-Game Review reports to the writer alone.
+The Dojo trains one athlete. Inkwell discloses provenance to no one in
+particular.
+
+Even the vocabulary gave it away. The word *collaborative* appears throughout
+`my-words-voice-native-research.md` and it never once means "with another
+person" — it means "the AI takes smaller turns." We built a theory of
+partnership in which the only available partner is a language model.
+
+This is not an oversight so much as an inheritance. Composition studies has a
+name for it: the myth of the solitary author, which Lunsford and Ede spent a
+book dismantling (*Singular Texts/Plural Authors*, 1990) by pointing out that
+most writing that matters in the world — proposals, reports, articles, policy,
+liturgy, code — is produced, reviewed, and owned plurally, while our images of
+writing remain stubbornly Romantic. Word processors are built for the myth.
+Sidebars are built for the myth. We built for the myth.
+
+The cost is specific, and it is worth stating in our own terms. Our anchor
+value is that *AI use should improve your unaided work*. Under the solitary
+assumption, "unaided" means "without the machine." But no serious writer has
+ever been unaided in the stronger sense. They had an advisor, a writing group,
+an editor, a colleague two doors down, a tradition of texts they were
+answering. When a tool inserts itself between the writer and the blank page, it
+is not only competing with the writer's own thought. It is competing with the
+writer's *people* — and it wins, because it is available at 11pm and never
+tired and never disappointed in you. That substitution is invisible in every
+metric we have proposed, because every metric we have proposed has one subject.
+
+**The question this document asks:** if discernment in community is a real
+value and not a decoration, what does it demand of the design? The answer turns
+out to be more interesting than "add sharing features." Three of our existing
+concepts get *better* when a second person enters. Two of them get *dangerous*.
+And one of our stated values quietly changes meaning.
+
+---
+
+## 2. What the traditions of communal discernment actually specify
+
+"Discernment in community" can degrade into a mood — warmth, consensus,
+belonging. The traditions that practice it seriously are not warm; they are
+*procedural*. Each one is a set of constraints on how a group is allowed to
+think together, and every constraint has a direct design analogue.
+
+**The Quaker clearness committee.** A person facing a decision convenes a small
+group. The committee's single rule is the interesting one: *members may ask
+questions only.* No advice, no anecdotes, no "what I would do." The discipline
+exists because advice returns the decision to the advisor, and the point is to
+help the focus person hear their own life. A clerk records; the group seeks the
+sense of the meeting rather than a vote.
+
+We have, without noticing, already written the clearness committee's rule into
+our covenant. "The AI's best verbs are not *write* or *fix*" — ask, quote,
+notice, gather, resurface, narrate. "Judgment stays home." Our machine is
+already trying to behave like a clearness committee of one. The obvious move is
+to notice that a *real* clearness committee is made of people, and that the
+machine's best role in it is the one job nobody wants: **clerk**. Scheduling,
+holding the question-only discipline when someone drifts into advice,
+recording, drafting the minute the group then approves aloud.
+
+**The Genevan practice, since this lab sits where it sits.** Calvin's Company
+of Pastors met weekly for the *congrégation* — one minister expounded a text
+while the others critiqued it, in front of the public — and quarterly for the
+*censura morum*, a mutual examination in which each pastor submitted his life
+and practice to the criticism of peers before communion. Two features are worth
+stealing. It was *mutual*: the critic this quarter is the criticized next
+quarter. And it was *scheduled*: it happened on the calendar, not when someone
+felt bad enough to ask. A review practice that only fires when a writer feels
+guilty selects for the wrong writers.
+
+**Benedict.** *The Rule*, chapter 3: the abbot calls the whole community to
+counsel, including the youngest, "because the Lord often reveals what is better
+to the younger." This is a design constraint about aggregation. A discernment
+surface that averages its members will systematically lose the novice's read —
+and the novice's read is the one that tells you the document is unreadable to a
+newcomer. Weight the margin, don't average the room.
+
+**Ignatian communal discernment.** Rounds in which each person speaks without
+rebuttal before anyone responds; a period of deliberate indifference to one's
+own preferred outcome; attention to consolation and desolation as data. The
+mechanic that matters here is *no rebuttal in round one*. It is a protocol
+against the loudest person setting the frame.
+
+**Bonhoeffer.** *Life Together*: "the first service one owes to others in the
+fellowship consists in listening to them," and the warning that the community
+you *wish* for is the enemy of the one you actually have. Applied to us: a
+feature that simulates the ideal reader is a wish dream. The rushed, distracted,
+partly-hostile actual colleague is the community.
+
+**And the counter-tradition, which the design needs more than the tradition.**
+Kierkegaard: the crowd is untruth. Communal discernment fails in known,
+repeatable ways, and the empirical literature names them precisely — group
+polarization (Sunstein), and the hidden-profile effect (Stasser & Titus, 1985),
+in which groups spend their discussion on information everyone already shares
+and never surface the unique thing one member knows. That failure is *exactly*
+what an LLM does by construction: it returns the modal reading. A community
+surface built on a model that outputs consensus, applied to a group that drifts
+toward consensus, produces the most confident possible wrongness.
+
+This yields the hardest constraint in the document, and it is worth putting in
+the covenant:
+
+> **The AI may convene, hold discipline, record, and route. It may never speak
+> for the group, and it may never report a consensus it computed.** Where a
+> synthesis is needed, the AI drafts it as a minute — provisional, attributed,
+> inert — and the group has to say yes out loud.
+
+---
+
+## 3. The theory that makes it buildable
+
+The traditions give the ethics. Five bodies of HCI and social theory give the
+mechanisms, and one of them names our gap so exactly it is almost rude.
+
+**Activity theory (Engeström).** The activity triangle has six nodes: subject,
+object, instruments — and *community*, *rules*, *division of labor*. Our
+nineteen concepts populate the first three with real care and leave the second
+three empty. That is the whole diagnosis in one diagram. "Who else is in this
+activity, what norms govern it, and who does which part" are not features we
+forgot; they are a third of the model.
+
+**Social translucence (Erickson & Kellogg, 2000).** Systems should make socially
+salient information visible enough that people can use their ordinary social
+intelligence. Their canonical image is the frosted-glass door: you can see that
+someone is on the other side, and that they are moving, so you don't slam it
+into them — but you cannot see who they are or what they are doing.
+*Translucent, not transparent.* This is precisely the right calibration for the
+sharing question, and it rules out the version of provenance-disclosure that
+everyone reaches for first. Their three requirements — visibility, awareness,
+accountability — are a usable checklist.
+
+**Contextual integrity (Nissenbaum).** Information flows are appropriate or not
+relative to the norms of the context they occur in; there is no context-free
+"private" or "public." This is the theory that makes *sharing-aware AI* cut both
+ways, which is the thing our first instinct gets wrong. If a document is
+co-authored, the naive move is "give the AI more context — it should know about
+the collaborators." The contextual-integrity move is the opposite: **a
+co-authored document is a context in which the AI must do less.** My Prior Self
+atlas surfacing an excerpt from my private 2023 memo, in a sidebar my
+co-author's screen share is broadcasting, is a leak I never authorized and the
+tool arranged.
+
+**Distributed cognition (Hutchins) and transactive memory (Wegner).** Cognitive
+capability is a property of a system of people and artifacts, not of a skull.
+Hutchins's navigation team knows how to fix a position; no member does. Wegner's
+couples remember more together because each maintains a directory of *who knows
+what*. Two consequences for us. First, our KPI is individualist in a way we
+should at least argue about (§6). Second, transactive memory hands us the single
+best design move in this document: the Prior Self's most valuable card is
+sometimes **not a passage but a person**.
+
+**Grudin's groupware challenges (1994).** Groupware fails when the person who
+does the extra work is not the person who gets the benefit. This is the
+guillotine under every idea below. Provenance disclosure benefits readers,
+reviewers, and institutions; the work falls on the writer. Community memory
+benefits the newcomer; the work falls on the veteran. Any feature here that
+does not pay its author back *within the session* is already dead, and our own
+Loom notes said as much for the solo case.
+
+Three more, briefly, because each generates a concrete move:
+
+- **Boundary objects (Star & Griesemer).** Artifacts plastic enough to mean
+  different things locally, robust enough to hold identity across groups. The
+  Charter is one criterion-edit away from being a real boundary object between
+  a writer and an advisor.
+- **Legitimate peripheral participation (Lave & Wenger).** Novices learn by
+  watching competent practice from the edge. Nobody has ever watched anybody
+  write. This is the affirmative argument for the trajectory logs, and it is
+  much stronger than the audit argument.
+- **Genre as social action (Miller) and discourse communities (Swales).**
+  Norms for AI use are genre-specific and community-specific, not universal. A
+  tool that offers the same eight buttons for a grant proposal, a pastoral
+  email, a peer review, and a freshman essay is asserting that these are the
+  same act. They are not, and the community — not the vendor — is the body with
+  standing to say so.
+
+And one debt we should have paid already: **Peter Elbow's teacherless writing
+class** (*Writing Without Teachers*, 1973) is a group of seven to twelve people
+who meet weekly and give each other "movies of the reader's mind." Our Table
+Read is a machine reconstruction of that class. We took the one practice in the
+literature whose entire thesis is *you do not need an expert, you need each
+other*, and we replaced the each-other with personas. That is either the
+cleverest or the most self-defeating thing in the design space, and which one it
+is depends on whether the simulation increases or decreases the number of times
+a real person reads the draft.
+
+---
+
+## 4. Eight design moves
+
+Each is stated as: what it is, which existing concept it modifies, what the AI
+pointedly does *not* do, the risk, and the cheapest honest test.
+
+### 4.1 Footing — the sidebar knows who else is in the room
+
+*Modifies: everything. Theory: contextual integrity, Goffman's participation
+framework, social translucence.*
+
+The add-in reads the document's actual sharing state — co-authors present,
+permission scope, whether this file is shared with a named person, a team, or
+the world — and lets that state change its behavior. Goffman's vocabulary is
+better than "author" here: a document has an **animator** (who typed it), an
+**author** (who composed the words), and a **principal** (whose commitments the
+text expresses). AI writing scrambles these, and "was AI used?" is the wrong
+question because it collapses all three.
+
+What changes with a second name on the document:
+
+- **Restraint first.** Private-corpus retrieval (Prior Self) goes quiet, or asks
+  before surfacing anything from outside this document's sharing context.
+  Cross-document coaching observations (Tidelines) never render while a co-author
+  may be looking.
+- **Then affordance.** New questions become askable that are nonsense alone:
+  *who is writing which part?* *Where do you two disagree and has either of you
+  said so in the text?* Division of labor is a first-class thing to notice.
+- **Then translucence.** A frosted-glass indicator — the sidebar is in use on
+  this document — coarse by design, reciprocal by construction. Not *what* was
+  generated. Not *how much*. Presence only, the way a cursor tells you someone
+  is in the file.
+
+**The AI does not:** report your activity to your co-authors in any granularity
+finer than presence, or make a disclosure on your behalf.
+
+**Risk:** presence indicators become pressure. Someone will read "sidebar in
+use" as "not really their work," which is exactly the inference the coarse
+signal is meant to prevent and will not always prevent. Reciprocity is
+load-bearing: if you can see mine, I can see yours, and if you opt out you also
+opt out of seeing.
+
+**Cheapest test:** instrument nothing. Ask ten people who co-author regularly
+what they'd want a collaborator to know about their AI use, and — separately,
+first — what they'd want to know about a collaborator's. The gap between the two
+answers is the finding, and I would bet real money it's large.
+
+### 4.2 The Clearness Committee — the Table Read with the humans put back
+
+*Modifies: Concept 5 (Table Read), Concept 1 (Charter). Theory: Quaker practice,
+Elbow's teacherless class, Grudin.*
+
+The Table Read simulates readers because real readers are expensive. Attack the
+expense instead of the reader.
+
+A writer requests a clearness reading: three colleagues, twenty minutes each,
+asynchronous, within a week. Each gets the draft and one instruction — **you may
+ask questions only.** No advice, no line edits, no "have you considered." The
+AI's role is the clerk's, entirely: it composes the ask so it is small and
+answerable, it holds the discipline (when a reader types "I'd move paragraph
+three," it offers back "what's the question underneath that?"), it collects, it
+anchors each question to the text with the doctext links Revise already has, and
+it drafts a minute the writer edits and keeps.
+
+The believing pass and the doubting pass survive intact from the Table Read, and
+the order is still non-configurable — but now Act I is a real human trying to
+restate your argument at its strongest, which is a completely different artifact
+from a model doing it, because when a real person can't restate your argument,
+that is *news*.
+
+**The AI does not:** answer any of the questions. Rank them. Summarize the three
+readers into one reader. Or read the draft in the readers' place when a reader
+doesn't show up.
+
+**Risk:** it dies on logistics, like every writing group in history. Which is
+also the opportunity — logistics is articulation work, and articulation work is
+the thing software is genuinely good at and communities are genuinely bad at.
+If this works it works because the ask got small enough to say yes to.
+
+**Cheapest test:** run it by hand, no code, four writers in the lab, three
+rounds. Measure one thing: does the question-only rule hold without enforcement,
+and if not, where does it break?
+
+### 4.3 Predict-the-Readers — commit before reveal, as a group ritual
+
+*Modifies: Concept 4 (Predict-the-Reader). Theory: hidden-profile effect,
+Delphi, group polarization.*
+
+Our best existing mechanic is commit-then-reveal: the writer guesses three
+reader questions before the AI shows its list, and the overlap is scored over
+time. That mechanic scales to groups without modification, and at group scale it
+is doing something more important than calibration — it is *protecting
+independent judgment before aggregation*, which is the single defense against
+the failure modes in §2.
+
+Everyone in the reading group — co-authors, reviewers, a committee — records
+their own read privately. Nobody sees anyone else's until everyone has
+submitted. Then all reads reveal at once, anchored to the same paragraphs.
+
+The artifact is the **divergence map**, and the design slogan is:
+
+> **The AI's contribution is the variance, not the mean.**
+
+Where four readers converge, the text is doing one thing. Where they scatter,
+the text is doing four things, and the writer didn't know. Divergence is the
+signal; consensus is comparatively worthless, and it is exactly what an
+LLM-summarized "here's what your reviewers said" would have destroyed.
+
+**The AI does not:** aggregate, average, rank, or resolve. It aligns independent
+reads to common anchors and displays the spread. Where two readers contradict,
+it pins them side by side — the single best frame in the Loom storyboard,
+promoted from feedback-management to the core mechanic.
+
+**Risk:** the private-commit step is friction, and friction is where rituals die.
+It has to cost under three minutes.
+
+**Cheapest test:** it is already a condition in the experiment paradigm.
+Individual Predict-the-Reader is specced; group Predict-the-Readers is the same
+instrument with N participants and one extra field. Divergence among readers is
+a clean, publishable dependent measure.
+
+### 4.4 The examen, and the rule of life
+
+*Modifies: Concept 6 (Post-Game Review), Concept 3 (Tidelines). Theory: Ignatian
+examen, censura morum, Ostrom.*
+
+This is the second of the two intuitions that prompted this document — logging
+your own trajectory for later reflection — and it splits cleanly into a personal
+half we can build now and a communal half that needs governance before it needs
+code.
+
+**Personal (the examen).** Weekly, five minutes, from the logs we already write
+in `backend/src/logging.ts`. Questions, never scores, and never a dashboard: *Where
+this week did you accept something you didn't understand? Which suggestion are
+you still not sure was yours? What did you stop trying to do yourself?* The
+Ignatian examen is a review of consolation and desolation, not a productivity
+audit, and the tone difference is the entire feature.
+
+**Communal (the rule of life).** A lab, a class, a newsroom, a writing group
+covenants together about what AI use is fitting for the kind of writing they do,
+and then reviews the practice together on a schedule. Ostrom's design principles
+are the governance spec, near-verbatim: those affected by the rules make the
+rules; monitors are accountable to the monitored; responses are graduated and
+start absurdly low; there is a real conflict-resolution path; and boundaries are
+explicit.
+
+Four guards, all non-negotiable, and each corresponds to a way this becomes
+surveillance:
+
+1. **The logs are the writer's.** The community sees what the writer brings.
+   This is closer to confession than to telemetry, and the difference is
+   who initiates.
+2. **Reciprocity.** Whoever reviews is also reviewed. The Genevan pastors put
+   this in the constitution, not the culture.
+3. **Formative questions only.** "Where did you outsource the thinking you most
+   needed to do?" is a discernment question. "Did you exceed your AI budget?" is
+   a compliance question with a discernment costume on.
+4. **A guaranteed backstage.** See §6.3. Non-negotiable, and the reason this
+   section is the most dangerous idea in the document.
+
+**The AI does not:** initiate disclosure, compute an adherence score, notify
+anyone of anything, or retain review artifacts past the session that produced
+them.
+
+**Cheapest test:** the covenant without the software. Have the lab write its own
+one-page rule of life for AI use in writing, and hold one review meeting where
+people bring what they choose. If that meeting is worth having, build toward it.
+If it isn't, no feature would have saved it.
+
+### 4.5 The AI's best answer is a person's name
+
+*Modifies: Concept 2 (Prior Self). Theory: transactive memory, Illich's
+peer-matching.*
+
+Prior Self is a memex for one person. Extend the atlas across a community — with
+per-item, revocable, opt-in contribution — and the librarian gains a new highest
+move. Not an excerpt. A referral:
+
+```
+┌──────────────────────────────────────────┐
+│  Your ¶7 argues the accreditation case    │
+│  from enrollment data.                    │
+│                                           │
+│  Marcus argued the opposite in the 2024   │
+│  self-study, §3 — and he's still here.    │
+│                                           │
+│  [read his §3]  [ask him]  [dismiss]      │
+│                                           │
+│  I'm not going to summarize his argument  │
+│  for you. He'd rather tell you himself.   │
+└──────────────────────────────────────────┘
+```
+
+This adds a verb to the list our own sketching produced — ask, quote, notice,
+gather, resurface, narrate, believe, doubt, fade — and it is the one that turns
+the tool outward: **refer**. It also implies a matching refusal, which is the
+part I'd defend hardest: *the AI declines to answer when a person should.*
+
+A tool whose most valuable output is "go talk to Marcus" is a tool that builds
+community rather than substituting for it. It is also, bluntly, the only feature
+in this document that a language model is uniquely positioned to provide,
+because finding the one person in a 200-person institution who has already
+thought about your problem is a retrieval task no human directory solves.
+
+**Risk:** extraction, in two directions. It mines colleagues' corpora, and then
+it spends colleagues' time. Consent per source, reciprocity in the directory
+(you appear in referrals only if you participate), and a visible cost to
+referring — you are spending someone's attention, and the interface should say
+so.
+
+**Cheapest test:** the Slack question that starts "does anyone know if we've
+already written about—". Count how often it's asked in a month and how often it
+gets a useful answer. That is the baseline the feature has to beat.
+
+### 4.6 The Chronicle — process made watchable
+
+*Modifies: Concept 6, Concept 3. Theory: legitimate peripheral participation.*
+
+The artifact nobody has is not the finished document; it is somebody competent
+being confused in public. Experienced writers opt to publish an annotated replay
+of one real document's evolution — the false starts, the paragraph that survived
+eleven revisions, the section deleted in week three, the AI suggestion taken and
+the AI suggestion refused, with a sentence about why.
+
+Tidelines already says *your own best work is the exemplar*. The community
+version: **your community's best work-in-process is the exemplar.** For a
+graduate student, watching an advisor's actual drafting mess is worth more than
+any amount of finished prose, and it is the single thing apprenticeship provides
+that our tools have never even attempted.
+
+**The AI does not:** publish anything automatically, narrate the writer's process
+for them, or generate the annotations. The annotations are the value and they
+are the writer's.
+
+**Risk:** it costs the veteran and pays the newcomer. Grudin's law, cleanly
+stated. The only honest answer is that the annotation pass has to be worth doing
+for the veteran too — which it plausibly is, since explaining your process is
+how you find out what it was.
+
+### 4.7 Covenant as configuration
+
+*Modifies: the Charter, and `flags.ts` / the tool launcher. Theory: genre as
+social action, Ostrom's collective choice.*
+
+Make the community's norms a first-class artifact the software actually reads: a
+machine-readable covenant, authored *in* the app by the community, that
+provisions which tools appear for which genres. In a class where the point of
+the assignment is to learn to structure an argument, the Charter is on and Draft's
+generative modes are off — because the class decided that, visibly, with a date
+and an amendment history, not because a vendor shipped a "student mode."
+
+Two structural features carried over from the Charter: a `history ▾` so norms
+are visibly renegotiable rather than handed down, and a **dissent register** that
+records the minority position instead of erasing it. A covenant that shows its
+own unresolved argument is Benedict's chapter 3 in a data structure — and it is
+the specific defense against Kierkegaard's objection.
+
+The plumbing partly exists. `docs/tool-launcher-plan.md` already contemplates
+per-tool grants and scopes, and `frontend/src/pages/flags.ts` is explicit that
+real per-user gating belongs server-side next to `isAllowed` in
+`backend/src/auth.ts`. A covenant is that mechanism with a community as the
+subject instead of a user.
+
+**Risk:** this is the feature that becomes a compliance product if we're
+careless, and there is a large market rewarding exactly that carelessness. The
+distinguishing test is whether the community can amend it in under five minutes
+without asking us.
+
+### 4.8 The tradition as a member of the community
+
+*Modifies: Concept 2. Theory: MacIntyre, Chesterton's "democracy of the dead."*
+
+The community of discernment includes people who are dead and people who have
+left. MacIntyre's tradition is "an historically extended, socially embodied
+argument," and a lab that has written forty grant proposals has a tradition
+whether or not it knows it. The Prior Self, pointed at institutional rather than
+personal memory, is how a newcomer joins an argument already in progress instead
+of starting one: *here is how this department has argued for its programs since
+2011, including the two times it lost.*
+
+This is the least urgent and most quietly important idea here. It is also the
+one that makes the citation practices of scholarship legible as what they are —
+a technology for being accountable to people you will never meet.
+
+---
+
+## 5. Where these sit against what we already built
+
+| Existing | Under discernment-in-community | Verdict |
+|---|---|---|
+| The brief (audience/purpose, shipped) | Already document-scoped and inherited by the next reader | **Latent** — the second person is present and unaddressed (§7.0) |
+| Charter (goal negotiation) | Boundary object co-held with advisor/committee | **Improves** — a rubric only you agreed to is a diary |
+| Prior Self (personal atlas) | Community atlas; best card is a *person* | **Improves**, with real consent cost |
+| Tidelines (solo coach, months) | Cohort practice; peer exemplars; shared focus skill | **Improves** — deliberate practice is social everywhere else |
+| Loom (threads, layers) | Layers are *already* other people's feedback | **Latent** — it's the closest to multiplayer and doesn't know it |
+| Table Read (simulated panel) | Replaced by, or gated behind, a real reading | **Endangered** — see §6.4 |
+| Post-Game Review (private log) | Examen + communal rule of life | **Improves, dangerously** — needs §4.4's four guards |
+| Inkwell (per-character provenance) | In a shared doc, becomes an instrument of dispute | **Endangered** — see §6.5 |
+| The Dojo (no-AI days, unaided KPI) | Whose capability are we measuring? | **Contested** — see §6.1 |
+
+---
+
+## 6. Where this pushes against us
+
+The invitation was to push. Five places where taking community seriously costs
+us something we've already written down.
+
+### 6.1 "AI use should improve your unaided work" is an individualist metric
+
+It is our second anchor value and it assumes the skull is the unit of
+capability. Distributed cognition says otherwise: Hutchins's navigation team is
+more capable than any navigator on it, and no one calls that team over-reliant.
+If reliance on people is fine and reliance on machines is not, we owe an account
+of the difference — and I think there is a good one, but we have not written it.
+
+My candidate: the difference is **reciprocity and formation**. Depending on
+Marcus makes Marcus's knowledge available *and* obliges you to Marcus, who will
+depend on you next month, and the relationship forms both of you. Depending on a
+model creates no obligation, forms nobody, and leaves nothing behind when it is
+switched off. That is a real asymmetry and it survives scrutiny — but note what
+it implies for our KPI. The success metric is not only "how well you write
+without the tool." It is also **whether the tool left a community more capable
+of forming writers than it found it.** Those can come apart: a tool could improve
+every individual's unaided prose while quietly ending the practice of anyone
+reading anyone else's draft, and by our current dashboard that reads as total
+success.
+
+### 6.2 "Silence is a feature" collides with awareness
+
+Weiser's calm technology gave us covenant point 4, and community features are
+made of exactly the thing calm computing exists to prevent: noticing other
+people. Every awareness indicator is an interruption with good manners.
+
+The reconciliation I'd defend: awareness of *artifacts* may be ambient;
+awareness of *people* must be pull, never push. The presence of a colleague's
+question in your draft can wait for you to look. It may never buzz.
+
+### 6.3 A community surface without a backstage will destroy the drafting
+
+This is the one I am most confident about. Goffman's front stage and back stage
+are not a nicety — the reason Elbow's freewriting works is that the writer has
+somewhere to be bad. Every practice in §2 assumes a protected interior:
+clearness committees are confidential, the examen is between you and God, the
+censura morum happened behind a closed door.
+
+If writing becomes observable — logged, reviewable, publishable, presence-
+indicated — writers will optimize the observable. They will stop the exploratory
+mess that produces good work, because the mess is now evidence. **Any feature in
+§4 must ship with a guaranteed unobserved room**: a drafting space that is
+never logged, never presence-indicated, never reviewable, and visibly so. Not a
+setting. A room, with a door, that the writer can see is closed.
+
+### 6.4 Simulated community may be a substitute good, and we can measure it
+
+The Table Read is the sharpest case. If the simulated dean is *good enough*,
+writers will stop asking the real dean — and the tool will have removed a human
+encounter from the world while scoring well on every metric we have. The
+believing pass is genuinely better performed by a person, because the
+information content of "a real colleague could not restate your argument" is
+categorically higher than a model producing the same sentence.
+
+This gives an evaluative heuristic worth adopting across the whole product,
+alongside unaided performance:
+
+> **Human encounters per document.** Does this feature increase or decrease the
+> number of times a real person engages this draft?
+
+Rehearsal before a real reading is a legitimate use of a simulation — you
+rehearse *because* the performance is real. Rehearsal *instead of* the reading is
+the failure. Design the Table Read so the natural next click is scheduling one.
+
+### 6.5 Provenance among peers is not provenance to yourself
+
+Inkwell's per-character honesty heatmap is a fine instrument for self-knowledge
+and a terrible one for a shared document, because in a shared document it will
+be used in disputes — by a co-author assigning credit, an instructor assigning
+blame, a reviewer assigning suspicion. Fine-grained provenance in a social
+context is not translucence; it is transparency, which Erickson & Kellogg
+specifically warned is not the goal.
+
+The communal form has to be a *declaration of footing*, in Goffman's sense,
+authored by the writer, shaped by the community's covenant, coarse by design,
+and reciprocal. "I drafted this from my own notes; the AI questioned the
+structure; §4 is Marcus's, rewritten" is a disclosure a human made and can be
+held to. A heatmap is a forensic artifact nobody consented to.
+
+---
+
+## 7. What this would touch in the code today
+
+Four things, in order of how real they are.
+
+**7.0 The cheapest multiplayer surface is already shipped, and we didn't notice.**
+`EditorAPI`'s `getDocumentSetting`/`setDocumentSetting` store values that belong
+to the *document* rather than the user, and — the operative phrase from
+`frontend/CLAUDE.md` — they "follow the file to whoever opens it next." The
+writer's brief (`contexts/docBriefContext.tsx`) already rides that channel:
+audience, purpose, constraints, authored by one person and read by the next
+person to open the file. That is a boundary object in the Star & Griesemer sense,
+in production, today, with no backend work required.
+
+Its design rule is the tell. `frontend/CLAUDE.md` says a brief field is a fact
+about the rhetorical situation, never an instruction to the model, and: **"Add a
+field only if a human collaborator would want to know it too."** We were already
+using an imagined colleague as the arbiter of what belongs in the document's
+shared state. The brief is where §4.1 and §4.7 should start — not because it is
+ambitious, but because it is the one place where the second person is already
+implicitly present and merely unaddressed.
+
+**7.1 The consent ladder has one axis and needs at least two.**
+`frontend/src/consent.ts:11-16` models consent as depth of content — `none`,
+`usage`, `ai_output`, `document`. Every question in this document is about a
+second axis it does not have: **audience**. Who may see this, at what
+aggregation, for how long, and can I revoke it? "Log my document text for the
+study" and "show my revision trajectory to my writing group" are different grants
+and today they are the same level.
+
+**7.2 A co-authored document has more than one data subject, and the consent
+model has one.** This is not a design musing; it is a live gap. If I set consent
+to `document` and open a file I co-author, `docContext` goes to the backend
+carrying my collaborator's sentences, and my collaborator never agreed to
+anything. Same for chat `message` payloads quoting a shared draft. I don't know
+the study protocol well enough to say whether this is an IRB problem, but
+somebody who does know should look, because the code can't currently express
+"this text is not only mine." Worth filing regardless of whether any feature in
+this document gets built.
+
+**7.3 Rooms already exist as a primitive and are pointed the wrong way.**
+`docs/tool-launcher-plan.md` §v2 specs rooms anchored on a document-in-progress,
+with a doc authority and arbitrary members over WebSocket — built for one user's
+several devices, with "eventually collaborators" in a parenthesis. Every idea in
+§4 that needs live multi-party awareness is that primitive with the membership
+rule relaxed from *one user's surfaces* to *a document's people*. The switchboard
+design (no server-side document state, no OT/CRDT) holds fine, because none of
+these features move text.
+
+**7.4 The covenant needs a server-side home.** `flags.ts` says out loud that it
+is not access control and that per-user targeting belongs next to `isAllowed` in
+`backend/src/auth.ts`. A community covenant is the same shape with a group as
+the subject. Nothing needs building yet; it means the eventual answer isn't a
+localStorage flag.
+
+---
+
+## 8. Research implications
+
+The unit of analysis changes, and that is the publishable part. Nearly all
+AI-writing research measures individuals; the questions above are dyadic and
+group-level, and the experiment app already has the logging spine for it.
+
+- **Divergence among independent reads** (§4.3) as a dependent measure — with
+  the strong hypothesis that AI-assisted drafts show *lower* reader divergence,
+  i.e. they read the same way to everyone because they're generically written,
+  and that this looks like clarity while being flatness.
+- **Human encounters per document** (§6.4) as a cross-cutting metric, and the
+  substitution question: does access to a simulated panel reduce real
+  consultation? Straightforwardly testable, and it's the study I'd most want to
+  see run.
+- **Referral acceptance** (§4.5): when the tool says "go ask Marcus," do they?
+- **Covenant amendment history** (§4.7) as a naturalistic record of a community
+  actually deliberating about AI — a rare artifact.
+- **The Chronicle** (§4.6) as an intervention: do novices with access to
+  veterans' annotated process revise differently?
+
+---
+
+## 9. Principles that emerged
+
+Mirroring the three that closed `interface-concepts.md`:
+
+1. **Sharing awareness first produces restraint, then affordance.** The instinct
+   is that a shared document lets the AI do more. Contextual integrity says the
+   first correct response to "someone else is here" is for the tool to do less,
+   more carefully. Every feature in §4.1 that adds capability is downstream of
+   one that removes it.
+
+2. **The AI convenes; it does not speak for the group.** It may clerk, hold
+   discipline, anchor, record, route, and refer. The moment it reports what "the
+   group thinks," it has replaced the discernment with a summary of the
+   discernment — and because it returns the modal reading, the thing it erases
+   is exactly the minority voice both Benedict and Stasser tell us is carrying
+   the information.
+
+3. **A tool that says "go ask a person" is doing its best work.** The verb
+   *refer* belongs in the covenant next to ask, notice, and fade, along with its
+   refusal: decline to answer when a person should. This is the only line in the
+   document that would show up on the invoice as a cost, which is roughly how
+   you know it's the real commitment.
+
+4. **Community needs a backstage or it eats the drafting.** Observability is
+   corrosive to exploratory writing. A guaranteed unobserved room is a
+   precondition for every other idea here, not a preference toggle.

--- a/docs/design/discernment-in-community.md
+++ b/docs/design/discernment-in-community.md
@@ -7,6 +7,11 @@
 > [`interaction-concepts.md`](interaction-concepts.md) (the fourteen concepts).
 > Nothing here is specced for implementation, except §7, which names things
 > already broken or missing in the code.
+>
+> Continued in [`writing-to-learn.md`](writing-to-learn.md), which finds the
+> second buried assumption — that the document is the point — and corrects §4.4
+> below: Ostrom's governance model does not survive a classroom's power
+> asymmetry.
 
 ---
 
@@ -367,6 +372,11 @@ surveillance:
 **The AI does not:** initiate disclosure, compute an adherence score, notify
 anyone of anything, or retain review artifacts past the session that produced
 them.
+
+**Where this breaks:** Ostrom's principles assume roughly symmetric power among
+commoners. A classroom does not have that, and a student cannot dissent from a
+graded requirement without cost — see `writing-to-learn.md` §3.2, which replaces
+this governance model with fiduciary duty for the classroom case.
 
 **Cheapest test:** the covenant without the software. Have the lab write its own
 one-page rule of life for AI use in writing, and hold one review meeting where

--- a/docs/design/writing-to-learn.md
+++ b/docs/design/writing-to-learn.md
@@ -1,0 +1,419 @@
+# Writing to Learn, and the Classroom
+
+*A design exploration — what changes when the document is not the point.
+July 2026*
+
+> **Status:** exploration. Third in a series with
+> [`interface-concepts.md`](interface-concepts.md),
+> [`interaction-concepts.md`](interaction-concepts.md), and
+> [`discernment-in-community.md`](discernment-in-community.md). That last one
+> found that our designs assume **one writer**. This one finds that they assume
+> **one document, and that the document is the point.** Both assumptions are
+> load-bearing and both are wrong for the setting our lab actually sits in.
+
+---
+
+## 1. The second assumption
+
+The community doc caught the first: nineteen concepts, one human in each. Here
+is the second, and it hides better.
+
+Every concept we have written takes a document as its object. The Charter
+defines success *for a document*. Revise improves *a document*. The Table Read
+rehearses *a document's* reception. Tidelines is the sole exception, and even it
+treats documents as the substrate it observes. Our stated value —
+**formation over output** — is expressed as a claim about the tool's posture
+*toward output*. Output is still the thing we are posturing toward.
+
+Writing-to-learn says something more radical than "care about the writer too."
+It says that for a large and important class of writing, **the document is a
+byproduct.** Janet Emig's "Writing as a Mode of Learning" (1977) makes the claim
+that writing is not a report on thinking that has already happened; it is a mode
+in which thinking happens, uniquely, because it is self-rhythmed, because it
+makes thought visible and reviewable to its own author, and because the writer
+gets feedback from their own product mid-process. Under that claim, a paragraph
+that took forty minutes and got deleted was not wasted work. It was the work.
+
+Our tool cannot represent that paragraph. It has no concept of writing that
+isn't going anywhere. Ask the sidebar for help with a passage you intend to
+throw away and it will earnestly try to make it good.
+
+---
+
+## 2. What writing-to-learn actually claims
+
+Three ideas do the work, and the third names our problem precisely.
+
+**2.1 Modes, not quality levels.** Britton's *Development of Writing Abilities
+11–18* (1975) sorts writing into three functions: **transactional** (to inform,
+persuade, transact with a reader), **poetic** (the verbal artifact), and
+**expressive** — writing close to speech, exploratory, loosely organized,
+addressed to the self or to a trusted reader who will not judge it. Britton's
+claim is that expressive writing is the *seedbed*: the matrix out of which the
+other two develop, and the mode in which a writer works out what they think.
+
+Now read our design docs against that taxonomy. Draft, Revise, Chat, the
+Charter, the Table Read, Who Is Served?, The Reader's Reply, Say-Back — every
+single one is an instrument for transactional writing. Several of them
+(the Charter's refusal to run without an audience; the brief's audience field)
+make audience-orientation a *precondition of help*. In expressive mode that is
+not merely useless, it is the wrong instruction: the whole point is to write
+before you know who it's for, because knowing who it's for too early is what
+stops you finding out what you think.
+
+**We built an entire product on one of Britton's three modes and called it
+writing.**
+
+**2.2 Low stakes and high stakes.** Elbow's "High Stakes and Low Stakes in
+Assigning and Responding to Writing" (1997) makes the operational version:
+low-stakes writing is frequent, short, ungraded or lightly graded, and its
+purpose is to make students think and to show the teacher what they're
+thinking. High-stakes writing is the polished artifact. Elbow's argument is that
+low-stakes writing is where students are willing to be wrong, and that being
+willing to be wrong is a precondition of the high-stakes work getting good.
+
+Our tool treats every session as high-stakes, because it always behaves as
+though the document matters. There is no dial.
+
+**2.3 The mechanism, and it is exact.** Bereiter & Scardamalia's *Psychology of
+Written Composition* (1987) — already cited in our Loom concept, which is
+a nice piece of luck — distinguishes **knowledge-telling** from
+**knowledge-transforming**. Knowledge-telling: retrieve what you know about the
+topic, write it down, stop when you run out. Knowledge-transforming: the
+*content* problem space ("what do I actually believe, and is it true?") and the
+*rhetorical* problem space ("how do I say this to this reader?") interact, and
+each one changes the other. You reach for a way to phrase it, discover you
+can't, and find out that you didn't believe the thing. Learning happens in the
+traffic between the two spaces. Only there.
+
+That gives us the mechanism of harm in one sentence, and it is sharper than
+anything in the over-reliance literature:
+
+> **Fluent generated prose solves the rhetorical problem without ever entering
+> the content problem — so the traffic between the two spaces, which is where
+> the learning is, never happens.**
+
+This is what our own experiment already calls *premature closure*
+(`experiment/docs/research-overview.md` §1.1: "the AI short-circuits the
+thinking process itself"). Writing-to-learn supplies the theory of *which*
+thinking, and *why* its absence is invisible: the document looks fine. It looks
+better than fine. The rhetorical problem was solved beautifully. Nothing in the
+artifact records that the content problem was never opened.
+
+---
+
+## 3. The classroom is not just a community with homework
+
+The community doc treated the lab, the writing group, the newsroom as
+interchangeable. A classroom differs on three axes that change the design, and I
+got one of them wrong last time.
+
+**3.1 The grade is the strongest force in the room, and it bends everything.**
+Deci and Ryan's self-determination theory, and the long line of work on
+extrinsic rewards crowding out intrinsic motivation, predict what every teacher
+observes: whatever is graded becomes the object of effort, and whatever is
+merely encouraged does not. The design consequence is brutal and general:
+
+> **Anything the tool can log, a grading regime will eventually grade.**
+
+Not because instructors are villains — because assessment is under real pressure
+and a process log looks like exactly the evidence everyone has been asking for.
+This flips the "guaranteed backstage" from the community doc's §6.3 from an
+important guard into a structural requirement. In a classroom, a *policy* that
+expressive writing won't be reviewed will lose to institutional need within two
+semesters. The only durable guarantee is that the data does not exist.
+
+**3.2 Ostrom does not survive the power asymmetry — my previous doc was wrong
+about this.** I proposed community covenants governed by Ostrom's design
+principles, including collective choice: those affected by the rules make the
+rules. Ostrom's commons are roughly power-symmetric. A classroom is not. A
+student cannot meaningfully dissent from a graded requirement, so a
+"co-authored" classroom covenant risks being a compliance document that has been
+made to look consensual — which is worse than an honestly imposed one, because
+it launders the imposition through the student's own signature.
+
+The governance model for a classroom is closer to **fiduciary duty** than to
+commons self-governance: the instructor holds power on behalf of students'
+formation and is accountable for it, and the tool's job is to make that
+accountability legible rather than to stage a fake negotiation. Where genuine
+student choice exists it should be real and low-stakes (which practices to try,
+what to bring to review) rather than nominal and structural.
+
+**3.3 The instructor is a user we have never once considered.** Every design doc
+in this repo has a writer as its subject. But the highest-leverage intervention
+in AI-and-writing pedagogy is not a student-facing feature at all — it is
+**assignment design.** Bean's *Engaging Ideas* is built on the observation that
+most writing assignments fail because they do not pose a genuine problem, and a
+prompt with no real question is a prompt a language model can complete perfectly
+and a student can learn nothing from. The pedagogically serious answer to "AI
+does my homework" is not detection. It is homework worth doing.
+
+Detection deserves one sentence so we can stop discussing it: automated AI
+detectors are unreliable and are documented to be biased against non-native
+English writers (Liang et al., *Patterns*, 2023), and our trajectory logs would
+be extremely attractive to anyone who wanted to build one. We should decide now,
+in writing, whether we will permit that use of them.
+
+---
+
+## 4. Design moves
+
+### 4.1 The Seedbed — a mode where the tool's contribution is refusal
+
+*Britton's expressive function; Elbow's freewriting; the backstage requirement.*
+
+A writing surface for text that is not going to a reader. The sidebar goes dark.
+No suggestions, no reader personas, no Charter, no audience field, no doctext
+analysis. What remains: a prompt, a timer, a word count that goes up, and a
+promise — **nothing here is logged, reviewed, or retrievable by anyone but
+you.** Not a setting. A visibly different room.
+
+This is the strangest thing in three design documents: a feature whose entire
+content is an absence, in a product whose business is presence. I would defend
+it as the most honest expression of "formation over output" we have available,
+because it is the one place we stop asserting restraint and implement it. It is
+also the only way the covenant's "silence is a feature" ever gets tested — right
+now silence means "the AI waits to be asked," which is not the same thing at
+all.
+
+**What the AI does not do:** anything. That is the feature. The strong version
+doesn't even have a model behind it.
+
+**Cheapest test:** the Seedbed is a text box and a timer. Build it in an
+afternoon, put it in Labs, and see whether anyone uses it twice.
+
+### 4.2 The stakes dial
+
+*Elbow's high/low stakes; document-scoped settings, which already ship.*
+
+Make stakes an explicit property of a writing session, set by the writer (or by
+a course covenant), that changes what the tool is. Low: Seedbed behavior,
+quantity over quality, nothing retained. High: the full apparatus. Middle:
+questions but no prose.
+
+This is the cheapest structural fix in the document, because the mechanism
+exists — `getDocumentSetting`/`setDocumentSetting`, the channel the brief already
+rides. And it converts a problem we currently paper over into a first-class
+choice: right now every session is implicitly high-stakes, and a writer who
+wants to think badly on purpose has to fight the tool to do it.
+
+### 4.3 Be most helpful where the writer is confused about the world
+
+*Knowledge-telling vs. knowledge-transforming, turned into a policy.*
+
+If the learning lives in the traffic between the content and rhetorical problem
+spaces, then a tool's help should be allocated by *which space the writer is
+stuck in* — and the allocation should be the opposite of the industry default:
+
+> **Most helpful where the writer is confused about the world. Least helpful
+> where they are confused about the sentence.**
+
+Concretely: "I don't know whether this is even true" gets the tool's full
+attention — sources, counter-cases, the reader who would object, our existing
+Say-Back and Reader's Perspective machinery. "Make this paragraph flow better"
+gets a question instead. Our Earn-the-Answer concept (#7) is already this
+mechanic; what's new is the *criterion* for when to apply it, which until now was
+"always," and "always" is a blunt instrument that will annoy people out of the
+product.
+
+**Risk, and it is real:** this stance has a cost that falls unevenly. For a
+second-language writer, sentence-level fluency help may be exactly the scaffold
+that gets them *into* the content problem space, where the learning is. The
+distinction that keeps this honest is Bjork's: a **desirable difficulty** is
+difficulty in the skill being learned; everything else — interface friction,
+anxiety, a language barrier orthogonal to the learning goal — is just
+difficulty. Which is which depends on the learning goal, which means this must
+be set by the goal (or the course), never hard-coded as a universal virtue.
+"Friction is good for learning" is one careless sentence away from an
+accessibility failure.
+
+### 4.4 Give the Charter to a class
+
+*Sadler's evaluative expertise; rubric co-construction; boundary objects.*
+
+Sadler's argument (1989, and the long line after it) is that the goal of
+formative assessment is for students to develop the tacit knowledge of what good
+work looks like — and that this cannot be transmitted, only built by making
+judgments. Rubric co-construction is the most robust practical form of that.
+
+Which means **the Charter is already a classroom feature and nobody noticed.**
+Students draft criteria before writing; the class negotiates a shared version;
+each student's personal Charter inherits from it and may dissent, with the
+dissent recorded (the register from the community doc, which survives the
+classroom fine even though Ostrom didn't). The ●◐○ marks are already
+writer-set, which is already Sadler's point: the student grades against criteria
+they helped build, and the AI's contribution is evidence.
+
+Of everything across three documents, this is the highest value per unit of work
+remaining, because most of it is built.
+
+### 4.5 Peer review that keeps the learning with the reviewer
+
+*Lundstrom & Baker (2009); Hattie & Timperley; Carless & Boud's feedback
+literacy; the clearness committee.*
+
+The finding that should govern every automated-feedback decision we make:
+**giving feedback benefits the giver more than receiving it benefits the
+receiver** (Lundstrom & Baker, *JSLW* 2009, and consistent replications). If
+that holds, then:
+
+> **Automating feedback takes the learning away from the student and gives it to
+> the machine.**
+
+The student who would have learned by reviewing now receives a review instead —
+and receiving is the weaker half of the transaction. The instructor sees better
+feedback and less learning, and the trade is invisible.
+
+So the classroom version of the clearness committee inverts who the AI is
+coaching. Students review each other; the AI's *student is the reviewer*. It
+holds the question-only discipline, anchors comments to text, and teaches
+feedback literacy in situ: *"that comment is about the writer, not the writing —
+Hattie's four levels say the 'self' level is the one that reliably doesn't work.
+Can you make it about the process?"* The AI never produces the feedback. It
+produces better reviewers.
+
+### 4.6 The muddiest point, and the variance
+
+*Angelo & Cross's minute paper; the divergence map from the community doc.*
+
+The classic low-stakes classroom instrument: two minutes at the end, "what was
+the muddiest point?" Its problem at scale is that thirty responses are hard to
+read, and its solution is the one thing we must not do — summarize them.
+
+The divergence map transfers here without modification. Show the instructor the
+*spread*, and surface the outlier response rather than burying it, because
+Benedict's chapter 3 and Stasser's hidden-profile work agree that the lone
+divergent read is carrying the information. A consensus summary of thirty
+muddiest points tells the instructor what they already knew.
+
+### 4.7 The theory-of-writing portfolio
+
+*Yancey, Robertson & Taczak, "Teaching for Transfer" (2014).*
+
+Transfer — the thing every writing course claims and few demonstrate — turns out
+to depend on students building and revising an *articulated theory of writing*
+they can carry to the next context. Not a reflection at the end; a theory,
+stated early, revised against evidence from their own work all term.
+
+That is Tidelines and the examen, scoped to a course, and it doubles as the
+assessment artifact the AI-integrity panic is actually looking for: a claim about
+your own process, evidenced by your own trajectory, which is hard to fake
+convincingly and pointless to fake at all. It is also the place where the
+trajectory logs earn their keep pedagogically rather than forensically — the
+student uses their own record, and nobody else has to.
+
+### 4.8 The instructor's assignment workbench
+
+*Bean; genre as social action; the leverage argument.*
+
+The one feature here aimed at a user we've never designed for. Help an
+instructor turn "write five pages on the causes of the war" into a question with
+a genuine problem in it — and, having done so, decide which Britton mode it
+lives in, what stakes it carries, and which of the tool's capabilities are on for
+it. The output is the course covenant from the community doc, but authored where
+the actual design power sits.
+
+I'd rank this second only to §4.4 in expected value, and it is the least
+glamorous idea in three documents.
+
+---
+
+## 5. Where this pushes against us
+
+**5.1 Our headline KPI has a hole in it, in the other direction now.** The
+community doc argued "improve your unaided work" is individualist. Writing-to-
+learn adds that it is also *document-scoped*: it measures unaided writing
+performance, when the thing at risk is the learning the writing existed to
+produce. A student can end a term writing better and having learned less about
+the subject, and our instrument cannot see it. **Document quality and learning
+can move in opposite directions, and only one of them is visible.**
+
+**5.2 Student satisfaction is actively misleading here, and we can prove it.**
+Bjork's work on metacognitive illusions is unambiguous: conditions that produce
+fluency during acquisition feel like effective learning and produce worse
+retention and transfer, and learners cannot detect this by introspection. AI
+assistance is a fluency machine. The strong prediction — testable in our own
+experiment app — is that participants will *rate AI-assisted sessions as better
+learning experiences while performing worse on delayed transfer measures.* If
+that dissociation holds, it is the most useful thing this lab could publish, and
+it indicts the entire industry's primary metric.
+
+**5.3 One tool, one classroom, twenty expertise levels.** The expertise reversal
+effect (Kalyuga) says scaffolding that helps a novice actively harms an expert.
+There is no setting of our features that is right for a whole class. This makes
+Tidelines' fading mechanic not a nice developmental touch but a structural
+necessity, and it means any course-level covenant is a compromise that will be
+wrong for the students at both tails.
+
+**5.4 "Silence is a feature" was never tested.** Our covenant's silence means the
+AI waits to be asked. Britton's expressive mode requires a stronger silence: the
+AI is not there. Until the Seedbed exists, the principle is a manner, not a
+commitment.
+
+**5.5 The deepest one: the object of the activity is not the document.** Russell
+and the activity-theory line make the point that a writing classroom is a strange
+system, because its object is the student's development and the document is
+merely the instrument. Our entire design space inverts that. Put the two
+critiques together and the shape is clean:
+
+> The community doc found we assume **one writer**.
+> This one finds we assume **the document is the point**.
+> A classroom is the setting where both assumptions fail at once — which makes
+> it the sharpest available test of whether "formation over output" is a value
+> or a slogan.
+
+---
+
+## 6. What this would touch in the code
+
+**6.1 The stakes dial is a document setting, and that channel already works.**
+`EditorAPI.getDocumentSetting`/`setDocumentSetting` plus `docBriefContext` is the
+existing pattern (see `frontend/CLAUDE.md`). Stakes belongs beside the brief's
+audience/purpose/constraints — and it satisfies that section's own rule, since a
+human collaborator would absolutely want to know whether this draft is a
+throwaway.
+
+**6.2 The Seedbed needs a logging bypass, not a consent level.** This is a
+different requirement from anything in `frontend/src/consent.ts`. Consent levels
+strip payloads; the Seedbed needs sessions that never generate a payload at all,
+and needs that to be architecturally true rather than configured — because §3.1
+says a policy will not hold. A "no events emitted from this page, enforced at
+`useLog`" boundary is a small piece of work with a large guarantee attached.
+
+**6.3 Stakes and mode should gate the page registry, not just prompts.**
+`frontend/src/pages/registry.tsx` already gates pages by tier and an `enabled`
+predicate; a course covenant that turns Draft's generative modes off for an
+assignment is that mechanism with a server-side subject — the same conclusion the
+community doc reached from a different direction, which is mild evidence it's
+right.
+
+**6.4 The experiment app measures the wrong dependent variable for this
+question.** `experiment/docs/research-overview.md` measures information-seeking
+and email quality — good instruments for premature closure, and premature closure
+is the right construct. What's missing for the WTL claim is a **delayed** measure
+with **no tool present**: transfer, not performance. That is a study-design note
+rather than a code note, but it's the difference between measuring what the AI
+did to the email and what it did to the writer.
+
+---
+
+## 7. Principles
+
+Adding to the four from the community doc:
+
+5. **Not all writing is going to a reader, and the tool currently cannot tell.**
+   Britton's expressive mode is where learning happens and it is the one mode we
+   have no surface for. Audience-orientation as a precondition of help is a
+   correct policy for two of three modes and an error for the third.
+
+6. **Be most helpful about the world, least helpful about the sentence** — with
+   the allocation set by the learning goal, never universal, because the same
+   friction that is desirable difficulty for one writer is an access barrier for
+   another.
+
+7. **Whoever gives the feedback is doing the learning.** This governs every
+   automation decision in a classroom. An AI that reviews student writing has
+   taken the more valuable half of the exchange and handed back the lesser one.
+
+8. **Anything the tool can log, a grading regime will eventually grade.** Design
+   for that, structurally, or the expressive writing dies first and quietly.


### PR DESCRIPTION
Two companion docs to `interface-concepts.md` and `interaction-concepts.md`. Each finds one buried assumption in our existing nineteen concepts.

## `docs/design/discernment-in-community.md` — we assume one writer

Every concept has exactly one human in it. The word *collaborative* appears throughout our docs and never means "with another person" — it means the AI takes smaller turns. Engeström's activity triangle names the gap precisely: we populated subject, object, and instruments and left community, rules, and division of labor empty.

- **§2, the traditions as procedure, not mood.** Quaker clearness committees (questions only — so the AI's role is *clerk*, not oracle), the Genevan `censura morum` (mutual and scheduled), Benedict ch. 3 (weight the margin, don't average the room), Ignatian rounds — plus the counter-tradition, since group polarization and the hidden-profile effect are exactly what an LLM amplifies by construction.
- **§3, theory that makes it buildable.** Social translucence (frosted glass, not transparency), contextual integrity, distributed and transactive memory, Grudin's disparity, boundary objects, legitimate peripheral participation.
- **§4, eight design moves** mapped onto existing concepts, each with the AI's refusals and a cheapest honest test.
- **§6, five places it pushes against our own values** — including that "AI should improve your *unaided* work" is individualist, and that a community surface without a guaranteed backstage destroys exploratory drafting.

## `docs/design/writing-to-learn.md` — we assume the document is the point

Britton's three modes show we built the entire product on transactional writing: several concepts make audience-orientation a *precondition of help*, which is correct for two modes and an error for the expressive one, where the learning happens.

Bereiter & Scardamalia give the mechanism of harm exactly: **fluent generated prose solves the rhetorical problem without ever entering the content problem, so the traffic between the two spaces — which is where learning is — never happens.** That is our experiment's "premature closure" with a theory of *which* thinking is missing and why the artifact cannot show it.

- **§3, why a classroom isn't just a community with homework.** The grade bends everything: anything the tool can log, a grading regime will eventually grade. And the instructor is a user no doc in this repo has considered, though assignment design is the highest-leverage intervention in the space.
- **§4, eight moves** — a Seedbed mode whose entire content is an absence, a stakes dial, help allocated toward confusion about the world rather than the sentence, the Charter given to a class as rubric co-construction, peer review that keeps the learning with the reviewer (giving feedback benefits the giver more — so automating it takes the learning from the student), the muddiest-point divergence map, a theory-of-writing portfolio, and an instructor's assignment workbench.
- **§5, the strong testable claim:** document quality and learning can move in opposite directions and only one is visible; and Bjork's metacognitive illusions predict students will rate AI-assisted sessions as better learning while performing worse on delayed transfer.

It also **corrects the first doc**: Ostrom's collective-choice principle assumes symmetric power and does not survive a classroom, where a student cannot dissent from a graded requirement without cost. Fiduciary duty replaces it there.

## Code notes, which are the load-bearing parts

- **We already shipped a shared artifact and didn't notice.** `getDocumentSetting`/`setDocumentSetting` "follow the file to whoever opens it next," and the brief rides that channel — `frontend/CLAUDE.md` already states its rule as *"add a field only if a human collaborator would want to know it too."* Cheapest place to start, and where the stakes dial belongs.
- **The consent ladder has one axis and needs two.** `frontend/src/consent.ts:11-16` models content depth; every question here is about *audience* — who sees it, at what aggregation, for how long, revocably.
- **A co-authored document has more than one data subject, and the consent model has one.** At `document` consent, `docContext` carries a collaborator's sentences to the backend and the collaborator agreed to nothing. Flagged for someone who knows the study protocol.
- **The Seedbed needs a logging bypass, not a consent level** — enforced at `useLog`, because a policy that expressive writing goes unreviewed will lose to institutional pressure.
- **The tool launcher's `rooms` primitive is the multi-party plumbing already designed**, currently aimed at one user's several devices.
- **The experiment measures the wrong DV for the WTL claim** — performance with the tool, where the claim needs delayed transfer with no tool present.

Docs only — no code changes.