### PR TITLE
Design: mobile-native interface concepts

### DIFF
--- a/docs/design/mobile-native-concepts.md
+++ b/docs/design/mobile-native-concepts.md
@@ -1,0 +1,558 @@
+# Mobile-Native Interfaces for Thoughtful
+
+*Design sketches — August 2026*
+
+> Companion to [`interface-concepts.md`](./interface-concepts.md) (the five
+> long-horizon concepts) and [`interaction-concepts.md`](./interaction-concepts.md)
+> (the fourteen value-anchored interactions). This note asks one question of both:
+> **is there anything here that would feel more at home on a phone than on a desk?**
+
+The answer is yes, and the reason is not the obvious one. It isn't that phones are
+convenient. It's that this product's central covenant — *the AI never writes your
+prose* — is a rule the desktop has to enforce with willpower and the phone enforces
+with physics.
+
+---
+
+## 1. The thesis: a tool that won't write for you belongs on a device you can't write on
+
+Every concept in the two companion docs is built around a refusal. The AI asks,
+quotes, notices, gathers, resurfaces, narrates, believes, doubts, and fades. Across
+five concepts and fourteen interactions, the verbs that survived sketching were
+*never* "write" or "fix" (interface-concepts.md, Principle 2). The whole design
+problem is keeping the tool on the right side of that line.
+
+On the desktop this is a constant, low-grade fight. The sidebar sits eighteen
+inches from the document, the cursor is already blinking, and every suggestion is
+one ⌘C away from being the writer's next paragraph. Concept after concept has to
+invent machinery to resist it: wet-ink styling that expires if untouched, the debt
+ledger, Blind Rewrite's paste-blocking, "noticed, not decided."
+
+On a phone, that machinery is partly free. Typing a paragraph on glass is
+miserable; typing it *twice* is unthinkable. A surface that is bad at composing
+prose is not a degraded desktop for this product — it is a **purified** one. The
+constraint the desktop has to simulate is simply the hardware.
+
+This flips the usual porting question. The right question is not "how do we fit
+Draft, Revise, and Chat onto a small screen?" It is: **which moments of writing
+happen away from the desk, and what does the tool owe the writer then?**
+
+Notably, the layout half of the port is already done by accident. The navbar and
+page chrome are tuned for the Google Docs sidebar's locked ~300px
+(`frontend/src/components/navbar/styles.module.css`, and the `MAX_CORE_PAGES`
+derivation in `pages/registry.tsx`) — *narrower than an iPhone SE*. Nothing here is
+blocked on responsive CSS. The gap is interaction idiom, not pixels.
+
+---
+
+## 2. What the phone actually has that the desk does not
+
+Five primitives. Everything below is built out of them.
+
+| Primitive | What it is | What it's worth here |
+|---|---|---|
+| **A microphone you carry** | Speech is available in situations where a keyboard isn't | Thinking out loud becomes an *input method*, not a transcription convenience |
+| **Interstitial time** | The queue, the bus, the four minutes before a meeting | Time that is currently lost to writing entirely — not stolen from composing |
+| **Encounter-time capture** | Share sheet, camera, clipboard, wherever you are | You meet the relevant book page, podcast, or screenshot *away from the desk* |
+| **Reading conditions** | Small screen, one thumb, distracted, bright sun | This is your *reader's* situation, and you can't otherwise inhabit it |
+| **Inability to edit comfortably** | The constraint, reframed as a feature | Marking, judging, and noticing without the escape hatch of fixing |
+
+And one primitive that is a liability, addressed in §5: **the notification**, the
+phone's native idiom of interruption, aimed straight at the covenant's fourth
+commitment ("silence is a feature").
+
+---
+
+## 3. Five mobile-native concepts
+
+Each is derived from an existing concept, and each is named with the moment it
+owns rather than the feature it is.
+
+---
+
+### M1 — The Walk
+#### Voice-native My Words, with the eyes-on-screen constraint finally relaxed
+
+**Derived from:** My Words (`frontend/src/pages/my-words/`), and
+[`my-words-voice-native-research.md`](../my-words-voice-native-research.md).
+
+The voice research note commits to **hands-free, eyes-on-screen** — the writer
+speaks, the document and highlights stay visible as shared reference. That note
+calls the eyes-free distinction "load-bearing," and it is: at a desk, eyes-free
+voice is strictly worse, because the screen is right there and free to use.
+
+On a phone in a coat pocket, eyes-free stops being a degradation and becomes the
+*only* available mode — and the one mode the desk can never offer. The Walk is My
+Words with no document view at all.
+
+The reason this works, and works only for this product, is `corpus.ts`. My Words
+may place only the writer's own words — spans lifted verbatim from the document,
+the scratchpad, and *what the writer says to it* — bridged by punctuation and a
+closed set of glue words, enforced in code by `validateText`. Which means a voice
+session cannot produce prose the writer didn't say. **The output of a walk is not
+a draft. It's a shelf of your own sentences, with the machine's fingerprints
+structurally absent.**
+
+```
+┌─────────────────────────────┐
+│  ●  The Walk        14:32   │   ← lock screen / one-thumb
+│                             │
+│   "…so the real problem     │
+│    isn't the cost, it's     │
+│    that nobody trusts the   │
+│    baseline numbers—"       │
+│                             │
+│         ▁▃▅▇▅▃▁             │   listening
+│                             │
+│  ┌───────────────────────┐  │
+│  │ Say that again, the   │  │   ← one move, then yields
+│  │ part about trust?     │  │      (the turn rule from the
+│  └───────────────────────┘  │       interaction-design note)
+│                             │
+│  kept from this walk: 4     │
+│  ─────────────────────────  │
+│  ⏸  pause      ✓  end walk  │
+└─────────────────────────────┘
+```
+
+Arriving back at the desk:
+
+```
+┌─────────────────────────────┐
+│  FROM YOUR WALK · 22 min    │
+│                             │
+│  Nothing here is in your    │
+│  document. These are your   │
+│  words, waiting.            │
+│                             │
+│  ❝ nobody trusts the        │
+│    baseline numbers ❞       │
+│    said twice, 6 min apart  │
+│                             │
+│  ❝ we've been arguing about │
+│    the price of a thing we  │
+│    haven't measured ❞       │
+│                             │
+│  ❝ the audit is the ask ❞   │
+│    ← you paused 9s after    │
+│      this one               │
+│                             │
+│  [→ scratchpad]  [discard]  │
+└─────────────────────────────┘
+```
+
+**What the AI pointedly does not do:** propose sentences, summarize the walk into
+tidy prose, or decide what mattered. It replays. The one inference it makes visible
+is *behavioral* — you said this twice; you went quiet after that — which is evidence
+about the writer, not judgment about the text.
+
+**Why it's more at home here:** the "think-aloud" tradition the research note cites
+holds that speaking recruits different idea-generating pathways than typing. At a
+desk that claim is hard to cash, because the keyboard is right there and speaking
+feels like a worse keyboard. Walking, it's the only channel open. The word-bank
+rule, which reads as a constraint in text, is the entire point in voice.
+
+**Cheapest honest prototype:** no app. A voice memo, transcribed, run through
+`buildCorpus` + `validateText` offline, returned as the shelf above the next
+morning. Measure: does the writer use their own returned phrases, and do they say
+things they wouldn't have typed?
+
+---
+
+### M2 — The Shelf
+#### The Loom's someday shelf, on the device where you actually meet the material
+
+**Derived from:** Concept 4 (The Loom), "the someday shelf" — *a zero-friction
+inbox for sources not yet relevant; the AI's job is patience.*
+
+The someday shelf is described in interface-concepts.md as a panel in a full-window
+editor host. That is the wrong host, and the doc half-admits it: in the storyboard,
+Dr. Okafor is **reading a book chapter** when she flings a reference at the shelf.
+She is not at her desk. Nobody is at their desk when they encounter the thing.
+
+The shelf's defining property is that filing costs zero. On mobile that isn't a
+design goal, it's a system feature already built into the OS: the shelf is a
+**share-sheet target**, plus a camera button, and nothing else.
+
+```
+┌─────────────────────────────┐
+│  ← Share                    │   ← OS share sheet, any app
+│  ┌───┐ ┌───┐ ┌───┐ ┌───┐    │
+│  │   │ │   │ │ ◈ │ │   │    │
+│  └───┘ └───┘ └───┘ └───┘    │
+│   Msg  Mail  Shelf  More    │
+└─────────────────────────────┘
+        ↓  one tap, no dialog
+┌─────────────────────────────┐
+│  ◈  shelved.                │
+│     nothing to file.        │
+└─────────────────────────────┘   ← 1.5s, then gone
+```
+
+The shelf itself, on the rare occasion you open it:
+
+```
+┌─────────────────────────────┐
+│  THE SHELF          41 ⌄    │
+│                             │
+│  ⟲ RESURFACED               │
+│  ┌─────────────────────────┐│
+│  │ "2019 audit.pdf"        ││
+│  │ shelved 5 weeks ago     ││
+│  │                         ││
+│  │ relates to the para-    ││
+│  │ graph you wrote Tuesday ││
+│  │ (cost per student)      ││
+│  │                         ││
+│  │ [open] [not now] [🗑]   ││
+│  └─────────────────────────┘│
+│                             │
+│  RECENT                     │
+│  📷 book p.114 · Tuesday    │
+│  🔗 podcast ep. 212 · Mon   │
+│  ✂ "…attention is a gift"   │
+│                             │
+│  ─────────────────────────  │
+│  composted (17) ⌄           │
+└─────────────────────────────┘
+```
+
+The camera earns its place: photographing a book page is the single fastest path
+from *encountering an idea* to *having it*, and it has no desktop equivalent at all.
+
+**What the AI pointedly does not do:** summarize what you shelved, tag it, organize
+it, or ask you to. Filing is the cost the shelf exists to eliminate. It also does
+not notify — resurfacing waits for you to arrive (§5).
+
+**Why it's more at home here:** this is the clearest case in the whole document
+set. The desktop version of the shelf is strictly worse than the mobile version,
+because the desktop version requires you to still have the thing, and still care,
+by the time you get back to your desk. Automated patience is only worth having if
+capture was free at the moment of encounter.
+
+**Cheapest honest prototype:** a shared note or an email-to-self address as the
+shelf, and a weekly LLM pass over the week's writing to produce at most one
+resurfacing line. Measure: what fraction of shelved items are *ever* opened again —
+and whether resurfacing beats the writer's own memory.
+
+---
+
+### M3 — The Commute Read
+#### Read your draft in your reader's actual conditions, where you can mark but not fix
+
+**Derived from:** Concept 5 (The Table Read) and interaction concept 9 (Skim View /
+Reading Playback).
+
+The Table Read's best moment is in its storyboard, and it's a moment about a phone:
+Rosa realizes "the real reader is not 'the committee' but one hurried program
+officer reading on a phone between meetings," and "that reframe alone changes her
+opening."
+
+The tool simulates that reader on a desktop. On a phone, you can just *be* one.
+
+```
+┌─────────────────────────────┐
+│  ⟵  reading as: the officer │
+│     6 min · one thumb       │
+│  ───────────────────────    │
+│                             │
+│  The district's cost per    │
+│  student has risen 34%      │
+│  since the last review,     │
+│  and the program's own      │
+│  reporting has not kept     │
+│  pace with that change.     │
+│                             │
+│  ░░░░░░░░░░░░░░░░░░░░░░     │  ← below the fold your
+│  ░░░░░░░░░░░░░░░░░░░░░░     │    reader's first screen
+│                             │    ends here
+│  ─────────────────────────  │
+│   😐 lost me    ⏱ too slow   │
+│   ❓ what's the ask?         │
+│  ─────────────────────────  │
+│   🎤 read it aloud          │
+└─────────────────────────────┘
+```
+
+Two things happen here that a desktop cannot stage honestly.
+
+**The fold is real.** On a 375px screen, "what your reader sees before deciding
+whether to keep reading" is not a simulation with a dotted line drawn across it —
+it's just where the screen stops. Every writer knows their opening is too long; very
+few have watched their opening *not fit*.
+
+**Reading aloud is a diagnostic, and the mic is right there.** Tap 🎤 and read your
+own draft out loud. The places your tongue trips, backs up, or re-reads are, with
+uncanny reliability, the places the sentence is broken. The tool records where you
+stumbled and marks those spots — it does not analyze your prose to find them. This
+is the writer's own body producing the evidence, which is about as close to
+"judgment stays home" as an interface can get.
+
+And the crucial constraint: **there is no edit affordance on this screen.** You can
+mark, and marking produces a worklist that's waiting at the desk. You cannot fix,
+because fixing a sentence in situ is how a reading pass becomes a revising pass and
+the read never finishes. On the desktop this rule would have to be enforced by
+disabling something. Here it's just what a phone is like.
+
+**What the AI pointedly does not do:** react, score, suggest, or narrate. On this
+screen the AI's role is *staging* — reading conditions, the fold, the stumble marks.
+The reactions are the writer's own.
+
+**Cheapest honest prototype:** send yourself the draft as a plain web page sized to
+a phone, read it aloud on a walk with the voice memo running, and hand-transcribe
+the stumbles. Measure: do stumble locations predict the revisions the writer
+actually makes?
+
+---
+
+### M4 — The Standing Question
+#### One question, ninety seconds, answerable by thumb or by voice — and it never asks twice
+
+**Derived from:** interaction concepts 4 (Predict-the-Reader) and 7
+(Earn-the-Answer), plus the Charter's renegotiation prompt (Concept 1, Frame 5).
+
+Several concepts hinge on the writer committing to their own answer *before* seeing
+the AI's — the generation effect, made into interaction grammar. On the desktop
+that's friction placed directly in the path of composing, and the honest risk is
+that it gets clicked past.
+
+Broken off as a phone-shaped unit, it stops being friction and becomes the entire
+activity. It has exactly the shape of interstitial time: self-contained, no
+document editing, no context to reload, ninety seconds, one thumb.
+
+```
+┌─────────────────────────────┐
+│                             │
+│   Before I show you mine:   │
+│                             │
+│   Name one question your    │
+│   reader will have that     │
+│   your draft doesn't        │
+│   answer.                   │
+│                             │
+│  ┌───────────────────────┐  │
+│  │                       │  │
+│  └───────────────────────┘  │
+│         🎤  or say it       │
+│                             │
+│                    [skip]   │
+└─────────────────────────────┘
+        ↓
+┌─────────────────────────────┐
+│   You said:                 │
+│   "where the $40k came      │
+│    from"                    │
+│                             │
+│   I had that one too.       │
+│   ────────────────────────  │
+│   I also had:               │
+│   · why now and not in Q3   │
+│   · who owns it after       │
+│     year one                │
+│                             │
+│   overlap, last 6 asks:     │
+│   ▁▂▃▃▅▅   improving        │
+│                             │
+│   [→ worklist]   [done]     │
+└─────────────────────────────┘
+```
+
+That overlap sparkline is the product's actual thesis made checkable: *AI use should
+improve your unaided work*, tracked as how well the writer predicts the AI before
+seeing it. It is also, per interaction-concepts.md's research note, a publishable
+dependent measure.
+
+**What the AI pointedly does not do:** ask more than one. The screen has no "next
+question" button. A second question would convert a moment of reflection into a quiz,
+and the covenant's fourth commitment into a lie.
+
+**Why it's more at home here:** on the desktop this competes with composing, and
+loses. On the phone it competes with nothing — the alternative use of that time is
+the queue.
+
+**Cheapest honest prototype:** it already exists as a prompt. Run it as a daily
+one-question text message during a diary study, with a human tracking overlap.
+Measure: does predicted-vs-actual overlap rise over weeks?
+
+---
+
+### M5 — The Tideline
+#### Your own sentences, months of them, as the one thing worth scrolling
+
+**Derived from:** Concept 3 (Tidelines), element 4 — *progress shown not as a score
+but as a shelf of the writer's own before/after sentences over months.*
+
+The Tidelines wireframe puts the tideline in a Word task pane, where it is a panel
+that competes for attention with the work. It will lose that competition every time,
+because nobody opens a progress panel while writing.
+
+But the artifact itself — a vertical, chronological, image-free feed of short
+excerpts of your own best language — is *precisely* the shape of the thing people
+scroll on phones for pleasure. That is not a cynical observation. It's the one place
+where the phone's most habituated gesture points at something worth looking at.
+
+```
+┌─────────────────────────────┐
+│  YOUR TIDELINE          ⌄   │
+│  ───────────────────────    │
+│                             │
+│   JUNE                      │
+│   ❝ Cancel the vendor       │
+│     contract. Here's why. ❞ │
+│                             │
+│   ─────────                 │
+│   APRIL                     │
+│   ❝ Three things went       │
+│     wrong in Q1; one of     │
+│     them is fixable by      │
+│     June. ❞                 │
+│                             │
+│   ─────────                 │
+│   FEBRUARY                  │
+│   ❝ This memo provides an   │
+│     overview of several     │
+│     considerations… ❞       │
+│                             │
+│   ─────────                 │
+│   these are all yours       │
+│                             │
+│   retired: hedging ✓ (May)  │
+└─────────────────────────────┘
+```
+
+Read-only. No input. No AI text anywhere on the screen — every word is the writer's
+own, dated. The only editorial act is selection, and even that should show its work
+(tap a card to see the document it came from).
+
+**Why it's more at home here:** the desktop version is a panel you open when you
+remember it exists. The phone version is what you look at while the coffee is being
+made — and unlike everything else you'd look at then, reading it makes the case that
+you are getting better at something. Tidelines' stated reward is "reading your own
+tideline"; a phone is where reading-for-its-own-sake actually happens.
+
+**Cheapest honest prototype:** a static page, generated weekly from the existing
+JSONL logs, at a URL the writer bookmarks to their home screen. Zero app. Measure:
+unprompted opens.
+
+---
+
+## 4. What does *not* belong on the phone
+
+Being specific about this is what keeps the list above honest.
+
+- **The Loom's threads, layers, and try-on structures.** Three panes, drag-to-
+  rearrange, contradictory feedback pinned side by side so it can be *looked at
+  together*. Cooper's information landscape needs landscape. This is desktop or
+  nothing; interface-concepts.md already says a task pane can't hold it, and a phone
+  is smaller than a task pane. The phone's honest role is the shelf (M2) and a
+  read-only "what's live" glance.
+- **Revise, as it exists.** Its whole value is doctext links that jump the document
+  to a location (`revise/docTextJump.ts`). Without the document beside it, a jump
+  target is just a quotation.
+- **Draft, as it exists.** It serves the moment the cursor is stuck, which is by
+  definition a moment at the keyboard.
+- **The Charter's negotiation.** Rewriting five candidate criteria in your own words
+  is real writing, and real writing wants a keyboard. What ports is the *check-in*:
+  glance at the marks, notice #3 is dormant, decide to renegotiate later.
+- **Anything with a text field taller than three lines.** A good test.
+
+The pattern: **the phone gets capture, judgment, and reading; the desk keeps
+composition and arrangement.** Every concept in §3 is one of the first three.
+
+---
+
+## 5. The covenant under mobile pressure
+
+The shared covenant's fourth commitment is: *Silence is a feature. Nothing interrupts
+composition.* Weiser's line in the imagined salon is sharper — "the most dangerous
+default in this decade is the assistant that always has something to say."
+
+The phone is the device where that default is most tempting and most damaging,
+because its native idiom is the push notification and push notifications are how
+engagement is bought. A tool aimed at its own obsolescence cannot want engagement.
+
+**Proposed rule, stated plainly enough to be violated visibly:**
+
+> **The phone may collect, and it may show. It may not summon.**
+
+- **Collect** — the shelf, the walk, a stumble mark. Always available, always
+  instant, never initiated by the tool.
+- **Show** — the tideline, the resurfaced card, the overlap sparkline. Present when
+  the writer arrives. Pull, never push.
+- **Summon** — a notification that says *come look at what I found*. Not offered.
+  Not as a setting, not as an opt-in default, not "just for streaks."
+
+Two consequences worth accepting up front. The Loom's resurfacing (M2) becomes
+*strictly* arrival-triggered: the 2019 audit waits on the shelf until Dr. Okafor
+opens it, and if she never opens it, the resurfacing was worth nothing — which is
+the correct price for the rule. And M4's Standing Question can never tap you on the
+shoulder; it can only be there when you look. A home-screen widget is the sharpest
+form of this: maximally glanceable, structurally incapable of interrupting.
+
+If a writer explicitly negotiates one recurring nudge for themselves — the Charter's
+weekly check-in, say — that is a Charter term, versioned and renegotiable like every
+other, and it should live in `history ▾` where they can see they chose it.
+
+---
+
+## 6. What the codebase already has
+
+A mobile companion here is closer to a fourth surface than a new product. Four
+pieces are already built and load-bearing:
+
+- **`detectPlatform()`** (`frontend/src/api/index.ts`) already returns
+  `word | google-docs | standalone`, with `EditorAPI` as the seam. A phone companion
+  is a fourth branch whose `EditorAPI` is mostly *unimplemented on purpose* — no
+  insert, no selection-jump. Which is exactly §1's argument, expressed as an
+  interface.
+- **Device authorization, RFC 8628** (`frontend/src/api/deviceAuth.ts`). The flow
+  for "pair this other device to my session" exists and is tested against the
+  backend. Pairing a phone to a desk session is the flow it was built for.
+- **Handoff grants with a document snapshot** (`frontend/src/api/handoff.ts`,
+  `backend/src/toolGrants.ts`, `docs/tool-launcher-plan.md`). The taskpane can
+  already mint a single-use, scope-limited grant carrying a read-only doc snapshot,
+  delivered in a URL fragment. "Send this draft to my phone for the commute read"
+  (M3) is `createHandoff` with `scopes: ['doc:read']` and a QR code instead of an
+  `openInBrowser` call.
+- **Layout at 300px.** Already the design constraint (`MAX_CORE_PAGES`,
+  `navbar/styles.module.css`), and narrower than the phones in question.
+
+What genuinely doesn't exist yet: a realtime voice session that survives the screen
+locking (M1), share-sheet registration (M2, needs a real installed app or a PWA
+share target), and per-session cost metering for voice — the reason My Words is
+flagged off in `pages/registry.tsx` today.
+
+Worth noting the current posture, too: `backlog/tasks/task-25` describes a study
+gate that **blocks mobile devices outright**. That's correct for the experiment's
+three-panel task layout, and it is worth being explicit that nothing here proposes
+relaxing it. These are different surfaces for different moments, not a responsive
+version of the same screen.
+
+---
+
+## 7. The five at a glance
+
+| | Moment it owns | Phone primitive | Derived from | Ports to desktop? |
+|---|---|---|---|---|
+| **The Walk** | Away from the desk, thinking | microphone + interstitial time | My Words voice | Worse — the keyboard competes |
+| **The Shelf** | Encountering material | share sheet + camera | Loom, someday shelf | Worse — you no longer have the thing |
+| **The Commute Read** | Before sending | reader's conditions + no edit affordance | Table Read, Skim View | Worse — the fold is simulated |
+| **The Standing Question** | Four spare minutes | interstitial time | Predict-the-Reader, Earn-the-Answer | Worse — competes with composing |
+| **The Tideline** | Idle attention | the scroll gesture | Tidelines | Worse — a panel nobody opens |
+
+The right-hand column is the actual answer to the question this note opened with.
+All five are *better* on the phone, and for the same underlying reason: each one
+depends on the writer **not being able to immediately act on what they've seen.**
+The gap between noticing and fixing is where the thinking happens, and the phone
+enforces that gap for free.
+
+**If only one gets built: The Shelf (M2).** It has the largest gap between mobile
+and desktop value, the smallest surface area, no realtime infrastructure, no model
+call in the capture path at all, and it makes the Loom — the biggest and least
+tractable of the five original concepts — testable years before the Loom itself
+could ship.
+
+**Sleeper pick: The Commute Read (M3),** because it needs no new backend at all —
+`createHandoff` with `doc:read` and a QR code — and because "watch your own opening
+not fit on the screen" is the kind of demo that changes a writer's mind in eight
+seconds.

