### PR TITLE
Pair @ai-sdk/openai with ai so the model needs no compatibility shim

### DIFF
--- a/docs/ai-sdk-upstream-wishlist.md
+++ b/docs/ai-sdk-upstream-wishlist.md
@@ -1,0 +1,118 @@
+# AI SDK upstream wishlist
+
+Things `frontend/src/api/errors.ts` and `generate.ts` do that arguably belong in
+the AI SDK, written down while the reasons are fresh. **Nothing here is filed
+upstream and nothing is blocked on it** — this is context for a future us who
+either takes one of these to the `vercel/ai` tracker or, more likely, has to
+re-derive why our error layer looks the way it does after a version bump moves
+the ground again.
+
+Versions this was written against: `ai@7.0.52`, `@ai-sdk/openai@4.0.30`,
+`@ai-sdk/provider@4.0.5`, `@ai-sdk/provider-utils@5.0.21`. Line references are
+to those builds in `node_modules` and will drift.
+
+Worth saying up front what is *not* on this list: mapping a provider error code
+to a sentence a writer can act on ("the AI account is out of credit, tell the
+team"), and deciding whether to offer Retry. That is product copy and product
+judgement, it is the reason `errors.ts` exists, and no SDK should own it.
+
+## 1. No retry predicate, so terminal errors still cost a full backoff
+
+`streamText` takes `maxRetries` and nothing else — there is no `shouldRetry`
+hook, though `@ai-sdk/provider-utils` has the `ShouldRetryFunction` type and
+`retryWithExponentialBackoff` internally.
+
+This bites because of how `@ai-sdk/openai` classifies quota failures. An `error`
+frame arriving before any output is thrown rather than streamed, and
+`getStatusCode` (`@ai-sdk/openai/dist/index.js:214`) maps `insufficient_quota`
+and `rate_limit` alike to **429**, which `APICallError` treats as retryable by
+default (`@ai-sdk/provider/dist/index.js:52`). So a billing failure — as
+terminal as an error gets, and one we deliberately show with Retry hidden — is
+attempted three times with backoff before the writer is told anything. Roughly
+five seconds of a spinner promising something that cannot happen.
+
+We can't fix it locally without also giving up retries for genuinely transient
+failures, since `maxRetries` is not per-error. What we'd want is either a
+caller-supplied predicate, or for the provider to stop laundering
+`insufficient_quota` through a status code that means "come back later".
+
+## 2. `RetryError` buries the failure it was retrying
+
+When the attempts run out, `ai` throws a `RetryError` whose `message` is only
+`Failed after 3 attempts. Last error: …`. Describing that value directly costs
+you the provider's code and its message — you get the generic
+"something went wrong, try again", which is the exact opposite of the truth for
+a quota failure.
+
+`lastError` is public, so unwrapping is easy *once you know to do it*. We only
+found out because an E2E test went red. It would be kinder if the wrapper
+carried the last attempt's `data`/`statusCode` forward, or if the SDK shipped a
+documented "describe the real cause" unwrap. See `retriedFailure` in
+`errors.ts`.
+
+## 3. `isAbortError` is in the wrong package and answers the wrong question
+
+`@ai-sdk/provider-utils` exports `isAbortError` (`dist/index.js:1216`), which
+`ai` does not re-export. Using it means taking a direct dependency on
+`provider-utils` — a package we otherwise only touch transitively — for one
+predicate.
+
+And it wouldn't replace `abortKind` anyway. It doesn't walk the `cause` chain,
+and it lumps `TimeoutError` in with `AbortError`, where we need them apart:
+"that took too long and was stopped" and "that request was cancelled" are
+different things to tell a writer, and only one of them is their own doing.
+
+Wanted: `isAbortError` re-exported from `ai`, cause-walking, and reporting
+*which* kind. We kept our own for now; the cost is that new abort spellings the
+SDK learns (it already knows Next.js's `ResponseAborted`) don't reach us.
+
+## 4. A dead network arrives in two shapes, one of them message-matched
+
+`handleFetchError` (`provider-utils/dist/index.js:1242`) rewrites a
+`TypeError: Failed to fetch` that carries a `cause` into an `APICallError` with
+no status and the message `Cannot connect to API: …`. Without a `cause` it
+passes the TypeError through untouched. Which one you get depends on the
+runtime: undici always sets `cause`, browsers often don't.
+
+So a caller wanting to say "check your connection" has to handle both, and the
+only thing identifying the wrapped form is that message prefix — there's no
+`isNetworkError`, and the wrapper doesn't set a code or a distinguishing marker
+class. We match the prefix in `isNetworkFailure` and are stuck with the fact
+that an upstream copy edit would silently regress it into "something went
+wrong". A `NetworkError` subclass, or any stable flag, would fix that.
+
+This one already cost us: the wrapped shape fell through to the generic message
+until we went looking.
+
+## 5. Error-body extraction is provider-shaped and stops at the HTTP boundary
+
+`@ai-sdk/openai` parses non-2xx bodies against `openaiErrorDataSchema` and hangs
+the result on `APICallError.data` — good, and we now read that first. But it
+covers exactly one envelope shape and only the HTTP path. It doesn't reach
+in-stream `error` frames, and it doesn't survive a proxy that re-wraps the
+error (`{error:{error:{…}}}`, which ours does hit).
+
+So `findProviderError` stays: a small recursive dig for the innermost
+`{code, message}` regardless of nesting or origin. A generic "pull the provider
+error out of whatever this is" helper would be the thing to upstream, and is
+probably the most reusable item on this list.
+
+`getErrorMessage` (`@ai-sdk/provider/dist/index.js:91`) is not that helper — it's
+`String` / `.toString()` / `JSON.stringify`, and for an `APICallError` it returns
+the class name plus message rather than what the provider actually said.
+
+## 6. A one-version-behind model spec degrades in silence
+
+This is what started all of it. `ai` accepts a model whose `specificationVersion`
+is older than its own by wrapping it in a compatibility shim. Two versions
+behind, it logs a warning — that's the console message that opened the
+investigation. **One** version behind, it shims silently
+(`asLanguageModelV4`, `ai/dist/index.js:811`), which is what you land on if you
+bump the provider and not `ai`.
+
+So the natural half-fix for a compatibility warning is to swap a loud mismatch
+for a quiet one. Wanted: a warning for any shimmed model, or a supported way to
+ask "is this model being shimmed?" — we ended up asserting it by capturing
+`AI_SDK_LOG_WARNINGS` and comparing against `MockLanguageModelV4`'s spec
+(`frontend/src/api/__tests__/openai.test.ts`), which works but leans on a mock
+class to learn what the runtime natively speaks.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -84,8 +84,9 @@ throw on model or transport errors: it puts them in the stream as an `error` par
 and `result.textStream` forwards only `text-delta` parts. A failed generation is
 therefore indistinguishable from an empty successful one — the loop ends, `await
 result.text` gives `''`, and the surrounding `try/catch` never runs. That is how a
-quota failure reached writers as a blank panel. The helpers read `fullStream`
-instead and throw a `GenerationError`.
+quota failure reached writers as a blank panel. The helpers read the full `stream`
+instead (`fullStream` is the deprecated alias for it) and throw a
+`GenerationError`.
 
 Catch it, run the value through `describeGenerationError` (`src/api/errors.ts`),
 and render the result with `<GenerationErrorNotice>`
@@ -94,6 +95,25 @@ text behind a "Technical details" toggle, and Retry only when `info.retryable`.
 Log `info.detail` (provider text) and `info.code`, not the sentence shown on
 screen. A successful-but-empty generation is also a visible outcome (`tone="info"`
 notice), never silence.
+
+Not every failure arrives as a stream part. An `error` event that reaches us
+*before* any output is raised by the provider as an `APICallError` carrying the
+status the error maps to, and `ai` retries whatever that status marks retryable
+— so a quota failure (429) surfaces only after the attempts run out, wrapped in
+a `RetryError` whose own message is just "Failed after 3 attempts…".
+`describeGenerationError` unwraps that to the last attempt; anything else that
+learns to read errors directly has to unwrap it too, or the writer gets the
+generic "something went wrong, try again" for a problem retrying cannot fix.
+The visible cost is latency: a terminal error now waits out the backoff before
+it appears.
+
+**`ai` and `@ai-sdk/openai` are upgraded as a pair.** Each model object declares
+a `specificationVersion`, and `ai` accepts an older one by wrapping it in a
+back-compat shim — logging `The feature "specificationVersion" is used in a
+compatibility mode` when it is two specs behind, and saying nothing at all when
+it is one behind. So a half-upgrade degrades quietly rather than breaking.
+`src/api/__tests__/openai.test.ts` holds that pairing: it drives the shared
+`languageModel` over a stubbed Responses stream and fails if a shim is involved.
 
 **The system prompt goes in `instructions`, never in `messages`.** Since ai@7, a
 `role: 'system'` message inside `messages` fails validation before the request

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -115,6 +115,10 @@ it is one behind. So a half-upgrade degrades quietly rather than breaking.
 `src/api/__tests__/openai.test.ts` holds that pairing: it drives the shared
 `languageModel` over a stubbed Responses stream and fails if a shim is involved.
 
+Where `errors.ts` looks like it is reimplementing the SDK, it usually is, and
+`docs/ai-sdk-upstream-wishlist.md` says why for each case — read it before
+"simplifying" that file against a newer SDK.
+
 **The system prompt goes in `instructions`, never in `messages`.** Since ai@7, a
 `role: 'system'` message inside `messages` fails validation before the request
 leaves the browser — `InvalidPromptError: System messages are not allowed in the

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,14 +9,14 @@
 			"version": "0.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@ai-sdk/openai": "^2.0.109",
-				"@ai-sdk/otel": "^1.0.0",
-				"@ai-sdk/react": "^4.0.0",
+				"@ai-sdk/openai": "^4.0.30",
+				"@ai-sdk/otel": "^1.0.52",
+				"@ai-sdk/react": "^4.0.55",
 				"@lexical/react": "^0.45.0",
 				"@posthog/react": "^1.9.0",
 				"@react-hook/window-size": "^3.1.1",
 				"@types/node": "^24.6.2",
-				"ai": "^7.0.0",
+				"ai": "^7.0.52",
 				"jotai": "^2.12.5",
 				"lexical": "^0.45.0",
 				"posthog-js": "^1.388.1",
@@ -74,11 +74,13 @@
 			}
 		},
 		"node_modules/@ai-sdk/gateway": {
-			"version": "4.0.28",
+			"version": "4.0.41",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-4.0.41.tgz",
+			"integrity": "sha512-DPkDmmA336kqmIp62on550/6Q6JHvldsnvN1SmkwU8QGrVt1PzFxqyKUn0C5EGGmSBpvF1ohZNtvWNl8gEVugA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/provider": "4.0.3",
-				"@ai-sdk/provider-utils": "5.0.12",
+				"@ai-sdk/provider": "4.0.5",
+				"@ai-sdk/provider-utils": "5.0.21",
 				"@vercel/oidc": "3.2.0"
 			},
 			"engines": {
@@ -88,38 +90,14 @@
 				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
-		"node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider": {
-			"version": "4.0.3",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"json-schema": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=22"
-			}
-		},
-		"node_modules/@ai-sdk/gateway/node_modules/@ai-sdk/provider-utils": {
-			"version": "5.0.12",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "4.0.3",
-				"@standard-schema/spec": "^1.1.0",
-				"@workflow/serde": "4.1.0",
-				"eventsource-parser": "^3.0.8"
-			},
-			"engines": {
-				"node": ">=22"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
 		"node_modules/@ai-sdk/mcp": {
-			"version": "2.0.16",
+			"version": "2.0.25",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-2.0.25.tgz",
+			"integrity": "sha512-TEQXa2UCl2963LYaVKjRkFi0zqRraCcY5jAcVqoUjzaiKdkMWuRYjhx8wvZ9UXpqj5NjkXczZovjCLHaX/TiTg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/provider": "4.0.3",
-				"@ai-sdk/provider-utils": "5.0.12",
+				"@ai-sdk/provider": "4.0.5",
+				"@ai-sdk/provider-utils": "5.0.21",
 				"pkce-challenge": "^5.0.1"
 			},
 			"engines": {
@@ -129,108 +107,77 @@
 				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
-		"node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider": {
-			"version": "4.0.3",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"json-schema": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=22"
-			}
-		},
-		"node_modules/@ai-sdk/mcp/node_modules/@ai-sdk/provider-utils": {
-			"version": "5.0.12",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "4.0.3",
-				"@standard-schema/spec": "^1.1.0",
-				"@workflow/serde": "4.1.0",
-				"eventsource-parser": "^3.0.8"
-			},
-			"engines": {
-				"node": ">=22"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
 		"node_modules/@ai-sdk/openai": {
-			"version": "2.0.117",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-2.0.117.tgz",
-			"integrity": "sha512-fqr2OwpegPlS58NUAat4+6cAOR/x1askt5dXKY1rCjDyhHJYxm2OZM9fZnG9I717ny4uRSp2mhsMio2uthA0Pg==",
+			"version": "4.0.30",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-4.0.30.tgz",
+			"integrity": "sha512-QyM0ucRiKUIQpgTyNaG2azXB0EiJStcfG2bwtDlPH1iBpL9yjUhdcohCTHyC2VesgqVD2dwt9o1O1XJyOt3FtA==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/provider": "2.0.3",
-				"@ai-sdk/provider-utils": "3.0.31"
+				"@ai-sdk/provider": "4.0.5",
+				"@ai-sdk/provider-utils": "5.0.21"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=22"
 			},
 			"peerDependencies": {
 				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/@ai-sdk/otel": {
-			"version": "1.0.37",
+			"version": "1.0.52",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/otel/-/otel-1.0.52.tgz",
+			"integrity": "sha512-3JlG76w6UDHnAEkJfd0rHP5G+Isf7IYTkUouDuJ77pGVJ0noCTGNVgLTV2aF0tHGqRpDp+v56ZcojyA9ZsvSpw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/provider": "4.0.3",
+				"@ai-sdk/provider": "4.0.5",
 				"@opentelemetry/api": "1.9.1",
-				"ai": "7.0.37"
-			},
-			"engines": {
-				"node": ">=22"
-			}
-		},
-		"node_modules/@ai-sdk/otel/node_modules/@ai-sdk/provider": {
-			"version": "4.0.3",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"json-schema": "^0.4.0"
+				"ai": "7.0.52"
 			},
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@ai-sdk/provider": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.3.tgz",
-			"integrity": "sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-4.0.5.tgz",
+			"integrity": "sha512-9WAerTaPU2jcVi8dh8x27tySEuLur1Kfg7Go74GuCmsC/2MDSvrTkrK8ZrXWjryEevKfcPPmO1enveE7eqlzoA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"json-schema": "^0.4.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=22"
 			}
 		},
 		"node_modules/@ai-sdk/provider-utils": {
-			"version": "3.0.31",
-			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.31.tgz",
-			"integrity": "sha512-hlxLxqbdV+f7gBpL2SbLL+UhjV+DfUpJ28J4vSHekVV9fiTRrhqcd/ewJwaVbR/ahtLCGJPAVYzj+yJzaddc6g==",
+			"version": "5.0.21",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-5.0.21.tgz",
+			"integrity": "sha512-Q4z27c5vqKuXZN65QuF7FVm+uvm3qxEioiQ+8c3s5xXlhbE1Y/SLGBB4BuF+UWia4KaDu2HmNpdR1RGW02/eGg==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/provider": "2.0.3",
-				"@standard-schema/spec": "^1.0.0",
-				"eventsource-parser": "^3.0.6",
-				"undici": "^5.29.0"
+				"@ai-sdk/provider": "4.0.5",
+				"@standard-schema/spec": "^1.1.0",
+				"@workflow/serde": "4.1.0",
+				"eventsource-parser": "^3.0.8",
+				"undici": "^7.28.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=22"
 			},
 			"peerDependencies": {
 				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/@ai-sdk/react": {
-			"version": "4.0.40",
+			"version": "4.0.55",
+			"resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-4.0.55.tgz",
+			"integrity": "sha512-eEtWwlfgeFNGzGZuuJce3IxTkDX2nFamkA/siBFYdjfQa37vmDwfkCo9zhhGhkxaLUr6mib55tJV8itsJm+sSw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/mcp": "2.0.16",
-				"@ai-sdk/provider": "4.0.3",
-				"@ai-sdk/provider-utils": "5.0.12",
-				"ai": "7.0.37",
+				"@ai-sdk/mcp": "2.0.25",
+				"@ai-sdk/provider": "4.0.5",
+				"@ai-sdk/provider-utils": "5.0.21",
+				"ai": "7.0.52",
 				"swr": "^2.4.1",
 				"throttleit": "2.1.0"
 			},
@@ -239,32 +186,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
-			}
-		},
-		"node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider": {
-			"version": "4.0.3",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"json-schema": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=22"
-			}
-		},
-		"node_modules/@ai-sdk/react/node_modules/@ai-sdk/provider-utils": {
-			"version": "5.0.12",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "4.0.3",
-				"@standard-schema/spec": "^1.1.0",
-				"@workflow/serde": "4.1.0",
-				"eventsource-parser": "^3.0.8"
-			},
-			"engines": {
-				"node": ">=22"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -1965,15 +1886,6 @@
 			"dev": true,
 			"license": "MIT",
 			"peer": true
-		},
-		"node_modules/@fastify/busboy": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			}
 		},
 		"node_modules/@feathersjs/hooks": {
 			"version": "0.6.5",
@@ -5216,9 +5128,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5240,9 +5149,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5264,9 +5170,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5288,9 +5191,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5312,9 +5212,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5336,9 +5233,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5610,9 +5504,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5630,9 +5521,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5650,9 +5538,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5670,9 +5555,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5690,9 +5572,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5710,9 +5589,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5887,9 +5763,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5904,9 +5777,6 @@
 				"arm"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5921,9 +5791,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5938,9 +5805,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5955,9 +5819,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5972,9 +5833,6 @@
 				"loong64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -5989,9 +5847,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6006,9 +5861,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6023,9 +5875,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6040,9 +5889,6 @@
 				"riscv64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6057,9 +5903,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6074,9 +5917,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6091,9 +5931,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6332,9 +6169,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6352,9 +6186,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6372,9 +6203,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -6392,9 +6220,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -7101,6 +6926,8 @@
 		},
 		"node_modules/@vercel/oidc": {
 			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+			"integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 20"
@@ -7297,38 +7124,14 @@
 			}
 		},
 		"node_modules/ai": {
-			"version": "7.0.37",
+			"version": "7.0.52",
+			"resolved": "https://registry.npmjs.org/ai/-/ai-7.0.52.tgz",
+			"integrity": "sha512-sEgRnYA+ddJ1rJSz1uKBjkGbOXhXdon1nvno49fVk3tabnlf8v5SaceLBpPDMtmDuLKQFztc/YbRsoCQoPzKZw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@ai-sdk/gateway": "4.0.28",
-				"@ai-sdk/provider": "4.0.3",
-				"@ai-sdk/provider-utils": "5.0.12"
-			},
-			"engines": {
-				"node": ">=22"
-			},
-			"peerDependencies": {
-				"zod": "^3.25.76 || ^4.1.8"
-			}
-		},
-		"node_modules/ai/node_modules/@ai-sdk/provider": {
-			"version": "4.0.3",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"json-schema": "^0.4.0"
-			},
-			"engines": {
-				"node": ">=22"
-			}
-		},
-		"node_modules/ai/node_modules/@ai-sdk/provider-utils": {
-			"version": "5.0.12",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@ai-sdk/provider": "4.0.3",
-				"@standard-schema/spec": "^1.1.0",
-				"@workflow/serde": "4.1.0",
-				"eventsource-parser": "^3.0.8"
+				"@ai-sdk/gateway": "4.0.41",
+				"@ai-sdk/provider": "4.0.5",
+				"@ai-sdk/provider-utils": "5.0.21"
 			},
 			"engines": {
 				"node": ">=22"
@@ -12471,9 +12274,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12495,9 +12295,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12519,9 +12316,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -12543,9 +12337,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -18374,15 +18165,12 @@
 			"peer": true
 		},
 		"node_modules/undici": {
-			"version": "5.29.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+			"integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
 			"license": "MIT",
-			"dependencies": {
-				"@fastify/busboy": "^2.0.0"
-			},
 			"engines": {
-				"node": ">=14.0"
+				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/undici-types": {
@@ -18861,6 +18649,474 @@
 				}
 			}
 		},
+		"node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/android-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-arm": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+			"cpu": [
+				"loong64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/linux-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/vitest/node_modules/@esbuild/win32-x64": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/vitest/node_modules/@vitest/mocker": {
 			"version": "4.1.8",
 			"dev": true,
@@ -18892,6 +19148,50 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/vitest/node_modules/esbuild": {
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/vitest/node_modules/lightningcss": {
@@ -19033,9 +19333,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -19057,9 +19354,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -19081,9 +19375,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -19105,9 +19396,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,14 +41,14 @@
 		"test:dev-server": "node test-dev-server.mjs"
 	},
 	"dependencies": {
-		"@ai-sdk/openai": "^2.0.109",
-		"@ai-sdk/otel": "^1.0.0",
-		"@ai-sdk/react": "^4.0.0",
+		"@ai-sdk/openai": "^4.0.30",
+		"@ai-sdk/otel": "^1.0.52",
+		"@ai-sdk/react": "^4.0.55",
 		"@lexical/react": "^0.45.0",
 		"@posthog/react": "^1.9.0",
 		"@react-hook/window-size": "^3.1.1",
 		"@types/node": "^24.6.2",
-		"ai": "^7.0.0",
+		"ai": "^7.0.52",
 		"jotai": "^2.12.5",
 		"lexical": "^0.45.0",
 		"posthog-js": "^1.388.1",

--- a/frontend/src/api/__tests__/errors.test.ts
+++ b/frontend/src/api/__tests__/errors.test.ts
@@ -90,6 +90,54 @@ describe('describeGenerationError', () => {
 		expect(info.retryable).toBe(true);
 	});
 
+	it('still names it when the SDK wrapped the failed fetch', () => {
+		// `handleFetchError` in @ai-sdk/provider-utils rewrites a TypeError that
+		// carries a `cause` into a status-less APICallError, so the plain
+		// `instanceof TypeError` test never sees it and the writer gets the
+		// generic copy for an unreachable server.
+		const info = describeGenerationError(
+			new APICallError({
+				message: 'Cannot connect to API: ECONNREFUSED',
+				url: 'https://example.test/openai/responses',
+				requestBodyValues: {},
+				isRetryable: true,
+			}),
+		);
+
+		expect(info.message).toMatch(/could not reach the server/i);
+		expect(info.detail).toBe('Cannot connect to API: ECONNREFUSED');
+		expect(info.retryable).toBe(true);
+	});
+
+	it('prefers the parsed error body over re-parsing the raw text', () => {
+		// `data` is the body already validated against the provider's schema.
+		// A proxy that answers with a differently-shaped envelope leaves it
+		// empty, and the text parse is what keeps the code readable there.
+		const withData = new APICallError({
+			message: 'request failed',
+			url: 'https://example.test/openai/responses',
+			requestBodyValues: {},
+			statusCode: 429,
+			responseBody: 'not json at all',
+			data: {
+				error: { code: 'rate_limit_exceeded', message: 'Slow down.' },
+			},
+		});
+		expect(describeGenerationError(withData).code).toBe(
+			'rate_limit_exceeded',
+		);
+
+		const textOnly = apiCallError({
+			statusCode: 429,
+			responseBody: JSON.stringify({
+				error: { code: 'rate_limit_exceeded', message: 'Slow down.' },
+			}),
+		});
+		expect(describeGenerationError(textOnly).code).toBe(
+			'rate_limit_exceeded',
+		);
+	});
+
 	it('keeps the raw text as detail for anything it cannot classify', () => {
 		const info = describeGenerationError(new Error('something odd'));
 

--- a/frontend/src/api/__tests__/errors.test.ts
+++ b/frontend/src/api/__tests__/errors.test.ts
@@ -1,4 +1,4 @@
-import { APICallError } from 'ai';
+import { APICallError, RetryError } from 'ai';
 import { describe, expect, it } from 'vitest';
 import { describeGenerationError, GenerationError } from '../errors';
 
@@ -96,6 +96,49 @@ describe('describeGenerationError', () => {
 		expect(info.message).toMatch(/something went wrong/i);
 		expect(info.detail).toBe('something odd');
 		expect(info.retryable).toBe(true);
+	});
+
+	it('describes the failure a RetryError wrapped, not the retrying', () => {
+		// What a quota failure looks like now that `@ai-sdk/openai` raises an
+		// `error` event that precedes any output as an APICallError: 429 marks
+		// it retryable, so the writer meets it wrapped in a RetryError whose own
+		// message is only "Failed after 3 attempts…".
+		const lastError = apiCallError({
+			statusCode: 429,
+			responseBody: JSON.stringify({
+				type: 'error',
+				error: {
+					type: 'insufficient_quota',
+					code: 'insufficient_quota',
+					message: 'You exceeded your current quota.',
+				},
+			}),
+		});
+		const info = describeGenerationError(
+			new RetryError({
+				message: 'Failed after 3 attempts. Last error: quota',
+				reason: 'maxRetriesExceeded',
+				errors: [lastError, lastError, lastError],
+			}),
+		);
+
+		expect(info.code).toBe('insufficient_quota');
+		expect(info.message).toMatch(/out of credit/i);
+		expect(info.detail).toBe('You exceeded your current quota.');
+		// The status said "retry", the code says otherwise; the code wins.
+		expect(info.retryable).toBe(false);
+	});
+
+	it('unwraps a RetryError that lost its class identity', () => {
+		// A duplicated `ai` in the tree breaks the marker check `isInstance`
+		// does, and the generic message is the failure mode that costs the most.
+		const info = describeGenerationError({
+			name: 'AI_RetryError',
+			message: 'Failed after 3 attempts.',
+			lastError: new TypeError('Failed to fetch'),
+		});
+
+		expect(info.message).toMatch(/could not reach the server/i);
 	});
 
 	it('passes an already-described error straight through', () => {

--- a/frontend/src/api/__tests__/generate.test.ts
+++ b/frontend/src/api/__tests__/generate.test.ts
@@ -1,4 +1,4 @@
-import { MockLanguageModelV3 } from 'ai/test';
+import { MockLanguageModelV4 } from 'ai/test';
 import { convertArrayToReadableStream } from '@ai-sdk/provider-utils/test';
 import { describe, expect, it, vi } from 'vitest';
 import { GenerationError } from '../errors';
@@ -6,14 +6,18 @@ import { generateFullText, streamTextDeltas } from '../generate';
 
 /**
  * The stream-part shape the installed `ai` expects, read off the mock instead of
- * imported by name. The top-level `@ai-sdk/provider` is the v2 copy that
- * `@ai-sdk/openai` still depends on, so it is a spec behind what `ai` itself
- * bundles, and its `LanguageModelV2StreamPart` no longer fits. Deriving keeps
- * this file correct across the next provider-spec bump too.
+ * imported by name. Deriving it keeps this file correct across provider-spec
+ * bumps: the named `LanguageModelV*StreamPart` type moves with
+ * `@ai-sdk/provider`, and which copy of that package a bare import resolves to
+ * depends on hoisting.
+ *
+ * Mock at the spec version the real provider speaks (`@ai-sdk/openai` v4 →
+ * `specificationVersion: 'v4'`), so these tests exercise the same path
+ * production does rather than `ai`'s back-compat shim for older models.
  */
 type StreamPart =
 	Awaited<
-		ReturnType<MockLanguageModelV3['doStream']>
+		ReturnType<MockLanguageModelV4['doStream']>
 	>['stream'] extends ReadableStream<infer Part>
 		? Part
 		: never;
@@ -35,7 +39,7 @@ const QUOTA_ERROR = {
 };
 
 function modelStreaming(parts: StreamPart[]) {
-	return new MockLanguageModelV3({
+	return new MockLanguageModelV4({
 		doStream: () =>
 			Promise.resolve({ stream: convertArrayToReadableStream(parts) }),
 	});
@@ -56,11 +60,11 @@ function textParts(...deltas: string[]): StreamPart[] {
 
 const FINISH: StreamPart = {
 	type: 'finish',
-	// v3 splits the finish reason into the unified value and the provider's own
-	// raw string, which a mock has none of.
+	// The spec splits the finish reason into the unified value and the provider's
+	// own raw string, which a mock has none of.
 	finishReason: { unified: 'stop', raw: undefined },
-	// The v3 spec breaks each side of the token count down (cache reads,
-	// reasoning tokens); these helpers only care that a finish part arrives.
+	// It also breaks each side of the token count down (cache reads, reasoning
+	// tokens); these helpers only care that a finish part arrives.
 	usage: {
 		inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
 		outputTokens: { total: 1, text: 1, reasoning: 0 },

--- a/frontend/src/api/__tests__/openai.test.ts
+++ b/frontend/src/api/__tests__/openai.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The shared model must be one `ai` speaks natively.
+ *
+ * `@ai-sdk/openai` and `ai` version their wire contract as a
+ * `specificationVersion` on every model object. When the provider's is older
+ * than what the installed `ai` implements, `ai` still runs the generation — it
+ * wraps the model in a back-compat shim and logs
+ *
+ *   AI SDK Warning (openai.responses / <model>): The feature
+ *   "specificationVersion" is used in a compatibility mode. …
+ *
+ * so a mismatch shows up only as console noise plus quietly unavailable
+ * features. That is easy to reintroduce by bumping one package and not the
+ * other, hence this test rather than a note in a changelog.
+ *
+ * `ai` only warns about the spec two behind its own; one behind it shims in
+ * silence. So the second assertion pins the provider's spec to the mock class
+ * `generate.test.ts` builds its fixtures from — if a provider bump makes those
+ * disagree, the fixtures are describing a stream shape production no longer
+ * sees, and both files need looking at together.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MockLanguageModelV4 } from 'ai/test';
+import { GenerationError } from '../errors';
+import { generateFullText } from '../generate';
+import { languageModel, openaiProviderOptions } from '../openai';
+
+type Warning = { type: string; feature?: string };
+
+/** Responses-API SSE, the shape our proxy passes through from OpenAI. */
+function responsesStream(text: string): string {
+	const event = (payload: object) => `data: ${JSON.stringify(payload)}\n\n`;
+	return (
+		event({
+			type: 'response.created',
+			response: { id: 'resp-test', created_at: 0, model: 'test-model' },
+		}) +
+		event({
+			type: 'response.output_item.added',
+			output_index: 0,
+			item: { type: 'message', id: 'msg-test' },
+		}) +
+		event({
+			type: 'response.output_text.delta',
+			item_id: 'msg-test',
+			delta: text,
+		}) +
+		event({
+			type: 'response.completed',
+			response: { usage: { input_tokens: 0, output_tokens: 0 } },
+		}) +
+		'data: [DONE]\n\n'
+	);
+}
+
+/**
+ * Collect what the SDK would otherwise print. `AI_SDK_LOG_WARNINGS` is the
+ * documented hook for replacing the default logger.
+ */
+function captureWarnings(): Warning[] {
+	const warnings: Warning[] = [];
+	(globalThis as { AI_SDK_LOG_WARNINGS?: unknown }).AI_SDK_LOG_WARNINGS = ({
+		warnings: batch,
+	}: {
+		warnings: Warning[];
+	}) => {
+		warnings.push(...batch);
+	};
+	return warnings;
+}
+
+afterEach(() => {
+	delete (globalThis as { AI_SDK_LOG_WARNINGS?: unknown })
+		.AI_SDK_LOG_WARNINGS;
+	vi.unstubAllGlobals();
+});
+
+describe('the shared language model', () => {
+	it('generates through the Responses API without a compatibility shim', async () => {
+		const warnings = captureWarnings();
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() =>
+				Promise.resolve(
+					new Response(responsesStream('Hello from the model'), {
+						status: 200,
+						headers: {
+							'content-type': 'text/event-stream; charset=utf-8',
+						},
+					}),
+				),
+			),
+		);
+
+		const text = await generateFullText({
+			model: languageModel,
+			prompt: 'hi',
+			providerOptions: openaiProviderOptions,
+		});
+
+		expect(text).toBe('Hello from the model');
+		expect(
+			warnings.filter(
+				(w) =>
+					w.type === 'compatibility' ||
+					w.feature === 'specificationVersion',
+			),
+		).toEqual([]);
+	});
+
+	it('still names the quota failure when the error precedes any output', async () => {
+		// The provider turns a leading `error` event into a thrown APICallError
+		// rather than a stream part, and 429 makes `ai` retry until it gives up
+		// and wraps the lot in a RetryError. The writer must still be told it is
+		// a billing problem, not "something went wrong, try again".
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() =>
+				Promise.resolve(
+					new Response(
+						`data: ${JSON.stringify({
+							type: 'error',
+							sequence_number: 2,
+							error: {
+								type: 'insufficient_quota',
+								code: 'insufficient_quota',
+								message:
+									'You exceeded your current quota, please check your plan and billing details.',
+							},
+						})}\n\ndata: [DONE]\n\n`,
+						{
+							status: 200,
+							headers: {
+								'content-type':
+									'text/event-stream; charset=utf-8',
+							},
+						},
+					),
+				),
+			),
+		);
+
+		const err = await generateFullText({
+			model: languageModel,
+			prompt: 'hi',
+			// One retry rather than the default two: the point here is the
+			// wrapping, and each attempt costs its backoff.
+			maxRetries: 1,
+		}).catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(GenerationError);
+		const { info } = err as GenerationError;
+		expect(info.code).toBe('insufficient_quota');
+		expect(info.message).toMatch(/out of credit/i);
+		expect(info.retryable).toBe(false);
+	}, 20000);
+
+	it('speaks the spec version the test fixtures are written against', () => {
+		expect(languageModel.specificationVersion).toBe(
+			new MockLanguageModelV4().specificationVersion,
+		);
+	});
+});

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -10,6 +10,12 @@
  *   `error` part's payload). It is a plain object, not an `Error`.
  * - A non-2xx response from our proxy throws an `APICallError`, whose
  *   `responseBody` is the provider's JSON error envelope as text.
+ * - An `error` event that arrives *before* any output does not become a stream
+ *   part at all: the provider raises it as an `APICallError` carrying the
+ *   status the error maps to, and `ai` retries anything that status marks
+ *   retryable. When the attempts run out it throws a `RetryError` whose own
+ *   message is "Failed after 3 attempts…" — the provider's error is inside, as
+ *   `lastError`.
  * - Aborts and timeouts throw a `DOMException` named `AbortError`/`TimeoutError`.
  * - A dead network throws `TypeError: Failed to fetch`.
  *
@@ -18,7 +24,7 @@
  * provider text kept aside for a details disclosure and the event log, and
  * whether retrying unchanged is worth offering.
  */
-import { APICallError } from 'ai';
+import { APICallError, RetryError } from 'ai';
 
 export interface GenerationErrorInfo {
 	/** One plain-language sentence for the writer, naming a next step. */
@@ -165,6 +171,25 @@ function firstProviderError(...candidates: unknown[]): {
 	return {};
 }
 
+/**
+ * The failure a {@link RetryError} was retrying, or null.
+ *
+ * The wrapper says only how many attempts were made, so describing it directly
+ * costs us the provider's code and message — a quota failure comes out as the
+ * generic "something went wrong", retryable, which is exactly the copy the
+ * writer can't act on. `isInstance` is a marker check rather than
+ * `instanceof`, but it still assumes the throwing `ai` is the one we imported;
+ * fall back to the shape so a duplicated copy in the tree can't quietly
+ * reintroduce the generic message.
+ */
+function retriedFailure(err: unknown): unknown {
+	if (RetryError.isInstance(err)) return err.lastError ?? null;
+	const record = asRecord(err);
+	if (record?.name === 'AI_RetryError' && record.lastError != null)
+		return record.lastError;
+	return null;
+}
+
 /** True for aborts and timeouts, which need their own copy. */
 function abortKind(err: unknown): 'timeout' | 'abort' | null {
 	for (let cur: unknown = err, depth = 0; cur && depth < 4; depth++) {
@@ -183,6 +208,10 @@ function abortKind(err: unknown): 'timeout' | 'abort' | null {
  */
 export function describeGenerationError(err: unknown): GenerationErrorInfo {
 	if (err instanceof GenerationError) return err.info;
+
+	// Describe what actually failed, not the retry bookkeeping around it.
+	const retried = retriedFailure(err);
+	if (retried !== null) return describeGenerationError(retried);
 
 	const aborted = abortKind(err);
 	if (aborted !== null) {

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -17,7 +17,9 @@
  *   message is "Failed after 3 attempts…" — the provider's error is inside, as
  *   `lastError`.
  * - Aborts and timeouts throw a `DOMException` named `AbortError`/`TimeoutError`.
- * - A dead network throws `TypeError: Failed to fetch`.
+ * - A dead network throws `TypeError: Failed to fetch` — or, where the runtime
+ *   gave that TypeError a `cause`, a status-less `APICallError` the SDK wrapped
+ *   it in.
  *
  * {@link describeGenerationError} normalizes all of them into one
  * {@link GenerationErrorInfo}: a plain-language sentence for the writer, the raw
@@ -190,6 +192,27 @@ function retriedFailure(err: unknown): unknown {
 	return null;
 }
 
+/**
+ * True for a dead network, which reaches us in two shapes.
+ *
+ * A browser `fetch` that never connects throws a bare `TypeError: Failed to
+ * fetch`. But when the runtime attaches a `cause` to that TypeError — undici
+ * always does, browsers sometimes — `handleFetchError` in
+ * `@ai-sdk/provider-utils` converts it to an `APICallError` before it reaches
+ * us, with no status and a `Cannot connect to API: …` message. Matching on that
+ * message is unlovely; it is the only thing distinguishing the wrapped form,
+ * and getting it wrong costs a writer the "check your connection" line and
+ * hands them "something went wrong" for an unplugged cable.
+ */
+function isNetworkFailure(err: unknown): boolean {
+	if (err instanceof TypeError) return true;
+	return (
+		APICallError.isInstance(err) &&
+		err.statusCode === undefined &&
+		err.message.startsWith('Cannot connect to API')
+	);
+}
+
 /** True for aborts and timeouts, which need their own copy. */
 function abortKind(err: unknown): 'timeout' | 'abort' | null {
 	for (let cur: unknown = err, depth = 0; cur && depth < 4; depth++) {
@@ -225,12 +248,15 @@ export function describeGenerationError(err: unknown): GenerationErrorInfo {
 		};
 	}
 
-	// APICallError keeps the provider's JSON body as text; everything else we
-	// read straight off the value we were handed.
+	// An APICallError has usually parsed the body for us already: `data` is what
+	// came back validated against the provider's own error schema. Re-parsing
+	// `responseBody` is the fallback for the case that leaves `data` empty — an
+	// OpenAI-compatible proxy whose envelope doesn't fit that schema. Everything
+	// else we read straight off the value we were handed.
 	const isApiCallError = APICallError.isInstance(err);
 	const status = isApiCallError ? err.statusCode : undefined;
 	const provider = isApiCallError
-		? firstProviderError(parseJson(err.responseBody), err.data)
+		? firstProviderError(err.data, parseJson(err.responseBody))
 		: firstProviderError(err);
 
 	const detail =
@@ -253,8 +279,7 @@ export function describeGenerationError(err: unknown): GenerationErrorInfo {
 		};
 	}
 
-	// A failed `fetch` throws a bare TypeError with no status and no body.
-	if (err instanceof TypeError) {
+	if (isNetworkFailure(err)) {
 		return {
 			message:
 				'Could not reach the server. Check your connection and try again.',

--- a/frontend/src/api/generate.ts
+++ b/frontend/src/api/generate.ts
@@ -39,10 +39,10 @@ export async function* streamTextDeltas(
 	options: StreamTextOptions,
 ): AsyncGenerator<string, void, void> {
 	const result = streamText(options);
-	// `fullStream`, not `textStream`: the latter drops `error` parts on the floor.
-	// (Still true in ai@7, which only renames `fullStream` to `stream` and keeps
-	// the old name as a deprecated alias — switch this line when we upgrade.)
-	for await (const part of result.fullStream) {
+	// `stream`, not `textStream`: the latter drops `error` parts on the floor.
+	// (`stream` is ai@7's name for what used to be `fullStream`, which is still
+	// there as a deprecated alias.)
+	for await (const part of result.stream) {
 		if (part.type === 'text-delta') {
 			yield part.text;
 		} else if (part.type === 'error') {


### PR DESCRIPTION
## The warning

```
AI SDK Warning (openai.responses / gpt-5.6-terra): The feature "specificationVersion"
is used in a compatibility mode. Using v2 specification compatibility mode.
Some features may not be available.
```

Every model object declares a `specificationVersion`, and `ai` refuses nothing — it wraps an older model in a back-compat shim and logs this. The frontend was a half-upgraded pair: `ai@7` speaks the current spec, `@ai-sdk/openai@2` hands it models two specs behind. Generation worked, so the only symptom was the warning plus whatever the shim can't carry across.

`experiment/` is on a matched `ai@5` / `@ai-sdk/openai@2` pair and is untouched.

## Version alignment (`frontend/package.json`)

| package | before | after |
| --- | --- | --- |
| `@ai-sdk/openai` | `^2.0.109` | `^4.0.30` |
| `ai` | `^7.0.0` (locked at 7.0.37) | `^7.0.52` |
| `@ai-sdk/react` | `^4.0.0` (locked at 4.0.40) | `^4.0.55` |
| `@ai-sdk/otel` | `^1.0.0` (locked at 1.0.37) | `^1.0.52` |

The three floors move because `ai@7.0.37` predates the spec `@ai-sdk/openai@4` emits — bumping the provider alone swaps a loud mismatch for a silent one, since `ai` shims one-version-behind without warning. Everything now resolves to a single copy of `ai` and of `@ai-sdk/provider`, and the declared floors keep a fresh install from resolving back.

`npm ci` also works again: the lockfile was missing esbuild's platform packages under `vitest`, and it failed outright before this change.

## Error-path fixes

**Quota failures lost their copy** — caught by the existing error-visibility E2E specs. In `@ai-sdk/openai@4` an `error` event arriving before any output is no longer a stream part: `throwIfOpenAIStreamErrorBeforeOutput` raises it as an `APICallError`, and `getStatusCode` maps `insufficient_quota` to **429**, which `ai` retries until it gives up and wraps everything in a `RetryError` whose message is only `Failed after 3 attempts…`. So a billing failure reached the writer as the generic "something went wrong, try again" — retryable copy for a problem retrying cannot fix. `describeGenerationError` now unwraps to the attempt that actually failed, with a structural fallback in case a duplicated `ai` breaks the marker check.

Consequence worth knowing: a terminal error now waits out the retry backoff (~5s) before appearing. The provider-assigned status drives the retry and `maxRetries` isn't per-error, so suppressing it would suppress retries for genuinely transient failures too.

**A dead network could reach the writer as "something went wrong"** (pre-existing, found while auditing the above). `handleFetchError` in `@ai-sdk/provider-utils` rewrites a `TypeError: Failed to fetch` that carries a `cause` into a status-less `APICallError`, so the `instanceof TypeError` branch never saw it. Which shape you get is runtime-dependent — undici always sets `cause`, browsers often don't — so both are handled now.

**Read `APICallError.data` before re-parsing `responseBody`** — `data` is the body already validated against the provider's error schema. The text parse stays as the fallback for OpenAI-compatible proxies whose envelope doesn't fit that schema.

**`stream` over the deprecated `fullStream`** in `generate.ts` — the to-do the comment there was already carrying.

## Docs

`docs/ai-sdk-upstream-wishlist.md` (new) records six places where our error layer reimplements something the SDK nearly provides, and why we kept ours each time — no retry predicate on `streamText`, `RetryError` burying its cause, `isAbortError` not re-exported from `ai` and not distinguishing timeout from cancellation, the two shapes of a network failure, provider-shaped error-body extraction that stops at the HTTP boundary, and the silent one-version-behind shim. Nothing is filed upstream; it's there so the next bump doesn't re-derive it. `frontend/CLAUDE.md` points at it from the error-handling section.

## Tests

- `src/api/__tests__/openai.test.ts` (new) — drives the shared `languageModel` over a stubbed Responses stream and fails if a shim is involved, if the quota copy regresses, or if the provider's spec drifts from the mocks the other tests use. Verified non-vacuous: a model reporting the older spec does produce the captured warning.
- `generate.test.ts` mocks at the spec the real provider speaks rather than through the shim.
- `errors.test.ts` covers both `RetryError` unwrap paths, the wrapped network failure, and both error-body sources.

`npm test` 229 passed · `npm run typecheck` clean · `npm run lint` 0 errors (3 pre-existing warnings) · `npm run build` clean · Playwright: all generation and error-visibility flows pass. The only failures in a full E2E run are 4 visual-snapshot specs with sub-1% pixel diffs, on pages that don't touch the SDK — this sandbox's Chromium build differs from the one the snapshots were captured with.