--- a/docs/design/prototypes/mobile-native-prototype.html
+++ b/docs/design/prototypes/mobile-native-prototype.html
@@ -1,0 +1,1066 @@
+<title>Five phones — mobile-native concept prototype</title>
+<style>
+  /* ============================================================
+     Prototype for docs/design/mobile-native-concepts.md.
+
+     Inherits the design system already established in
+     interface-concepts-prototype.html — warm paper, blue accent,
+     and the load-bearing rule that the WRITER'S prose renders in
+     serif while the TOOL'S chrome renders in sans. That split
+     enacts the covenant "the writer's sentences are the writer's,"
+     and on these screens it does extra work: you can see at a
+     glance that the AI is never the one holding the serif.
+
+     Two tokens added for this note:
+       --live   a recording/mic state, semantic, not the accent
+       --bezel  the device frame the screens sit inside
+     ============================================================ */
+
+  :root {
+    --paper:      #f0ede6;
+    --surface:    #ffffff;
+    --surface-2:  #faf9f6;
+    --surface-3:  #f4f1ea;
+    --border:     rgba(28,24,18,0.10);
+    --border-2:   rgba(28,24,18,0.16);
+    --ink:        #201d18;
+    --ink-2:      #6b665c;
+    --ink-3:      #a7a094;
+    --accent:     #2d5be3;
+    --accent-bg:  #f3f5ff;
+    --accent-bd:  #c4caff;
+    --for:        #2f7d55;
+    --for-bg:     #eef6f0;
+    --against:    #b4562b;
+    --against-bg: #f8efe8;
+    --wet:        #7a63d6;
+    --wet-bg:     #f4f1fb;
+    --dormant:    #b6afa2;
+    --live:       #c2452b;
+    --live-bg:    #fbeeea;
+    --bezel:      #1b1814;
+    --bezel-2:    #2f2a24;
+
+    --shadow: 0 1px 2px rgba(28,24,18,.05), 0 12px 34px rgba(28,24,18,.10);
+    --shadow-device: 0 2px 6px rgba(28,24,18,.10), 0 30px 60px rgba(28,24,18,.22);
+    --radius: 12px;
+    --radius-sm: 8px;
+    --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --serif: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper:#201d18; --surface:#2a2621; --surface-2:#302b25; --surface-3:#35302a;
+      --border:rgba(255,248,236,0.10); --border-2:rgba(255,248,236,0.18);
+      --ink:#f2ede3; --ink-2:#b6afa2; --ink-3:#837c70;
+      --accent:#9db2ff; --accent-bg:#2b3050; --accent-bd:#3f4a7a;
+      --for:#7fc79c; --for-bg:#253328; --against:#e0a07a; --against-bg:#3a2c22;
+      --wet:#b7a4f0; --wet-bg:#322b46; --dormant:#6f685c;
+      --live:#f0917a; --live-bg:#3d2620;
+      --bezel:#0d0b09; --bezel-2:#1c1915;
+      --shadow: 0 1px 2px rgba(0,0,0,.3), 0 18px 44px rgba(0,0,0,.45);
+      --shadow-device: 0 2px 6px rgba(0,0,0,.4), 0 34px 70px rgba(0,0,0,.6);
+    }
+  }
+  :root[data-theme="light"] {
+    --paper:#f0ede6; --surface:#fff; --surface-2:#faf9f6; --surface-3:#f4f1ea;
+    --border:rgba(28,24,18,.10); --border-2:rgba(28,24,18,.16);
+    --ink:#201d18; --ink-2:#6b665c; --ink-3:#a7a094;
+    --accent:#2d5be3; --accent-bg:#f3f5ff; --accent-bd:#c4caff;
+    --for:#2f7d55; --for-bg:#eef6f0; --against:#b4562b; --against-bg:#f8efe8;
+    --wet:#7a63d6; --wet-bg:#f4f1fb; --dormant:#b6afa2;
+    --live:#c2452b; --live-bg:#fbeeea;
+    --bezel:#1b1814; --bezel-2:#2f2a24;
+    --shadow:0 1px 2px rgba(28,24,18,.05),0 12px 34px rgba(28,24,18,.10);
+    --shadow-device:0 2px 6px rgba(28,24,18,.10),0 30px 60px rgba(28,24,18,.22);
+  }
+  :root[data-theme="dark"] {
+    --paper:#201d18; --surface:#2a2621; --surface-2:#302b25; --surface-3:#35302a;
+    --border:rgba(255,248,236,.10); --border-2:rgba(255,248,236,.18);
+    --ink:#f2ede3; --ink-2:#b6afa2; --ink-3:#837c70;
+    --accent:#9db2ff; --accent-bg:#2b3050; --accent-bd:#3f4a7a;
+    --for:#7fc79c; --for-bg:#253328; --against:#e0a07a; --against-bg:#3a2c22;
+    --wet:#b7a4f0; --wet-bg:#322b46; --dormant:#6f685c;
+    --live:#f0917a; --live-bg:#3d2620;
+    --bezel:#0d0b09; --bezel-2:#1c1915;
+    --shadow:0 1px 2px rgba(0,0,0,.3),0 18px 44px rgba(0,0,0,.45);
+    --shadow-device:0 2px 6px rgba(0,0,0,.4),0 34px 70px rgba(0,0,0,.6);
+  }
+
+  * { box-sizing: border-box; }
+
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 24px 96px; }
+
+  /* ---------- masthead ---------- */
+
+  .masthead { padding: 72px 0 40px; max-width: 660px; }
+  .eyebrow {
+    font-size: 11px; letter-spacing: .14em; text-transform: uppercase;
+    color: var(--ink-3); margin: 0 0 20px;
+  }
+  h1 {
+    font-family: var(--serif);
+    font-size: clamp(30px, 4.4vw, 46px);
+    line-height: 1.12; font-weight: 400; margin: 0 0 22px;
+    text-wrap: balance; letter-spacing: -0.01em;
+  }
+  .standfirst { font-size: 17px; color: var(--ink-2); margin: 0 0 18px; max-width: 58ch; }
+  .standfirst strong { color: var(--ink); font-weight: 600; }
+
+  .thesis {
+    margin: 32px 0 0; padding: 20px 22px;
+    border-left: 2px solid var(--accent);
+    background: var(--accent-bg);
+    border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+    font-family: var(--serif); font-size: 18px; line-height: 1.5;
+  }
+
+  .legend {
+    display: flex; flex-wrap: wrap; gap: 8px 22px;
+    margin: 34px 0 0; padding-top: 20px; border-top: 1px solid var(--border);
+    font-size: 12.5px; color: var(--ink-2);
+  }
+  .legend span { display: inline-flex; align-items: center; gap: 8px; }
+  .swatch { width: 22px; height: 3px; border-radius: 2px; display: inline-block; }
+
+  /* ---------- concept sections ---------- */
+
+  .concept {
+    display: grid;
+    grid-template-columns: 320px minmax(0, 1fr);
+    gap: 52px;
+    align-items: start;
+    padding: 56px 0;
+    border-top: 1px solid var(--border);
+  }
+  @media (max-width: 840px) {
+    .concept { grid-template-columns: minmax(0,1fr); gap: 34px; justify-items: center; }
+    .concept__text { justify-self: stretch; }
+  }
+
+  .concept__text { padding-top: 6px; }
+  .tag {
+    display: inline-block; font-size: 11px; letter-spacing: .12em;
+    text-transform: uppercase; color: var(--accent);
+    border: 1px solid var(--accent-bd); background: var(--accent-bg);
+    padding: 3px 9px; border-radius: 999px; margin-bottom: 14px;
+  }
+  h2 {
+    font-family: var(--serif); font-size: 29px; font-weight: 400;
+    margin: 0 0 6px; line-height: 1.2; text-wrap: balance;
+  }
+  .owns { font-size: 15px; color: var(--ink-2); margin: 0 0 20px; font-style: italic; }
+  .concept__text p { margin: 0 0 15px; font-size: 15.5px; max-width: 60ch; }
+  .concept__text p:last-child { margin-bottom: 0; }
+
+  .derives {
+    font-size: 12.5px; color: var(--ink-2); margin: 0 0 20px;
+    padding-bottom: 16px; border-bottom: 1px dashed var(--border-2);
+  }
+  .derives code { font-family: var(--mono); font-size: 11.5px; }
+
+  .never {
+    margin-top: 22px; padding: 14px 16px;
+    background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: var(--radius-sm); font-size: 14px; color: var(--ink-2);
+  }
+  .never b {
+    display: block; font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--ink-3); margin-bottom: 6px; font-weight: 600;
+  }
+
+  /* ---------- the device ---------- */
+
+  .device {
+    width: 320px;
+    background: var(--bezel);
+    border-radius: 40px;
+    padding: 12px;
+    box-shadow: var(--shadow-device);
+    position: sticky; top: 28px;
+  }
+  @media (max-width: 840px) { .device { position: static; } }
+
+  .device__screen {
+    background: var(--surface);
+    border-radius: 30px;
+    height: 580px;
+    overflow: hidden;
+    position: relative;
+    display: flex; flex-direction: column;
+  }
+
+  .statusbar {
+    flex: 0 0 auto;
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 12px 22px 6px;
+    font-size: 11.5px; color: var(--ink-3);
+    font-variant-numeric: tabular-nums;
+  }
+  .statusbar .dots { letter-spacing: .1em; }
+
+  .screen {
+    flex: 1 1 auto; display: none; flex-direction: column;
+    overflow: hidden; min-height: 0;
+  }
+  .screen.is-on { display: flex; }
+
+  .screen__body { flex: 1 1 auto; overflow-y: auto; padding: 6px 20px 16px; min-height: 0; }
+  .screen__foot {
+    flex: 0 0 auto; padding: 12px 20px 22px;
+    border-top: 1px solid var(--border);
+    display: flex; gap: 8px; align-items: center;
+  }
+
+  .apphead {
+    flex: 0 0 auto; padding: 4px 20px 12px;
+    display: flex; align-items: baseline; justify-content: space-between;
+  }
+  .apphead h3 {
+    margin: 0; font-size: 11.5px; letter-spacing: .13em; text-transform: uppercase;
+    font-weight: 600; color: var(--ink-2);
+  }
+  .apphead .meta { font-size: 11.5px; color: var(--ink-3); font-variant-numeric: tabular-nums; }
+
+  /* writer's words: always serif. tool chrome: always sans. */
+  .writer { font-family: var(--serif); }
+
+  .btn {
+    font-family: var(--sans); font-size: 13.5px; font-weight: 500;
+    padding: 9px 14px; border-radius: 999px; cursor: pointer;
+    border: 1px solid var(--border-2); background: var(--surface-2); color: var(--ink);
+    transition: background .15s ease, border-color .15s ease;
+  }
+  .btn:hover { background: var(--surface-3); border-color: var(--ink-3); }
+  .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  /* The accent flips light in dark mode, so the primary button's label has to
+     flip with it — white-on-pale-blue would be unreadable. */
+  .btn--primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+  @media (prefers-color-scheme: dark) { .btn--primary { color: #1b2140; } }
+  :root[data-theme="light"] .btn--primary { color: #fff; }
+  :root[data-theme="dark"] .btn--primary { color: #1b2140; }
+  /* `.btn:hover` is (0,2,0) and would otherwise beat the (0,1,0) variant rules,
+     repainting a primary button with the neutral hover fill while its label
+     stays white — invisible on cream. Every variant restates its own hover. */
+  .btn--primary:hover { background: var(--accent); border-color: var(--accent); filter: brightness(1.08); }
+  .btn--live { background: var(--live-bg); border-color: var(--live); color: var(--live); }
+  .btn--live:hover { background: var(--live-bg); border-color: var(--live); filter: brightness(.97); }
+  .btn--wide { flex: 1 1 auto; }
+  .btn--ghost { background: transparent; border-color: transparent; color: var(--ink-3); }
+  .btn--ghost:hover { background: var(--surface-2); border-color: var(--border); }
+
+  /* ---------- M1 the walk ---------- */
+
+  .live-dot {
+    width: 7px; height: 7px; border-radius: 50%; background: var(--live);
+    display: inline-block; margin-right: 7px;
+    animation: pulse 1.8s ease-in-out infinite;
+  }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .25; } }
+
+  .heard {
+    font-family: var(--serif); font-size: 19px; line-height: 1.45;
+    color: var(--ink); margin: 18px 0 26px;
+  }
+  .heard .settling { color: var(--ink-3); }
+
+  .wave {
+    display: flex; align-items: flex-end; justify-content: center;
+    gap: 4px; height: 42px; margin: 0 0 26px;
+  }
+  .wave i {
+    width: 4px; background: var(--live); border-radius: 2px; opacity: .8;
+    animation: bounce 1.1s ease-in-out infinite;
+  }
+  @keyframes bounce { 0%,100% { height: 6px; } 50% { height: 34px; } }
+  .wave.is-paused i { animation-play-state: paused; height: 6px; }
+
+  .partner {
+    background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: var(--radius); padding: 13px 15px; font-size: 14.5px;
+    color: var(--ink-2);
+  }
+  .partner .who {
+    font-size: 10.5px; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--ink-3); display: block; margin-bottom: 5px;
+  }
+  .yield { font-size: 12px; color: var(--ink-3); margin-top: 10px; font-style: italic; }
+
+  .kept-count {
+    margin-top: 22px; padding-top: 14px; border-top: 1px solid var(--border);
+    font-size: 12.5px; color: var(--ink-3); font-variant-numeric: tabular-nums;
+  }
+
+  .disclaimer {
+    font-size: 13px; color: var(--ink-2); background: var(--surface-3);
+    border-radius: var(--radius-sm); padding: 11px 13px; margin: 4px 0 18px;
+  }
+
+  .phrase {
+    border-left: 2px solid var(--border-2); padding: 2px 0 2px 14px; margin: 0 0 20px;
+  }
+  .phrase q {
+    font-family: var(--serif); font-size: 16.5px; line-height: 1.4;
+    quotes: "\201C" "\201D"; display: block;
+  }
+  .phrase .obs { font-size: 12px; color: var(--ink-2); margin-top: 6px; display: block; }
+
+  /* ---------- M2 the shelf ---------- */
+
+  .sharesheet {
+    position: absolute; inset: auto 0 0 0; z-index: 3;
+    background: var(--surface-2); border-top: 1px solid var(--border-2);
+    border-radius: 22px 22px 30px 30px; padding: 16px 16px 26px;
+    transform: translateY(0); transition: transform .3s ease;
+  }
+  .sharesheet.is-gone { transform: translateY(105%); }
+  .sharesheet .label { font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--ink-3); margin-bottom: 12px; }
+  .targets { display: flex; gap: 12px; }
+  .target { flex: 1 1 0; text-align: center; font-size: 11px; color: var(--ink-2); }
+  .target .icon {
+    height: 52px; border-radius: 14px; background: var(--surface-3);
+    border: 1px solid var(--border); margin-bottom: 6px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 18px; color: var(--ink-3);
+  }
+  .target--shelf .icon {
+    background: var(--accent-bg); border-color: var(--accent-bd); color: var(--accent);
+    cursor: pointer;
+  }
+  .target--shelf .icon:hover { filter: brightness(.97); }
+  .target--shelf .icon:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+  .toast {
+    position: absolute; left: 50%; top: 50%; z-index: 4;
+    transform: translate(-50%, -50%) scale(.94);
+    background: var(--bezel-2); color: #f2ede3;
+    padding: 16px 22px; border-radius: var(--radius);
+    text-align: center; font-size: 14px; line-height: 1.4;
+    opacity: 0; pointer-events: none; transition: opacity .25s ease, transform .25s ease;
+  }
+  .toast.is-on { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  .toast small { display: block; color: var(--dormant); font-size: 12px; margin-top: 3px; }
+
+  .resurfaced {
+    border: 1px solid var(--accent-bd); background: var(--accent-bg);
+    border-radius: var(--radius); padding: 14px; margin-bottom: 22px;
+  }
+  .resurfaced .why { font-size: 13.5px; color: var(--ink-2); margin: 8px 0 12px; }
+  .resurfaced .row { display: flex; gap: 7px; }
+  .resurfaced .btn { padding: 6px 11px; font-size: 12.5px; }
+
+  .shelf-item {
+    display: flex; gap: 11px; align-items: baseline;
+    padding: 11px 0; border-bottom: 1px solid var(--border); font-size: 14px;
+  }
+  .shelf-item .k { color: var(--ink-3); font-size: 13px; width: 16px; flex: 0 0 auto; }
+  .shelf-item .when { margin-left: auto; color: var(--ink-3); font-size: 12px; flex: 0 0 auto; }
+
+  .subhead {
+    font-size: 10.5px; letter-spacing: .13em; text-transform: uppercase;
+    color: var(--ink-3); margin: 0 0 10px;
+  }
+
+  /* ---------- M3 the commute read ---------- */
+
+  .draft { font-family: var(--serif); font-size: 16px; line-height: 1.62; }
+  .draft p { margin: 0 0 16px; }
+
+  .fold {
+    position: relative; margin: 4px 0 20px; height: 1px;
+    background: repeating-linear-gradient(90deg, var(--against) 0 5px, transparent 5px 10px);
+  }
+  .fold span {
+    position: absolute; right: 0; top: -9px; background: var(--surface);
+    padding-left: 8px; font-size: 10.5px; letter-spacing: .1em;
+    text-transform: uppercase; color: var(--against);
+  }
+
+  .stumble { background: transparent; border-bottom: 2px solid transparent; transition: background .4s ease, border-color .4s ease; }
+  .is-marked .stumble { background: var(--live-bg); border-bottom-color: var(--live); }
+
+  .stumble-note {
+    font-family: var(--sans); font-size: 12.5px; color: var(--live);
+    margin: -8px 0 16px; display: none;
+  }
+  .is-marked .stumble-note { display: block; }
+
+  .marks { display: flex; gap: 6px; flex-wrap: wrap; }
+  .marks .btn { padding: 7px 11px; font-size: 12.5px; }
+
+  .no-edit {
+    font-size: 11.5px; color: var(--ink-3); text-align: center;
+    padding: 8px 0 0; font-style: italic;
+  }
+
+  /* ---------- M4 standing question ---------- */
+
+  .ask {
+    font-family: var(--serif); font-size: 21px; line-height: 1.35;
+    margin: 32px 0 24px;
+  }
+  .ask .pre { display: block; font-size: 14px; color: var(--ink-3); font-family: var(--sans); margin-bottom: 14px; }
+
+  .field {
+    width: 100%; font-family: var(--serif); font-size: 16px; color: var(--ink);
+    background: var(--surface-2); border: 1px solid var(--border-2);
+    border-radius: var(--radius-sm); padding: 12px; resize: none; min-height: 74px;
+  }
+  .field:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+  .mic-line { text-align: center; font-size: 12.5px; color: var(--ink-3); margin: 12px 0 0; }
+
+  .yours { margin: 26px 0 0; }
+  .yours .lab { font-size: 11px; letter-spacing: .12em; text-transform: uppercase; color: var(--ink-3); }
+  .yours q { font-family: var(--serif); font-size: 17px; display: block; margin-top: 5px; }
+
+  .verdict {
+    margin: 20px 0; padding: 12px 14px; border-radius: var(--radius-sm);
+    background: var(--for-bg); color: var(--for); font-size: 14.5px; font-weight: 500;
+  }
+  .theirs { list-style: none; padding: 0; margin: 0 0 22px; }
+  .theirs li {
+    font-family: var(--serif); font-size: 15.5px; color: var(--ink-2);
+    padding: 7px 0 7px 16px; border-left: 2px solid var(--border-2);
+    margin-bottom: 6px;
+  }
+
+  .spark { display: flex; align-items: flex-end; gap: 4px; height: 32px; margin: 8px 0 6px; }
+  .spark i { width: 12px; background: var(--accent-bd); border-radius: 2px 2px 0 0; }
+  .spark i:last-child { background: var(--accent); }
+  .spark-lab { font-size: 12px; color: var(--ink-2); }
+
+  /* ---------- M5 tideline ---------- */
+
+  .tide { padding-top: 4px; }
+  .tide__month {
+    font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase;
+    color: var(--ink-3); margin: 0 0 8px;
+  }
+  .tide__card {
+    font-family: var(--serif); font-size: 17px; line-height: 1.44;
+    padding: 0 0 26px; margin: 0 0 26px; border-bottom: 1px solid var(--border);
+  }
+  .tide__card:last-of-type { border-bottom: none; }
+  .tide__card q { quotes: "\201C" "\201D"; }
+  .tide__src {
+    display: block; font-family: var(--sans); font-size: 11.5px;
+    color: var(--ink-2); margin-top: 9px;
+  }
+  .tide__close { font-size: 13px; color: var(--ink-3); text-align: center; padding: 8px 0 0; }
+  .retired { font-size: 12.5px; color: var(--for); margin-top: 16px; }
+
+  /* ---------- closing ---------- */
+
+  .closing { padding: 60px 0 0; border-top: 1px solid var(--border); }
+  .closing h2 { font-size: 27px; margin-bottom: 18px; }
+  .closing p { max-width: 62ch; font-size: 15.5px; color: var(--ink-2); }
+  .closing p strong { color: var(--ink); }
+
+  .table-wrap { overflow-x: auto; margin: 30px 0 0; }
+  table { border-collapse: collapse; width: 100%; min-width: 620px; font-size: 14px; }
+  th, td { text-align: left; padding: 11px 14px 11px 0; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th {
+    font-size: 10.5px; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--ink-3); font-weight: 600; border-bottom-color: var(--border-2);
+  }
+  td:first-child { font-weight: 600; white-space: nowrap; }
+  .worse { color: var(--ink-3); }
+
+  .not-here {
+    margin: 40px 0 0; padding: 22px 24px;
+    background: var(--surface-2); border: 1px solid var(--border);
+    border-radius: var(--radius);
+  }
+  .not-here h3 { margin: 0 0 12px; font-size: 15px; }
+  .not-here ul { margin: 0; padding-left: 20px; color: var(--ink-2); font-size: 14.5px; }
+  .not-here li { margin-bottom: 7px; }
+
+  .footnote { margin-top: 44px; font-size: 13px; color: var(--ink-2); }
+  .footnote code { font-family: var(--mono); font-size: 12px; }
+
+  @media (prefers-reduced-motion: reduce) {
+    * { animation-duration: .001ms !important; animation-iteration-count: 1 !important; transition-duration: .001ms !important; }
+  }
+</style>
+
+<div class="wrap">
+
+  <header class="masthead">
+    <p class="eyebrow">Thoughtful · design sketches · August 2026</p>
+    <h1>Five phones for a tool that refuses to write.</h1>
+    <p class="standfirst">
+      Companion prototype to <strong>docs/design/mobile-native-concepts.md</strong>.
+      Each screen below is walkable — tap through it. Every one is derived from a
+      concept that already exists on paper for the desktop.
+    </p>
+    <div class="thesis">
+      The covenant says the AI never writes your prose. On the desktop that rule
+      needs machinery to enforce — wet ink that expires, blocked paste, debt
+      ledgers. On a phone, it's just what the hardware is like.
+    </div>
+    <div class="legend">
+      <span><i class="swatch" style="background:var(--ink)"></i> serif = the writer's own words</span>
+      <span><i class="swatch" style="background:var(--ink-3)"></i> sans = the tool's chrome</span>
+      <span><i class="swatch" style="background:var(--live)"></i> the microphone, live</span>
+    </div>
+  </header>
+
+  <!-- ============ M1 THE WALK ============ -->
+  <section class="concept">
+    <div class="device">
+      <div class="device__screen">
+        <div class="statusbar"><span>14:32</span><span class="dots">▂▄▆ ⌁ 78%</span></div>
+
+        <div class="screen is-on" id="walk-live">
+          <div class="apphead">
+            <h3><i class="live-dot"></i>The Walk</h3>
+            <span class="meta" id="walk-timer">08:14</span>
+          </div>
+          <div class="screen__body">
+            <p class="heard">
+              “…so the real problem isn't the cost, it's that nobody trusts the
+              baseline numbers<span class="settling">—</span>”
+            </p>
+            <div class="wave" id="walk-wave" aria-hidden="true">
+              <i style="animation-delay:0s"></i><i style="animation-delay:.12s"></i>
+              <i style="animation-delay:.24s"></i><i style="animation-delay:.36s"></i>
+              <i style="animation-delay:.18s"></i><i style="animation-delay:.06s"></i>
+              <i style="animation-delay:.3s"></i><i style="animation-delay:.42s"></i>
+              <i style="animation-delay:.15s"></i>
+            </div>
+            <div class="partner">
+              <span class="who">your partner</span>
+              Say that again — the part about trust?
+              <div class="yield">one move, then it yields the floor</div>
+            </div>
+            <p class="kept-count">kept from this walk: 4</p>
+          </div>
+          <div class="screen__foot">
+            <button class="btn btn--wide" id="walk-pause" type="button">⏸ Pause</button>
+            <button class="btn btn--primary btn--wide" id="walk-end" type="button">End walk</button>
+          </div>
+        </div>
+
+        <div class="screen" id="walk-after">
+          <div class="apphead">
+            <h3>From your walk</h3><span class="meta">22 min</span>
+          </div>
+          <div class="screen__body">
+            <p class="disclaimer">
+              Nothing here is in your document. These are your words, waiting.
+            </p>
+            <div class="phrase">
+              <q class="writer">nobody trusts the baseline numbers</q>
+              <span class="obs">you said this twice, six minutes apart</span>
+            </div>
+            <div class="phrase">
+              <q class="writer">we've been arguing about the price of a thing we haven't measured</q>
+            </div>
+            <div class="phrase">
+              <q class="writer">the audit is the ask</q>
+              <span class="obs">you went quiet for nine seconds after this one</span>
+            </div>
+          </div>
+          <div class="screen__foot">
+            <button class="btn btn--primary btn--wide" type="button">→ Scratchpad</button>
+            <button class="btn btn--ghost" id="walk-back" type="button">↺ replay</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="concept__text">
+      <span class="tag">M1</span>
+      <h2>The Walk</h2>
+      <p class="owns">Owns the moment you're away from the desk and still thinking.</p>
+      <p class="derives">
+        Derived from My&nbsp;Words (<code>pages/my-words/</code>) and
+        <code>docs/my-words-voice-native-research.md</code>
+      </p>
+      <p>
+        The voice research note commits to <em>hands-free, eyes-on-screen</em>, and calls
+        the eyes-free distinction load-bearing. It is — at a desk. There, eyes-free is
+        strictly worse, because the screen is right there and free to use. In a coat
+        pocket it's the only mode available, and the only one the desk can never offer.
+      </p>
+      <p>
+        This works here and nowhere else because of <code>corpus.ts</code>. My Words may
+        place only spans lifted verbatim from the writer's own corpus — document,
+        scratchpad, and <em>what the writer says to it</em> — bridged by punctuation and a
+        closed set of glue words, enforced in code by <code>validateText</code>. A voice
+        session structurally cannot produce prose the writer didn't say.
+      </p>
+      <p>
+        So the output of a walk is not a draft. It's a shelf of your own sentences, with
+        the machine's fingerprints absent by construction.
+      </p>
+      <div class="never">
+        <b>What it doesn't do</b>
+        Propose sentences, tidy the walk into prose, or decide what mattered. It replays.
+        The only inference it shows is behavioral — you said this twice, you went quiet
+        after that — which is evidence about the writer, not judgment about the text.
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ M2 THE SHELF ============ -->
+  <section class="concept">
+    <div class="device">
+      <div class="device__screen">
+        <div class="statusbar"><span>18:05</span><span class="dots">▂▄▆ ⌁ 64%</span></div>
+
+        <div class="screen is-on" id="shelf-share">
+          <div class="apphead"><h3>Reading · ch. 4</h3><span class="meta">Books</span></div>
+          <div class="screen__body">
+            <p class="draft writer" style="color:var(--ink-2)">
+              …the district had, in effect, been budgeting against a number that no
+              one had audited since the reorganization. Trust in the figure had
+              become a proxy for trust in the office that produced it, and once
+              that slipped, every later argument about cost was really an argument
+              about credibility.
+            </p>
+          </div>
+          <div class="sharesheet" id="sheet">
+            <div class="label">Share</div>
+            <div class="targets">
+              <div class="target"><div class="icon">✉</div>Mail</div>
+              <div class="target"><div class="icon">💬</div>Messages</div>
+              <div class="target target--shelf">
+                <div class="icon" id="shelf-drop" role="button" tabindex="0" aria-label="Save to the shelf">◈</div>Shelf
+              </div>
+              <div class="target"><div class="icon">···</div>More</div>
+            </div>
+          </div>
+          <div class="toast" id="shelf-toast">
+            ◈ &nbsp;shelved.
+            <small>nothing to file.</small>
+          </div>
+        </div>
+
+        <div class="screen" id="shelf-view">
+          <div class="apphead"><h3>The Shelf</h3><span class="meta">41</span></div>
+          <div class="screen__body">
+            <p class="subhead">⟲ resurfaced</p>
+            <div class="resurfaced">
+              <strong style="font-size:14.5px">“2019 audit.pdf”</strong>
+              <p class="why">
+                Shelved five weeks ago. Relates to the paragraph you wrote Tuesday
+                — cost per student.
+              </p>
+              <div class="row">
+                <button class="btn btn--primary" type="button">Open</button>
+                <button class="btn" type="button">Not now</button>
+                <button class="btn btn--ghost" type="button">🗑</button>
+              </div>
+            </div>
+            <p class="subhead">recent</p>
+            <div class="shelf-item"><span class="k">✂</span><span>“trust in the figure had become a proxy…”</span><span class="when">now</span></div>
+            <div class="shelf-item"><span class="k">📷</span><span>book, p.114</span><span class="when">Tue</span></div>
+            <div class="shelf-item"><span class="k">🔗</span><span>podcast ep. 212</span><span class="when">Mon</span></div>
+            <div class="shelf-item"><span class="k">📷</span><span>whiteboard, budget mtg</span><span class="when">Fri</span></div>
+            <div class="shelf-item" style="border-bottom:none"><span class="k">🔗</span><span>Tocqueville, ch. 9</span><span class="when">3 wk</span></div>
+            <p class="tide__close" style="text-align:left;padding-top:14px">composted (17) ⌄</p>
+          </div>
+          <div class="screen__foot">
+            <button class="btn btn--ghost btn--wide" id="shelf-back" type="button">↺ replay the capture</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="concept__text">
+      <span class="tag">M2</span>
+      <h2>The Shelf</h2>
+      <p class="owns">Owns the moment you encounter the material — anywhere but your desk.</p>
+      <p class="derives">Derived from Concept 4, The Loom — “the someday shelf”</p>
+      <p>
+        The someday shelf is specced as a panel in a full-window editor. That's the wrong
+        host, and the original storyboard half-admits it: Dr. Okafor is <em>reading a book
+        chapter</em> when she flings a reference at the shelf. Nobody is at their desk when
+        they meet the thing.
+      </p>
+      <p>
+        Its defining property is that filing costs zero — and on mobile that isn't a
+        design goal, it's an OS feature. The shelf is a share-sheet target, plus a camera
+        button, and nothing else. Photographing a book page is the fastest path from
+        encountering an idea to having it, and it has no desktop equivalent at all.
+      </p>
+      <p>
+        Tap the <strong>◈ Shelf</strong> target to see the whole capture interaction. It is
+        one tap and 1.5 seconds, and then it is over.
+      </p>
+      <div class="never">
+        <b>What it doesn't do</b>
+        Summarize, tag, or organize what you shelved — filing is the cost the shelf exists
+        to eliminate. It also never notifies. Resurfacing waits for you to arrive.
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ M3 THE COMMUTE READ ============ -->
+  <section class="concept">
+    <div class="device">
+      <div class="device__screen">
+        <div class="statusbar"><span>08:41</span><span class="dots">▂▄▆ ⌁ 51%</span></div>
+        <div class="screen is-on" id="read-screen">
+          <div class="apphead">
+            <h3>Reading as: the officer</h3><span class="meta">6 min</span>
+          </div>
+          <div class="screen__body" id="read-body">
+            <div class="draft">
+              <p>
+                The district's cost per student has risen 34% since the last
+                review, and the program's own reporting has not kept pace with
+                that change. <span class="stumble">Given the constraints under which the current
+                reporting framework was originally established, it is
+                understandable that the figures available to the committee may
+                not reflect present conditions.</span>
+              </p>
+              <p class="stumble-note">↑ you backed up and re-read this twice</p>
+              <div class="fold"><span>your reader's first screen ends</span></div>
+              <p>
+                Since 2021, the office has published its figures annually, in a
+                format inherited from the pre-reorganization structure.
+              </p>
+              <p>
+                <span class="stumble">What we are asking for is a one-time independent audit of the
+                baseline.</span>
+              </p>
+              <p class="stumble-note">↑ you sped up here — the ask, four paragraphs in</p>
+              <p>
+                The cost is $40,000, roughly one percent of the program's annual
+                administrative spend.
+              </p>
+            </div>
+          </div>
+          <div class="screen__foot" style="flex-direction:column;align-items:stretch;gap:9px">
+            <div class="marks">
+              <button class="btn" type="button">😐 lost me</button>
+              <button class="btn" type="button">⏱ too slow</button>
+              <button class="btn" type="button">❓ what's the ask?</button>
+            </div>
+            <button class="btn btn--live" id="read-aloud" type="button">🎤 Read it aloud</button>
+            <p class="no-edit">no edit affordance on this screen</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="concept__text">
+      <span class="tag">M3</span>
+      <h2>The Commute Read</h2>
+      <p class="owns">Owns the moment before you send it.</p>
+      <p class="derives">Derived from Concept 5, The Table Read · interaction concept 9, Skim View</p>
+      <p>
+        The Table Read's best moment is in its storyboard, and it's a moment about a
+        phone: Rosa realizes the real reader is “one hurried program officer reading on a
+        phone between meetings,” and that reframe alone changes her opening. The tool
+        simulates that reader on a desktop. On a phone you can simply be one.
+      </p>
+      <p>
+        <strong>The fold is real.</strong> Scroll the screen: where your reader decides
+        whether to keep going isn't a dotted line drawn across a simulation, it's where
+        the glass stops. Every writer knows their opening runs long; few have watched it
+        not fit.
+      </p>
+      <p>
+        <strong>Reading aloud is a diagnostic, and the mic is right there.</strong> Tap it.
+        Where your tongue trips, backs up, or re-reads is — with uncanny reliability —
+        where the sentence is broken. The tool records the stumbles; it doesn't analyze
+        your prose to find them. The writer's own body produces the evidence.
+      </p>
+      <p>
+        And there is no way to edit here. You mark, and the marks are waiting at the desk.
+        Fixing a sentence in place is how a reading pass becomes a revising pass and the
+        read never finishes. On the desktop that rule needs a disabled button.
+      </p>
+      <div class="never">
+        <b>What it doesn't do</b>
+        React, score, suggest, or narrate. On this screen the AI's whole job is staging —
+        the reading conditions, the fold, the stumble marks. The reactions are yours.
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ M4 THE STANDING QUESTION ============ -->
+  <section class="concept">
+    <div class="device">
+      <div class="device__screen">
+        <div class="statusbar"><span>11:56</span><span class="dots">▂▄▆ ⌁ 43%</span></div>
+
+        <div class="screen is-on" id="q-ask">
+          <div class="apphead"><h3>Standing question</h3><span class="meta">≈90s</span></div>
+          <div class="screen__body">
+            <p class="ask">
+              <span class="pre">Before I show you mine:</span>
+              Name one question your reader will have that your draft doesn't answer.
+            </p>
+            <textarea class="field" id="q-field" aria-label="Your answer">where the $40k came from</textarea>
+            <p class="mic-line">🎤 &nbsp;or say it</p>
+          </div>
+          <div class="screen__foot">
+            <button class="btn btn--primary btn--wide" id="q-commit" type="button">Commit</button>
+            <button class="btn btn--ghost" type="button">Skip</button>
+          </div>
+        </div>
+
+        <div class="screen" id="q-reveal">
+          <div class="apphead"><h3>Standing question</h3><span class="meta">1 of 1</span></div>
+          <div class="screen__body">
+            <div class="yours">
+              <span class="lab">you said</span>
+              <q class="writer" id="q-echo">where the $40k came from</q>
+            </div>
+            <p class="verdict">✓ I had that one too.</p>
+            <p class="subhead">I also had</p>
+            <ul class="theirs">
+              <li>Why now, and not in Q3?</li>
+              <li>Who owns this after year one?</li>
+            </ul>
+            <p class="subhead">overlap, last six asks</p>
+            <div class="spark" aria-hidden="true">
+              <i style="height:20%"></i><i style="height:33%"></i><i style="height:47%"></i>
+              <i style="height:47%"></i><i style="height:73%"></i><i style="height:80%"></i>
+            </div>
+            <p class="spark-lab">improving — you're predicting me more often</p>
+          </div>
+          <div class="screen__foot">
+            <button class="btn btn--primary btn--wide" type="button">→ Worklist</button>
+            <button class="btn btn--ghost" id="q-back" type="button">↺ again</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="concept__text">
+      <span class="tag">M4</span>
+      <h2>The Standing Question</h2>
+      <p class="owns">Owns the four spare minutes in a queue.</p>
+      <p class="derives">Derived from interaction concepts 4 (Predict-the-Reader) and 7 (Earn-the-Answer)</p>
+      <p>
+        Several concepts hinge on the writer committing to their own answer before seeing
+        the AI's — the generation effect, made into interaction grammar. On the desktop
+        that's friction placed directly in the path of composing, and the honest risk is
+        that it gets clicked past.
+      </p>
+      <p>
+        Broken off as a phone-shaped unit, it stops being friction and becomes the whole
+        activity. It has exactly the shape of interstitial time: self-contained, no
+        document editing, no context to reload, ninety seconds, one thumb.
+      </p>
+      <p>
+        The sparkline is the product's thesis made checkable. <em>AI use should improve
+        your unaided work</em>, tracked as how well the writer predicts the AI before seeing
+        it — which is also a publishable dependent measure.
+      </p>
+      <div class="never">
+        <b>What it doesn't do</b>
+        Ask a second question. There is no “next” button. Two questions turns a moment of
+        reflection into a quiz, and the covenant's fourth commitment into a lie.
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ M5 THE TIDELINE ============ -->
+  <section class="concept">
+    <div class="device">
+      <div class="device__screen">
+        <div class="statusbar"><span>07:12</span><span class="dots">▂▄▆ ⌁ 92%</span></div>
+        <div class="screen is-on">
+          <div class="apphead"><h3>Your tideline</h3><span class="meta">6 months</span></div>
+          <div class="screen__body tide">
+            <p class="tide__month">June</p>
+            <p class="tide__card"><q class="writer">Cancel the vendor contract. Here's why.</q>
+              <span class="tide__src">Q2 procurement memo · June 14</span></p>
+
+            <p class="tide__month">April</p>
+            <p class="tide__card"><q class="writer">Three things went wrong in Q1; one of them is fixable by June.</q>
+              <span class="tide__src">Program update · April 2</span></p>
+
+            <p class="tide__month">March</p>
+            <p class="tide__card"><q class="writer">The audit is the ask.</q>
+              <span class="tide__src">Faculty senate proposal · March 3</span></p>
+
+            <p class="tide__month">February</p>
+            <p class="tide__card"><q class="writer">This memo provides an overview of several considerations relating to the current reporting framework…</q>
+              <span class="tide__src">Program update · February 9</span></p>
+
+            <p class="tide__close">these are all yours</p>
+            <p class="retired">retired: hedging ✓ (May)</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="concept__text">
+      <span class="tag">M5</span>
+      <h2>The Tideline</h2>
+      <p class="owns">Owns idle attention — the two minutes while the coffee is made.</p>
+      <p class="derives">Derived from Concept 3, Tidelines — “a shelf of the writer's own sentences over months”</p>
+      <p>
+        Tidelines puts this in a Word task pane, where it becomes a progress panel
+        competing with the work. It loses that competition every time, because nobody
+        opens a progress panel while writing.
+      </p>
+      <p>
+        But the artifact itself — a vertical, chronological, image-free feed of short
+        excerpts of your own best language — is precisely the shape of the thing people
+        scroll on phones for pleasure. That isn't a cynical observation. It's the one
+        place where the phone's most habituated gesture points at something worth
+        looking at.
+      </p>
+      <p>
+        Scroll from June back to February and the case makes itself. No score was
+        assigned. The evidence of growth is the language.
+      </p>
+      <div class="never">
+        <b>What it doesn't do</b>
+        Anything. There is no input on this screen and no AI-written word on it. The only
+        editorial act is selection, and even that shows its work — every card names the
+        document it came from.
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ CLOSING ============ -->
+  <section class="closing">
+    <h2>All five are better on the phone, for one reason</h2>
+    <p>
+      Each depends on the writer <strong>not being able to immediately act on what they've
+      just seen</strong>. The gap between noticing and fixing is where the thinking happens,
+      and the phone enforces that gap for free.
+    </p>
+
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr><th>Concept</th><th>Moment it owns</th><th>Phone primitive</th><th>Ported to desktop</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>The Walk</td><td>Away from the desk, thinking</td><td>Microphone + interstitial time</td><td class="worse">Worse — the keyboard competes</td></tr>
+          <tr><td>The Shelf</td><td>Encountering material</td><td>Share sheet + camera</td><td class="worse">Worse — you no longer have the thing</td></tr>
+          <tr><td>The Commute Read</td><td>Before sending</td><td>Reader's conditions; no edit affordance</td><td class="worse">Worse — the fold is simulated</td></tr>
+          <tr><td>The Standing Question</td><td>Four spare minutes</td><td>Interstitial time</td><td class="worse">Worse — competes with composing</td></tr>
+          <tr><td>The Tideline</td><td>Idle attention</td><td>The scroll gesture</td><td class="worse">Worse — a panel nobody opens</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="not-here">
+      <h3>What stays on the desk</h3>
+      <ul>
+        <li><strong>The Loom's threads, layers, and try-on structures.</strong> Contradictory feedback has to be lookable-at <em>together</em>. Cooper's information landscape needs landscape.</li>
+        <li><strong>Revise, as it exists.</strong> Its value is doctext links that jump the document. Without the document beside it, a jump target is just a quotation.</li>
+        <li><strong>Draft, as it exists.</strong> It serves the moment the cursor is stuck — by definition a moment at the keyboard.</li>
+        <li><strong>The Charter's negotiation.</strong> Rewriting criteria in your own words is real writing, and real writing wants a keyboard. Only the check-in ports.</li>
+        <li><strong>Anything with a text field taller than three lines.</strong> A good test.</li>
+      </ul>
+    </div>
+
+    <div class="not-here" style="background:var(--accent-bg);border-color:var(--accent-bd)">
+      <h3>The rule that keeps this from becoming an engagement product</h3>
+      <p style="margin:0 0 10px;font-size:15.5px;font-family:var(--serif)">
+        The phone may collect, and it may show. It may not summon.
+      </p>
+      <p style="margin:0;font-size:14.5px;color:var(--ink-2)">
+        Collect and show are pull, always available, never initiated by the tool. Summon —
+        a notification saying <em>come look at what I found</em> — is not offered, not as a
+        setting, not as an opt-in default, not for streaks. The price is real: the
+        resurfaced audit waits on the shelf until you open it, and if you never open it,
+        the resurfacing was worth nothing. That's the correct price for the rule.
+      </p>
+    </div>
+
+    <p class="footnote">
+      Prototype for <code>docs/design/mobile-native-concepts.md</code>. Interactions are
+      staged, not wired to a backend. The design system — warm paper, blue accent, and the
+      serif/sans split that marks the writer's words from the tool's — is inherited from
+      <code>interface-concepts-prototype.html</code>.
+    </p>
+  </section>
+</div>
+
+<script>
+  /* Screen switching: every "screen" lives in one device; showing one hides
+     its siblings. Kept deliberately dumb — these are staged states, not an app. */
+  function show(id) {
+    var el = document.getElementById(id);
+    if (!el) return;
+    var siblings = el.parentNode.querySelectorAll('.screen');
+    for (var i = 0; i < siblings.length; i++) siblings[i].classList.remove('is-on');
+    el.classList.add('is-on');
+  }
+  function on(id, event, fn) {
+    var el = document.getElementById(id);
+    if (el) el.addEventListener(event, fn);
+  }
+
+  /* --- M1 The Walk --- */
+  var walkSeconds = 494;
+  var walkTicking = true;
+  var timerEl = document.getElementById('walk-timer');
+  setInterval(function () {
+    if (!walkTicking) return;
+    walkSeconds += 1;
+    var m = String(Math.floor(walkSeconds / 60)).padStart(2, '0');
+    var s = String(walkSeconds % 60).padStart(2, '0');
+    if (timerEl) timerEl.textContent = m + ':' + s;
+  }, 1000);
+
+  on('walk-pause', 'click', function () {
+    walkTicking = !walkTicking;
+    document.getElementById('walk-wave').classList.toggle('is-paused', !walkTicking);
+    this.textContent = walkTicking ? '⏸ Pause' : '▶ Resume';
+  });
+  on('walk-end', 'click', function () { walkTicking = false; show('walk-after'); });
+  on('walk-back', 'click', function () { walkTicking = true; show('walk-live'); });
+
+  /* --- M2 The Shelf: capture is one tap and 1.5 seconds --- */
+  function shelveIt() {
+    var sheet = document.getElementById('sheet');
+    var toast = document.getElementById('shelf-toast');
+    sheet.classList.add('is-gone');
+    toast.classList.add('is-on');
+    setTimeout(function () {
+      toast.classList.remove('is-on');
+      setTimeout(function () {
+        show('shelf-view');
+        sheet.classList.remove('is-gone');
+      }, 260);
+    }, 1500);
+  }
+  on('shelf-drop', 'click', shelveIt);
+  on('shelf-drop', 'keydown', function (e) {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); shelveIt(); }
+  });
+  on('shelf-back', 'click', function () { show('shelf-share'); });
+
+  /* --- M3 The Commute Read: reading aloud marks where you stumbled --- */
+  on('read-aloud', 'click', function () {
+    var body = document.getElementById('read-body');
+    var marked = body.classList.toggle('is-marked');
+    this.textContent = marked ? '⏹ Stop — 2 stumbles marked' : '🎤 Read it aloud';
+    if (marked) body.scrollTop = 0;
+  });
+
+  /* --- M4 The Standing Question --- */
+  on('q-commit', 'click', function () {
+    var typed = document.getElementById('q-field').value.trim();
+    if (typed) document.getElementById('q-echo').textContent = typed;
+    show('q-reveal');
+  });
+  on('q-back', 'click', function () { show('q-ask'); });
+</script>


### PR DESCRIPTION
Docs only — no code changes. A companion to `docs/design/interface-concepts.md` and `docs/design/interaction-concepts.md`, asking one question of both: **is there anything here that would feel more at home on a phone than on a desk?**

## The thesis

The answer is yes, and not for the obvious reason. Every concept in the two existing notes is built around a refusal — the AI asks, quotes, notices, gathers, resurfaces, and fades, but never writes. Keeping the tool on the right side of that line is the whole design problem, and on the desktop it takes machinery: wet ink that expires if untouched, the debt ledger, Blind Rewrite's blocked paste, "noticed, not decided."

On a phone, much of that machinery is free. A surface that is bad at composing prose is not a degraded desktop for this product — it's a purified one. So the porting question isn't "how do we fit Draft, Revise and Chat onto a small screen," it's "which moments of writing happen away from the desk, and what does the tool owe the writer then?"

## Five concepts

Each is derived from an existing sketch, and each is *better* on the phone for the same underlying reason: it depends on the writer **not being able to immediately act on what they've just seen**.

| | Moment it owns | Derived from |
|---|---|---|
| **The Walk** | Away from the desk, thinking | My Words voice research |
| **The Shelf** | Encountering the material | The Loom's someday shelf |
| **The Commute Read** | Before you send it | The Table Read · Skim View |
| **The Standing Question** | Four spare minutes | Predict-the-Reader · Earn-the-Answer |
| **The Tideline** | Idle attention | Tidelines |

The Walk is the one that only works here: `corpus.ts` and `validateText` mean a voice session structurally cannot place words the writer didn't say, so the output of a walk is a shelf of their own sentences rather than a draft.

## Also covered

- **What stays on the desk** — the Loom's threads and try-on structures, Revise (its doctext links need the document beside them), Draft, and the Charter's negotiation. Being specific about this is what keeps the list honest.
- **A proposed notification rule.** The phone's native idiom is interruption; the covenant's fourth commitment is that silence is a feature. Proposed: *the phone may collect, and it may show. It may not summon.* The note states the price of that rule rather than hiding it.
- **What already exists in the codebase.** A mobile companion is closer to a fourth surface than a new product: `detectPlatform()` already has the seam, `deviceAuth.ts` already implements RFC 8628 pairing, and `handoff.ts` already mints scope-limited grants carrying a read-only doc snapshot — which is most of the Commute Read. Layout is already tuned to 300px, narrower than the phones in question.
- Notes that `backlog/tasks/task-25`'s mobile gate on the experiment is correct and that nothing here proposes relaxing it — these are different surfaces for different moments, not a responsive version of the same screen.

## Files

- `docs/design/mobile-native-concepts.md` — the note
- `docs/design/prototypes/mobile-native-prototype.html` — a walkable prototype of all five, following the existing prototype convention

The prototype inherits the design system from `interface-concepts-prototype.html`, including the serif/sans split that marks the writer's words apart from the tool's chrome — which does extra work on these screens, since you can see at a glance that the AI never holds the serif.

Verified in headless Chromium: all five screens walk through their states, no console or page errors, no horizontal overflow, and both themes render correctly (including the `data-theme` override beating the media query in both directions). Fixed one cascade collision found in review — `.btn:hover` at specificity (0,2,0) was overriding `.btn--primary` at (0,1,0), repainting primary buttons with the neutral hover fill while their labels stayed white, i.e. invisible on cream.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JiH3Jgg69yEUcnY66VyD6G)_